### PR TITLE
Feat: UI pagination

### DIFF
--- a/frontend/src/components/PaginationControl.tsx
+++ b/frontend/src/components/PaginationControl.tsx
@@ -1,0 +1,62 @@
+import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
+import { Flex, IconButton, Text } from "@radix-ui/themes";
+
+export const MIN_VISIBLE_RESULTS = 1;
+export const DEFAULT_VISIBLE_RESULTS = 10;
+
+export function clampVisibleResults(total: number, requested: number) {
+  if (total <= 0) return 0;
+  return Math.min(Math.max(requested, MIN_VISIBLE_RESULTS), Math.min(DEFAULT_VISIBLE_RESULTS, total));
+}
+
+type ResultCountControlProps = {
+  itemLabelSingular: string;
+  itemLabelPlural: string;
+  visibleCount: number;
+  totalCount: number;
+  onShowLess: () => void;
+  onShowMore: () => void;
+};
+
+export function ResultCountControl({
+  itemLabelSingular,
+  itemLabelPlural,
+  visibleCount,
+  totalCount,
+  onShowLess,
+  onShowMore,
+}: ResultCountControlProps) {
+  if (totalCount <= 1) return null;
+
+  const maxVisibleCount = Math.min(DEFAULT_VISIBLE_RESULTS, totalCount);
+  const noun = totalCount === 1 ? itemLabelSingular : itemLabelPlural;
+  const summary = visibleCount < totalCount
+    ? `Showing first ${visibleCount} of ${totalCount} ${noun}`
+    : `Showing ${visibleCount} ${noun}`;
+
+  return (
+    <Flex align="center" gap="2" wrap="wrap">
+      <Text size="2" color="gray">{summary}</Text>
+      <IconButton
+        type="button"
+        variant="soft"
+        size="1"
+        aria-label={`Show fewer ${itemLabelPlural}`}
+        onClick={onShowLess}
+        disabled={visibleCount <= MIN_VISIBLE_RESULTS}
+      >
+        <ChevronUpIcon />
+      </IconButton>
+      <IconButton
+        type="button"
+        variant="soft"
+        size="1"
+        aria-label={`Show more ${itemLabelPlural}`}
+        onClick={onShowMore}
+        disabled={visibleCount >= maxVisibleCount}
+      >
+        <ChevronDownIcon />
+      </IconButton>
+    </Flex>
+  );
+}

--- a/frontend/src/pages/AdminModerationPage.tsx
+++ b/frontend/src/pages/AdminModerationPage.tsx
@@ -24,6 +24,7 @@ import {
   type AdminRole,
 } from "../lib/api";
 import { useAuth } from "../providers/AuthProvider";
+import { clampVisibleResults, DEFAULT_VISIBLE_RESULTS, MIN_VISIBLE_RESULTS, ResultCountControl } from "../components/PaginationControl";
 
 function formatTimestamp(value: string | null): string {
   const ms = timestampToMillis(value);
@@ -54,6 +55,8 @@ export default function AdminModerationPage() {
 
   const [moderationFilter, setModerationFilter] = useState<SubmissionFilterState>("all");
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilterState>("all");
+  const [visibleSubmissionCount, setVisibleSubmissionCount] = useState(DEFAULT_VISIBLE_RESULTS);
+  const [visibleUserCount, setVisibleUserCount] = useState(DEFAULT_VISIBLE_RESULTS);
 
   const canAccess = Boolean(user) && isModerator;
 
@@ -62,6 +65,22 @@ export default function AdminModerationPage() {
     visibility: visibilityFilter === "all" ? undefined : visibilityFilter,
     limit: 100,
   }), [moderationFilter, visibilityFilter]);
+  const boundedVisibleSubmissionCount = useMemo(
+    () => clampVisibleResults(submissions.length, visibleSubmissionCount),
+    [submissions.length, visibleSubmissionCount],
+  );
+  const visibleSubmissions = useMemo(
+    () => submissions.slice(0, boundedVisibleSubmissionCount),
+    [boundedVisibleSubmissionCount, submissions],
+  );
+  const boundedVisibleUserCount = useMemo(
+    () => clampVisibleResults(users.length, visibleUserCount),
+    [users.length, visibleUserCount],
+  );
+  const visibleUsers = useMemo(
+    () => users.slice(0, boundedVisibleUserCount),
+    [boundedVisibleUserCount, users],
+  );
 
   const refreshSubmissions = useCallback(async () => {
     if (!canAccess) return;
@@ -108,6 +127,22 @@ export default function AdminModerationPage() {
     if (!canAccess) return;
     void refreshUsers();
   }, [canAccess, refreshUsers]);
+
+  useEffect(() => {
+    if (submissions.length === 0) return;
+    const nextVisibleCount = clampVisibleResults(submissions.length, visibleSubmissionCount);
+    if (nextVisibleCount !== visibleSubmissionCount) {
+      setVisibleSubmissionCount(nextVisibleCount);
+    }
+  }, [submissions.length, visibleSubmissionCount]);
+
+  useEffect(() => {
+    if (users.length === 0) return;
+    const nextVisibleCount = clampVisibleResults(users.length, visibleUserCount);
+    if (nextVisibleCount !== visibleUserCount) {
+      setVisibleUserCount(nextVisibleCount);
+    }
+  }, [users.length, visibleUserCount]);
 
   const handleModerationChange = useCallback(async (entry: AdminSubmissionSummary, moderationState: ModerationState) => {
     if (!canAccess) return;
@@ -181,7 +216,17 @@ export default function AdminModerationPage() {
     <Flex direction="column" gap="5">
       <Card>
         <Flex direction="column" gap="3">
-          <Heading as="h3" size="5">Submission moderation</Heading>
+          <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">
+            <Heading as="h3" size="5">Submission moderation</Heading>
+            <ResultCountControl
+              itemLabelSingular="submission"
+              itemLabelPlural="submissions"
+              visibleCount={boundedVisibleSubmissionCount}
+              totalCount={submissions.length}
+              onShowLess={() => setVisibleSubmissionCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
+              onShowMore={() => setVisibleSubmissionCount((current) => Math.min(DEFAULT_VISIBLE_RESULTS, current + 1))}
+            />
+          </Flex>
           <Flex gap="3" wrap="wrap" align="end">
             <Box>
               <Text size="2" color="gray">State</Text>
@@ -223,7 +268,7 @@ export default function AdminModerationPage() {
               </Table.Row>
             </Table.Header>
             <Table.Body>
-              {submissions.map((entry) => {
+              {visibleSubmissions.map((entry) => {
                 const busy = actionBusyId === `submission:${entry.deviceId}:${entry.batchId}`;
                 return (
                   <Table.Row key={`${entry.deviceId}:${entry.batchId}`}>
@@ -270,7 +315,17 @@ export default function AdminModerationPage() {
 
       <Card>
         <Flex direction="column" gap="3">
-          <Heading as="h3" size="5">User moderation</Heading>
+          <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">
+            <Heading as="h3" size="5">User moderation</Heading>
+            <ResultCountControl
+              itemLabelSingular="user"
+              itemLabelPlural="users"
+              visibleCount={boundedVisibleUserCount}
+              totalCount={users.length}
+              onShowLess={() => setVisibleUserCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
+              onShowMore={() => setVisibleUserCount((current) => Math.min(DEFAULT_VISIBLE_RESULTS, current + 1))}
+            />
+          </Flex>
           <Flex gap="3" wrap="wrap" align="center">
             <Button onClick={() => { void refreshUsers(); }} disabled={usersLoading}>
               {usersLoading ? "Refreshing..." : "Refresh"}
@@ -298,7 +353,7 @@ export default function AdminModerationPage() {
               </Table.Row>
             </Table.Header>
             <Table.Body>
-              {users.map((entry) => {
+              {visibleUsers.map((entry) => {
                 const busyDisabled = actionBusyId === `user:${entry.uid}:disabled`;
                 const busyRoles = actionBusyId === `user:${entry.uid}:roles`;
                 return (

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Badge, Box, Button, Callout, Card, Flex, Heading, IconButton, SegmentedControl, Select, Separator, Switch, Table, Text, TextField } from "@radix-ui/themes";
-import { ChevronDownIcon, ChevronUpIcon, ReloadIcon } from "@radix-ui/react-icons";
+import { Badge, Box, Button, Callout, Card, Flex, Heading, SegmentedControl, Select, Separator, Switch, Table, Text, TextField } from "@radix-ui/themes";
+import { ReloadIcon } from "@radix-ui/react-icons";
 import { timestampToMillis } from "@crowdpm/types";
 import {
   deleteBatch,
@@ -15,71 +15,12 @@ import {
 import { useAuth } from "../providers/AuthProvider";
 import { useUserSettings } from "../providers/UserSettingsProvider";
 import { buildActivationLink } from "../lib/activation";
+import { clampVisibleResults, DEFAULT_VISIBLE_RESULTS, MIN_VISIBLE_RESULTS, ResultCountControl } from "../components/PaginationControl";
 
 type UserDashboardProps = {
   onRequestActivation: () => void;
   refreshToken?: number;
 };
-
-const MIN_VISIBLE_RESULTS = 1;
-const MAX_VISIBLE_RESULTS = 10;
-
-function clampVisibleResults(total: number, requested: number) {
-  if (total <= 0) return 0;
-  return Math.min(Math.max(requested, MIN_VISIBLE_RESULTS), Math.min(MAX_VISIBLE_RESULTS, total));
-}
-
-type ResultCountControlProps = {
-  itemLabelSingular: string;
-  itemLabelPlural: string;
-  visibleCount: number;
-  totalCount: number;
-  onShowLess: () => void;
-  onShowMore: () => void;
-};
-
-function ResultCountControl({
-  itemLabelSingular,
-  itemLabelPlural,
-  visibleCount,
-  totalCount,
-  onShowLess,
-  onShowMore,
-}: ResultCountControlProps) {
-  if (totalCount <= 1) return null;
-
-  const maxVisibleCount = Math.min(MAX_VISIBLE_RESULTS, totalCount);
-  const noun = totalCount === 1 ? itemLabelSingular : itemLabelPlural;
-  const summary = visibleCount < totalCount
-    ? `Showing first ${visibleCount} of ${totalCount} ${noun}`
-    : `Showing ${visibleCount} ${noun}`;
-
-  return (
-    <Flex align="center" gap="2" wrap="wrap">
-      <Text size="2" color="gray">{summary}</Text>
-      <IconButton
-        type="button"
-        variant="soft"
-        size="1"
-        aria-label={`Show fewer ${itemLabelPlural}`}
-        onClick={onShowLess}
-        disabled={visibleCount <= MIN_VISIBLE_RESULTS}
-      >
-        <ChevronUpIcon />
-      </IconButton>
-      <IconButton
-        type="button"
-        variant="soft"
-        size="1"
-        aria-label={`Show more ${itemLabelPlural}`}
-        onClick={onShowMore}
-        disabled={visibleCount >= maxVisibleCount}
-      >
-        <ChevronDownIcon />
-      </IconButton>
-    </Flex>
-  );
-}
 
 function describeStatus(status?: string | null): { label: string; tone: "green" | "yellow" | "red" | "gray" } {
   const normalized = (status ?? "").toLowerCase();
@@ -97,7 +38,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
   const [devicesError, setDevicesError] = useState<string | null>(null);
   const [revokeError, setRevokeError] = useState<string | null>(null);
   const [revokingId, setRevokingId] = useState<string | null>(null);
-  const [visibleDeviceCount, setVisibleDeviceCount] = useState(MAX_VISIBLE_RESULTS);
+  const [visibleDeviceCount, setVisibleDeviceCount] = useState(DEFAULT_VISIBLE_RESULTS);
   const [batches, setBatches] = useState<BatchSummary[]>([]);
   const [isLoadingBatches, setIsLoadingBatches] = useState(false);
   const [batchesError, setBatchesError] = useState<string | null>(null);
@@ -106,7 +47,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
   const [batchActionMessage, setBatchActionMessage] = useState<string | null>(null);
   const [updatingBatchKey, setUpdatingBatchKey] = useState<string | null>(null);
   const [deletingBatchKey, setDeletingBatchKey] = useState<string | null>(null);
-  const [visibleBatchCount, setVisibleBatchCount] = useState(MAX_VISIBLE_RESULTS);
+  const [visibleBatchCount, setVisibleBatchCount] = useState(DEFAULT_VISIBLE_RESULTS);
   const [settingsMessage, setSettingsMessage] = useState<string | null>(null);
   const [settingsLocalError, setSettingsLocalError] = useState<string | null>(null);
   const activationUrl = useMemo(() => buildActivationLink(), []);
@@ -486,7 +427,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
               visibleCount={boundedVisibleDeviceCount}
               totalCount={devices.length}
               onShowLess={() => setVisibleDeviceCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
-              onShowMore={() => setVisibleDeviceCount((current) => Math.min(MAX_VISIBLE_RESULTS, current + 1))}
+              onShowMore={() => setVisibleDeviceCount((current) => Math.min(DEFAULT_VISIBLE_RESULTS, current + 1))}
             />
           </Flex>
           <Separator my="2" size="4" />
@@ -571,7 +512,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
                 visibleCount={boundedVisibleBatchCount}
                 totalCount={filteredBatches.length}
                 onShowLess={() => setVisibleBatchCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
-                onShowMore={() => setVisibleBatchCount((current) => Math.min(MAX_VISIBLE_RESULTS, current + 1))}
+                onShowMore={() => setVisibleBatchCount((current) => Math.min(DEFAULT_VISIBLE_RESULTS, current + 1))}
               />
               <Button variant="soft" onClick={refreshBatches} disabled={isLoadingBatches}>
                 <ReloadIcon /> {isLoadingBatches ? "Refreshing" : "Refresh"}

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Badge, Box, Button, Card, Flex, Heading, SegmentedControl, Separator, Table, Text, TextField, Callout, Switch, Select } from "@radix-ui/themes";
-import { ReloadIcon } from "@radix-ui/react-icons";
+import { Badge, Box, Button, Callout, Card, Flex, Heading, IconButton, SegmentedControl, Select, Separator, Switch, Table, Text, TextField } from "@radix-ui/themes";
+import { ChevronDownIcon, ChevronUpIcon, ReloadIcon } from "@radix-ui/react-icons";
 import { timestampToMillis } from "@crowdpm/types";
 import {
   deleteBatch,
@@ -21,6 +21,66 @@ type UserDashboardProps = {
   refreshToken?: number;
 };
 
+const MIN_VISIBLE_RESULTS = 1;
+const MAX_VISIBLE_RESULTS = 10;
+
+function clampVisibleResults(total: number, requested: number) {
+  if (total <= 0) return 0;
+  return Math.min(Math.max(requested, MIN_VISIBLE_RESULTS), Math.min(MAX_VISIBLE_RESULTS, total));
+}
+
+type ResultCountControlProps = {
+  itemLabelSingular: string;
+  itemLabelPlural: string;
+  visibleCount: number;
+  totalCount: number;
+  onShowLess: () => void;
+  onShowMore: () => void;
+};
+
+function ResultCountControl({
+  itemLabelSingular,
+  itemLabelPlural,
+  visibleCount,
+  totalCount,
+  onShowLess,
+  onShowMore,
+}: ResultCountControlProps) {
+  if (totalCount <= 1) return null;
+
+  const maxVisibleCount = Math.min(MAX_VISIBLE_RESULTS, totalCount);
+  const noun = totalCount === 1 ? itemLabelSingular : itemLabelPlural;
+  const summary = visibleCount < totalCount
+    ? `Showing first ${visibleCount} of ${totalCount} ${noun}`
+    : `Showing ${visibleCount} ${noun}`;
+
+  return (
+    <Flex align="center" gap="2" wrap="wrap">
+      <Text size="2" color="gray">{summary}</Text>
+      <IconButton
+        type="button"
+        variant="soft"
+        size="1"
+        aria-label={`Show fewer ${itemLabelPlural}`}
+        onClick={onShowLess}
+        disabled={visibleCount <= MIN_VISIBLE_RESULTS}
+      >
+        <ChevronUpIcon />
+      </IconButton>
+      <IconButton
+        type="button"
+        variant="soft"
+        size="1"
+        aria-label={`Show more ${itemLabelPlural}`}
+        onClick={onShowMore}
+        disabled={visibleCount >= maxVisibleCount}
+      >
+        <ChevronDownIcon />
+      </IconButton>
+    </Flex>
+  );
+}
+
 function describeStatus(status?: string | null): { label: string; tone: "green" | "yellow" | "red" | "gray" } {
   const normalized = (status ?? "").toLowerCase();
   if (["active", "ok", "ready"].includes(normalized)) return { label: "Active", tone: "green" };
@@ -37,6 +97,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
   const [devicesError, setDevicesError] = useState<string | null>(null);
   const [revokeError, setRevokeError] = useState<string | null>(null);
   const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [visibleDeviceCount, setVisibleDeviceCount] = useState(MAX_VISIBLE_RESULTS);
   const [batches, setBatches] = useState<BatchSummary[]>([]);
   const [isLoadingBatches, setIsLoadingBatches] = useState(false);
   const [batchesError, setBatchesError] = useState<string | null>(null);
@@ -45,6 +106,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
   const [batchActionMessage, setBatchActionMessage] = useState<string | null>(null);
   const [updatingBatchKey, setUpdatingBatchKey] = useState<string | null>(null);
   const [deletingBatchKey, setDeletingBatchKey] = useState<string | null>(null);
+  const [visibleBatchCount, setVisibleBatchCount] = useState(MAX_VISIBLE_RESULTS);
   const [settingsMessage, setSettingsMessage] = useState<string | null>(null);
   const [settingsLocalError, setSettingsLocalError] = useState<string | null>(null);
   const activationUrl = useMemo(() => buildActivationLink(), []);
@@ -132,6 +194,22 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
       return timeB - timeA;
     });
   }, [batches, selectedBatchDeviceId]);
+  const boundedVisibleDeviceCount = useMemo(
+    () => clampVisibleResults(devices.length, visibleDeviceCount),
+    [devices.length, visibleDeviceCount],
+  );
+  const visibleDevices = useMemo(
+    () => devices.slice(0, boundedVisibleDeviceCount),
+    [boundedVisibleDeviceCount, devices],
+  );
+  const boundedVisibleBatchCount = useMemo(
+    () => clampVisibleResults(filteredBatches.length, visibleBatchCount),
+    [filteredBatches.length, visibleBatchCount],
+  );
+  const visibleBatches = useMemo(
+    () => filteredBatches.slice(0, boundedVisibleBatchCount),
+    [boundedVisibleBatchCount, filteredBatches],
+  );
 
   useEffect(() => {
     if (selectedBatchDeviceId === "all") return;
@@ -140,6 +218,22 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
       setSelectedBatchDeviceId("all");
     }
   }, [batchDeviceOptions, selectedBatchDeviceId]);
+
+  useEffect(() => {
+    if (devices.length === 0) return;
+    const nextVisibleCount = clampVisibleResults(devices.length, visibleDeviceCount);
+    if (nextVisibleCount !== visibleDeviceCount) {
+      setVisibleDeviceCount(nextVisibleCount);
+    }
+  }, [devices.length, visibleDeviceCount]);
+
+  useEffect(() => {
+    if (filteredBatches.length === 0) return;
+    const nextVisibleCount = clampVisibleResults(filteredBatches.length, visibleBatchCount);
+    if (nextVisibleCount !== visibleBatchCount) {
+      setVisibleBatchCount(nextVisibleCount);
+    }
+  }, [filteredBatches.length, visibleBatchCount]);
 
   const handleDefaultVisibilityChange = useCallback(async (nextValue: string) => {
     const next = nextValue as BatchVisibility;
@@ -381,8 +475,20 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
 
       <Card>
         <Flex direction="column" gap="3">
-          <Heading as="h3" size="4">Registered devices</Heading>
-          <Text color="gray">These are exposed by the Functions API via /v1/devices for your account.</Text>
+          <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">
+            <Box>
+              <Heading as="h3" size="4">Registered devices</Heading>
+              <Text color="gray">These are exposed by the Functions API via /v1/devices for your account.</Text>
+            </Box>
+            <ResultCountControl
+              itemLabelSingular="device"
+              itemLabelPlural="devices"
+              visibleCount={boundedVisibleDeviceCount}
+              totalCount={devices.length}
+              onShowLess={() => setVisibleDeviceCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
+              onShowMore={() => setVisibleDeviceCount((current) => Math.min(MAX_VISIBLE_RESULTS, current + 1))}
+            />
+          </Flex>
           <Separator my="2" size="4" />
           {revokeError ? (
             <Callout.Root color="tomato">
@@ -406,7 +512,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
                 </Table.Row>
               </Table.Header>
               <Table.Body>
-                {devices.map((device) => {
+                {visibleDevices.map((device) => {
                   const status = describeStatus(device.registryStatus ?? device.status);
                   const createdMs = timestampToMillis(device.createdAt);
                   const created = createdMs === null ? "—" : new Date(createdMs).toLocaleDateString();
@@ -458,9 +564,19 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
               <Heading as="h3" size="4">Batch uploads</Heading>
               <Text color="gray">Manage uploaded batches for each registered device.</Text>
             </Box>
-            <Button variant="soft" onClick={refreshBatches} disabled={isLoadingBatches}>
-              <ReloadIcon /> {isLoadingBatches ? "Refreshing" : "Refresh"}
-            </Button>
+            <Flex align="center" gap="2" wrap="wrap">
+              <ResultCountControl
+                itemLabelSingular="batch"
+                itemLabelPlural="batches"
+                visibleCount={boundedVisibleBatchCount}
+                totalCount={filteredBatches.length}
+                onShowLess={() => setVisibleBatchCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
+                onShowMore={() => setVisibleBatchCount((current) => Math.min(MAX_VISIBLE_RESULTS, current + 1))}
+              />
+              <Button variant="soft" onClick={refreshBatches} disabled={isLoadingBatches}>
+                <ReloadIcon /> {isLoadingBatches ? "Refreshing" : "Refresh"}
+              </Button>
+            </Flex>
           </Flex>
 
           <Separator my="2" size="4" />
@@ -516,7 +632,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
                 </Table.Row>
               </Table.Header>
               <Table.Body>
-                {filteredBatches.map((batch) => {
+                {visibleBatches.map((batch) => {
                   const actionKey = `${batch.deviceId}:${batch.batchId}`;
                   const isUpdating = updatingBatchKey === actionKey;
                   const isDeleting = deletingBatchKey === actionKey;


### PR DESCRIPTION
The change adds a reusable PaginationControl component that clamps visible rows to 1-10, shows a summary like _Showing first 6 of 18 devices_, and uses ChevronUp to show fewer rows and ChevronDown to show more. 

This change has been made to the following lists:

Registered Devices
Batch Uploads
User Moderation 
Submission Moderation