### PR TITLE
Fix: Super Admins now access the Smoke Test tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -122,10 +122,11 @@ export default function App() {
   const [pendingSmokeCleanup, setPendingSmokeCleanup] = useState<IngestSmokeTestCleanupResponse | null>(null);
 
   const isSignedIn = Boolean(user);
-  const canUseSmokeTests = (() => {
+  const isSmokeTestAccount = (() => {
     const email = user?.email;
     return typeof email === "string" && email.length > 0 && isSmokeTestEmail(email);
   })();
+  const canUseSmokeTests = Boolean(user) && (isSmokeTestAccount || isSuperAdmin);
   const canUseAdmin = Boolean(user) && (isModerator || isSuperAdmin);
   const activeTab = !isSignedIn && tab !== "map" && tab !== "pairing-info" && tab !== "about" && tab !== "node"
     ? "map"


### PR DESCRIPTION
The existing checks for the smoke test email account are still in place, the main change was using the existing isSuperAdmin
auth check as a secondary condition that would set the flag to True. 
