### PR TITLE
Ensure ingest HMAC secret is provisioned for demo deploys

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -69,6 +69,7 @@ jobs:
             echo "::error::Set the DEMO_INGEST_HMAC_SECRET GitHub secret before deploying; ingest smoke tests require it."
             exit 1
           fi
+          printf '%s' "$INGEST_HMAC_SECRET" | firebase functions:secrets:set INGEST_HMAC_SECRET --project "$FIREBASE_PROJECT_ID" --data-file -
           firebase functions:config:set ingest.hmac_secret="$INGEST_HMAC_SECRET" --project "$FIREBASE_PROJECT_ID"
           firebase functions:config:set ingest.topic="$INGEST_TOPIC" --project "$FIREBASE_PROJECT_ID"
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,7 @@ import { app as adminApp } from "./lib/fire.js";
 import { devicesRoutes } from "./routes/devices.js";
 import { measurementsRoutes } from "./routes/measurements.js";
 import { adminRoutes } from "./routes/admin.js";
+import { ingestHmacSecret } from "./lib/runtimeConfig.js";
 adminApp();
 
 const api = Fastify({ logger: true });
@@ -57,7 +58,7 @@ const apiSetup = (async () => {
   throw err;
 });
 
-export const crowdpmApi = https.onRequest({ cors: true }, (req, res) => {
+export const crowdpmApi = https.onRequest({ cors: true, secrets: [ingestHmacSecret] }, (req, res) => {
   const requestWithRawBody = req as RequestWithRawBody;
   requestWithRawBody.rawBody = requestWithRawBody.rawBody ?? undefined;
   apiSetup.then(() => api.server.emit("request", req, res));

--- a/functions/src/lib/runtimeConfig.ts
+++ b/functions/src/lib/runtimeConfig.ts
@@ -1,4 +1,7 @@
 import { config } from "firebase-functions";
+import { defineSecret } from "firebase-functions/params";
+
+export const ingestHmacSecret = defineSecret("INGEST_HMAC_SECRET");
 
 type IngestConfig = {
   ingest?: {
@@ -17,8 +20,19 @@ function readConfig(): IngestConfig {
 }
 
 export function getIngestSecret(): string {
+  const envSecret = process.env.INGEST_HMAC_SECRET;
+  if (envSecret) return envSecret;
+
+  try {
+    const secret = ingestHmacSecret.value();
+    if (secret) return secret;
+  }
+  catch {
+    // ignore; fall back to runtime config
+  }
+
   const cfg = readConfig();
-  return process.env.INGEST_HMAC_SECRET || cfg.ingest?.hmac_secret || "";
+  return cfg.ingest?.hmac_secret || "";
 }
 
 export function getIngestTopic(): string {

--- a/functions/src/services/ingestGateway.ts
+++ b/functions/src/services/ingestGateway.ts
@@ -3,7 +3,7 @@ import { PubSub } from "@google-cloud/pubsub";
 import crypto from "node:crypto";
 import { bucket, db } from "../lib/fire.js";
 import { verifyHmac } from "../lib/crypto.js";
-import { getIngestTopic } from "../lib/runtimeConfig.js";
+import { getIngestTopic, ingestHmacSecret } from "../lib/runtimeConfig.js";
 import type { Request } from "firebase-functions/v2/https";
 
 const pubsub = new PubSub();
@@ -61,7 +61,7 @@ export async function ingestPayload(raw: string, body: IngestBody, options: Inge
   return { accepted: true, batchId, deviceId, storagePath: path };
 }
 
-export const ingestGateway = onRequest({ cors: true }, async (req, res) => {
+export const ingestGateway = onRequest({ cors: true, secrets: [ingestHmacSecret] }, async (req, res) => {
   const requestWithRawBody = req as RequestWithRawBody;
   const rawBody = requestWithRawBody.rawBody;
   const raw = typeof rawBody === "string"


### PR DESCRIPTION
## Summary
- load the ingest HMAC secret via Firebase Secret Manager and expose it to API functions
- fall back to existing runtime config for compatibility with local development
- update the demo deploy workflow to push the secret into Secret Manager before deployment

## Testing
- pnpm --filter crowdpm-functions build

------
https://chatgpt.com/codex/tasks/task_e_6902823c27e4832b9ae2ae111cc64287