### PR TITLE
chore(functions): bump fastify to 5.8.5

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@fastify/cors": "11.2.0",
-    "fastify": "5.8.4",
+    "fastify": "5.8.5",
     "fastify-rate-limit": "npm:@fastify/rate-limit@10.3.0",
     "firebase-admin": "13.8.0",
     "firebase-functions": "7.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,8 +125,8 @@ importers:
         specifier: 11.2.0
         version: 11.2.0
       fastify:
-        specifier: 5.8.4
-        version: 5.8.4
+        specifier: 5.8.5
+        version: 5.8.5
       fastify-rate-limit:
         specifier: npm:@fastify/rate-limit@10.3.0
         version: '@fastify/rate-limit@10.3.0'
@@ -3304,8 +3304,8 @@ packages:
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
-  fastify@5.8.4:
-    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -9544,7 +9544,7 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify@5.8.4:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0


### PR DESCRIPTION
## Summary
- bump `fastify` in `crowdpm-functions` from `5.8.4` to `5.8.5`
- refresh the pnpm lockfile
- no application code changes were required for this patch release

## Verification
- `pnpm --filter crowdpm-functions build`
- `pnpm --filter crowdpm-functions test`