### PR TITLE
Fix smoke test cleanup

### DIFF
--- a/functions/src/routes/admin.ts
+++ b/functions/src/routes/admin.ts
@@ -37,7 +37,7 @@ export const adminRoutes: FastifyPluginAsync = async (fastify) => {
 
   fastify.post<{ Body: SmokeTestBody }>("/v1/admin/ingest-smoke-test", async (req, rep) => {
     fastify.log.info({ bodyKeys: Object.keys(req.body ?? {}) }, "ingest smoke test requested");
-    const authedUser = await requireUser(req).catch(() => null); // allow unauthenticated usage when desired
+    const user = await requireUser(req);
 
     const defaultDeviceId = "device-123";
     const body = req.body ?? {};
@@ -121,9 +121,7 @@ export const adminRoutes: FastifyPluginAsync = async (fastify) => {
       return rep.code(500).send({ error: "INGEST_HMAC_SECRET must be set to run smoke tests" });
     }
 
-    const ownerSegment = authedUser?.uid
-      ? slugify(authedUser.uid, "user")
-      : `anon-${crypto.randomUUID().slice(0, 8)}`;
+    const ownerSegment = slugify(user.uid, "user");
 
     const rawDeviceIds = Array.from(new Set(
       payload.points
@@ -154,7 +152,7 @@ export const adminRoutes: FastifyPluginAsync = async (fastify) => {
     if (!primaryDeviceId) {
       return rep.code(400).send({ error: "unable to determine device_id for smoke test" });
     }
-    const ownerIds = authedUser?.uid ? [authedUser.uid] : ["smoke-test"];
+    const ownerIds = [user.uid];
     const arrayUnion = getFirebaseApp().firestore.FieldValue.arrayUnion;
     const primaryOwnerId = ownerIds[0];
     const scopedToRaw = new Map<string, string>();
@@ -218,15 +216,13 @@ export const adminRoutes: FastifyPluginAsync = async (fastify) => {
         allowedIds.push(deviceId); // stale device reference; allow cleanup to continue
         return;
       }
-      const data = snap.data() as { ownerUserId?: string | null; ownerUserIds?: string[] | null; ownerScope?: string | null } | undefined;
-      const owners = Array.isArray(data?.ownerUserIds) ? data.ownerUserIds.filter((id): id is string => typeof id === "string" && id.length > 0) : [];
-      const ownerUserId = typeof data?.ownerUserId === "string" && data.ownerUserId.length > 0 ? data.ownerUserId : null;
-      const ownerScope = typeof data?.ownerScope === "string" ? data.ownerScope : null;
-      const isSyntheticSmokeTest = ownerUserId === "smoke-test" || owners.includes("smoke-test") || Boolean(ownerScope && ownerScope.startsWith("anon-"));
-      if (isSyntheticSmokeTest || (!ownerUserId && owners.length === 0)) {
-        allowedIds.push(deviceId); // legacy/smoke test devices do not belong to a real user
-        return;
-      }
+      const data = snap.data() as { ownerUserId?: string | null; ownerUserIds?: string[] | null } | undefined;
+      const owners = Array.isArray(data?.ownerUserIds)
+        ? data.ownerUserIds.filter((id): id is string => typeof id === "string" && id.length > 0)
+        : [];
+      const ownerUserId = typeof data?.ownerUserId === "string" && data.ownerUserId.length > 0
+        ? data.ownerUserId
+        : null;
       const isOwner = ownerUserId === user.uid || owners.includes(user.uid);
       if (isOwner) {
         allowedIds.push(deviceId);


### PR DESCRIPTION
Title: Require auth for ingest smoke tests
Summary:
Require signed-in user for /v1/admin/ingest-smoke-test and scope seeded devices per user.
Cleanup route only deletes devices owned by the caller; no more anonymous smoke-test exceptions.