### PR TITLE
Fix: UI pagination format

### DIFF
--- a/frontend/src/components/PaginationControl.tsx
+++ b/frontend/src/components/PaginationControl.tsx
@@ -1,38 +1,73 @@
 import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
 import { Flex, IconButton, Text } from "@radix-ui/themes";
 
+export const DEFAULT_RESULTS_PAGE_SIZE = 10;
 export const MIN_VISIBLE_RESULTS = 1;
-export const DEFAULT_VISIBLE_RESULTS = 10;
+export const DEFAULT_VISIBLE_RESULTS = DEFAULT_RESULTS_PAGE_SIZE;
+
+export function getPageCount(total: number, pageSize = DEFAULT_RESULTS_PAGE_SIZE) {
+  if (total <= 0) return 0;
+  return Math.ceil(total / pageSize);
+}
 
 export function clampVisibleResults(total: number, requested: number) {
   if (total <= 0) return 0;
   return Math.min(Math.max(requested, MIN_VISIBLE_RESULTS), Math.min(DEFAULT_VISIBLE_RESULTS, total));
 }
 
+export function clampPageIndex(total: number, requested: number, pageSize = DEFAULT_RESULTS_PAGE_SIZE) {
+  const pageCount = getPageCount(total, pageSize);
+  if (pageCount === 0) return 0;
+  return Math.min(Math.max(requested, 0), pageCount - 1);
+}
+
+export function getPaginationWindow(total: number, pageIndex: number, pageSize = DEFAULT_RESULTS_PAGE_SIZE) {
+  if (total <= 0) {
+    return {
+      pageIndex: 0,
+      pageStart: 0,
+      pageEnd: 0,
+      pageCount: 0,
+    };
+  }
+
+  const nextPageIndex = clampPageIndex(total, pageIndex, pageSize);
+  const pageStart = nextPageIndex * pageSize;
+  const pageEnd = Math.min(pageStart + pageSize, total);
+
+  return {
+    pageIndex: nextPageIndex,
+    pageStart,
+    pageEnd,
+    pageCount: getPageCount(total, pageSize),
+  };
+}
+
 type ResultCountControlProps = {
   itemLabelSingular: string;
   itemLabelPlural: string;
-  visibleCount: number;
+  pageStart: number;
+  pageEnd: number;
   totalCount: number;
   onShowLess: () => void;
   onShowMore: () => void;
 };
 
-export function ResultCountControl({
-  itemLabelSingular,
-  itemLabelPlural,
-  visibleCount,
-  totalCount,
-  onShowLess,
-  onShowMore,
-}: ResultCountControlProps) {
+export function ResultCountControl(props: ResultCountControlProps) {
+  const {
+    itemLabelSingular,
+    itemLabelPlural,
+    pageStart,
+    pageEnd,
+    totalCount,
+    onShowLess,
+    onShowMore,
+  } = props;
+
   if (totalCount <= 1) return null;
 
-  const maxVisibleCount = Math.min(DEFAULT_VISIBLE_RESULTS, totalCount);
   const noun = totalCount === 1 ? itemLabelSingular : itemLabelPlural;
-  const summary = visibleCount < totalCount
-    ? `Showing first ${visibleCount} of ${totalCount} ${noun}`
-    : `Showing ${visibleCount} ${noun}`;
+  const summary = `Showing ${pageStart + 1}-${pageEnd} of ${totalCount} ${noun}`;
 
   return (
     <Flex align="center" gap="2" wrap="wrap">
@@ -43,7 +78,7 @@ export function ResultCountControl({
         size="1"
         aria-label={`Show fewer ${itemLabelPlural}`}
         onClick={onShowLess}
-        disabled={visibleCount <= MIN_VISIBLE_RESULTS}
+        disabled={pageStart === 0}
       >
         <ChevronUpIcon />
       </IconButton>
@@ -53,7 +88,7 @@ export function ResultCountControl({
         size="1"
         aria-label={`Show more ${itemLabelPlural}`}
         onClick={onShowMore}
-        disabled={visibleCount >= maxVisibleCount}
+        disabled={pageEnd >= totalCount}
       >
         <ChevronDownIcon />
       </IconButton>

--- a/frontend/src/components/PaginationControl.tsx
+++ b/frontend/src/components/PaginationControl.tsx
@@ -1,33 +1,24 @@
 import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
 import { Flex, IconButton, Text } from "@radix-ui/themes";
 
-export const DEFAULT_RESULTS_PAGE_SIZE = 10;
-export const MIN_VISIBLE_RESULTS = 1;
-export const DEFAULT_VISIBLE_RESULTS = DEFAULT_RESULTS_PAGE_SIZE;
+export const RESULTS_PER_PAGE = 10;
 
-export function getPageCount(total: number, pageSize = DEFAULT_RESULTS_PAGE_SIZE) {
+function getPageCount(total: number, pageSize = RESULTS_PER_PAGE) {
   if (total <= 0) return 0;
   return Math.ceil(total / pageSize);
 }
 
-export function clampVisibleResults(total: number, requested: number) {
-  if (total <= 0) return 0;
-  return Math.min(Math.max(requested, MIN_VISIBLE_RESULTS), Math.min(DEFAULT_VISIBLE_RESULTS, total));
-}
-
-export function clampPageIndex(total: number, requested: number, pageSize = DEFAULT_RESULTS_PAGE_SIZE) {
+export function clampPageIndex(total: number, requested: number, pageSize = RESULTS_PER_PAGE) {
   const pageCount = getPageCount(total, pageSize);
   if (pageCount === 0) return 0;
   return Math.min(Math.max(requested, 0), pageCount - 1);
 }
 
-export function getPaginationWindow(total: number, pageIndex: number, pageSize = DEFAULT_RESULTS_PAGE_SIZE) {
+export function getPaginationWindow(total: number, pageIndex: number, pageSize = RESULTS_PER_PAGE) {
   if (total <= 0) {
     return {
-      pageIndex: 0,
       pageStart: 0,
       pageEnd: 0,
-      pageCount: 0,
     };
   }
 
@@ -36,10 +27,8 @@ export function getPaginationWindow(total: number, pageIndex: number, pageSize =
   const pageEnd = Math.min(pageStart + pageSize, total);
 
   return {
-    pageIndex: nextPageIndex,
     pageStart,
     pageEnd,
-    pageCount: getPageCount(total, pageSize),
   };
 }
 

--- a/frontend/src/pages/AdminModerationPage.tsx
+++ b/frontend/src/pages/AdminModerationPage.tsx
@@ -24,7 +24,7 @@ import {
   type AdminRole,
 } from "../lib/api";
 import { useAuth } from "../providers/AuthProvider";
-import { clampVisibleResults, DEFAULT_VISIBLE_RESULTS, MIN_VISIBLE_RESULTS, ResultCountControl } from "../components/PaginationControl";
+import { clampPageIndex, getPaginationWindow, ResultCountControl } from "../components/PaginationControl";
 
 function formatTimestamp(value: string | null): string {
   const ms = timestampToMillis(value);
@@ -55,8 +55,8 @@ export default function AdminModerationPage() {
 
   const [moderationFilter, setModerationFilter] = useState<SubmissionFilterState>("all");
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilterState>("all");
-  const [visibleSubmissionCount, setVisibleSubmissionCount] = useState(DEFAULT_VISIBLE_RESULTS);
-  const [visibleUserCount, setVisibleUserCount] = useState(DEFAULT_VISIBLE_RESULTS);
+  const [submissionPageIndex, setSubmissionPageIndex] = useState(0);
+  const [userPageIndex, setUserPageIndex] = useState(0);
 
   const canAccess = Boolean(user) && isModerator;
 
@@ -65,21 +65,21 @@ export default function AdminModerationPage() {
     visibility: visibilityFilter === "all" ? undefined : visibilityFilter,
     limit: 100,
   }), [moderationFilter, visibilityFilter]);
-  const boundedVisibleSubmissionCount = useMemo(
-    () => clampVisibleResults(submissions.length, visibleSubmissionCount),
-    [submissions.length, visibleSubmissionCount],
+  const submissionPagination = useMemo(
+    () => getPaginationWindow(submissions.length, submissionPageIndex),
+    [submissionPageIndex, submissions.length],
   );
   const visibleSubmissions = useMemo(
-    () => submissions.slice(0, boundedVisibleSubmissionCount),
-    [boundedVisibleSubmissionCount, submissions],
+    () => submissions.slice(submissionPagination.pageStart, submissionPagination.pageEnd),
+    [submissionPagination.pageEnd, submissionPagination.pageStart, submissions],
   );
-  const boundedVisibleUserCount = useMemo(
-    () => clampVisibleResults(users.length, visibleUserCount),
-    [users.length, visibleUserCount],
+  const userPagination = useMemo(
+    () => getPaginationWindow(users.length, userPageIndex),
+    [userPageIndex, users.length],
   );
   const visibleUsers = useMemo(
-    () => users.slice(0, boundedVisibleUserCount),
-    [boundedVisibleUserCount, users],
+    () => users.slice(userPagination.pageStart, userPagination.pageEnd),
+    [userPagination.pageEnd, userPagination.pageStart, users],
   );
 
   const refreshSubmissions = useCallback(async () => {
@@ -129,20 +129,18 @@ export default function AdminModerationPage() {
   }, [canAccess, refreshUsers]);
 
   useEffect(() => {
-    if (submissions.length === 0) return;
-    const nextVisibleCount = clampVisibleResults(submissions.length, visibleSubmissionCount);
-    if (nextVisibleCount !== visibleSubmissionCount) {
-      setVisibleSubmissionCount(nextVisibleCount);
+    const nextPageIndex = clampPageIndex(submissions.length, submissionPageIndex);
+    if (nextPageIndex !== submissionPageIndex) {
+      setSubmissionPageIndex(nextPageIndex);
     }
-  }, [submissions.length, visibleSubmissionCount]);
+  }, [submissionPageIndex, submissions.length]);
 
   useEffect(() => {
-    if (users.length === 0) return;
-    const nextVisibleCount = clampVisibleResults(users.length, visibleUserCount);
-    if (nextVisibleCount !== visibleUserCount) {
-      setVisibleUserCount(nextVisibleCount);
+    const nextPageIndex = clampPageIndex(users.length, userPageIndex);
+    if (nextPageIndex !== userPageIndex) {
+      setUserPageIndex(nextPageIndex);
     }
-  }, [users.length, visibleUserCount]);
+  }, [userPageIndex, users.length]);
 
   const handleModerationChange = useCallback(async (entry: AdminSubmissionSummary, moderationState: ModerationState) => {
     if (!canAccess) return;
@@ -221,10 +219,11 @@ export default function AdminModerationPage() {
             <ResultCountControl
               itemLabelSingular="submission"
               itemLabelPlural="submissions"
-              visibleCount={boundedVisibleSubmissionCount}
+              pageStart={submissionPagination.pageStart}
+              pageEnd={submissionPagination.pageEnd}
               totalCount={submissions.length}
-              onShowLess={() => setVisibleSubmissionCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
-              onShowMore={() => setVisibleSubmissionCount((current) => Math.min(DEFAULT_VISIBLE_RESULTS, current + 1))}
+              onShowLess={() => setSubmissionPageIndex((current) => clampPageIndex(submissions.length, current - 1))}
+              onShowMore={() => setSubmissionPageIndex((current) => clampPageIndex(submissions.length, current + 1))}
             />
           </Flex>
           <Flex gap="3" wrap="wrap" align="end">
@@ -320,10 +319,11 @@ export default function AdminModerationPage() {
             <ResultCountControl
               itemLabelSingular="user"
               itemLabelPlural="users"
-              visibleCount={boundedVisibleUserCount}
+              pageStart={userPagination.pageStart}
+              pageEnd={userPagination.pageEnd}
               totalCount={users.length}
-              onShowLess={() => setVisibleUserCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
-              onShowMore={() => setVisibleUserCount((current) => Math.min(DEFAULT_VISIBLE_RESULTS, current + 1))}
+              onShowLess={() => setUserPageIndex((current) => clampPageIndex(users.length, current - 1))}
+              onShowMore={() => setUserPageIndex((current) => clampPageIndex(users.length, current + 1))}
             />
           </Flex>
           <Flex gap="3" wrap="wrap" align="center">

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -15,7 +15,7 @@ import {
 import { useAuth } from "../providers/AuthProvider";
 import { useUserSettings } from "../providers/UserSettingsProvider";
 import { buildActivationLink } from "../lib/activation";
-import { clampVisibleResults, DEFAULT_VISIBLE_RESULTS, MIN_VISIBLE_RESULTS, ResultCountControl } from "../components/PaginationControl";
+import { clampPageIndex, getPaginationWindow, ResultCountControl } from "../components/PaginationControl";
 
 type UserDashboardProps = {
   onRequestActivation: () => void;
@@ -38,7 +38,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
   const [devicesError, setDevicesError] = useState<string | null>(null);
   const [revokeError, setRevokeError] = useState<string | null>(null);
   const [revokingId, setRevokingId] = useState<string | null>(null);
-  const [visibleDeviceCount, setVisibleDeviceCount] = useState(DEFAULT_VISIBLE_RESULTS);
+  const [devicePageIndex, setDevicePageIndex] = useState(0);
   const [batches, setBatches] = useState<BatchSummary[]>([]);
   const [isLoadingBatches, setIsLoadingBatches] = useState(false);
   const [batchesError, setBatchesError] = useState<string | null>(null);
@@ -47,7 +47,7 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
   const [batchActionMessage, setBatchActionMessage] = useState<string | null>(null);
   const [updatingBatchKey, setUpdatingBatchKey] = useState<string | null>(null);
   const [deletingBatchKey, setDeletingBatchKey] = useState<string | null>(null);
-  const [visibleBatchCount, setVisibleBatchCount] = useState(DEFAULT_VISIBLE_RESULTS);
+  const [batchPageIndex, setBatchPageIndex] = useState(0);
   const [settingsMessage, setSettingsMessage] = useState<string | null>(null);
   const [settingsLocalError, setSettingsLocalError] = useState<string | null>(null);
   const activationUrl = useMemo(() => buildActivationLink(), []);
@@ -135,21 +135,21 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
       return timeB - timeA;
     });
   }, [batches, selectedBatchDeviceId]);
-  const boundedVisibleDeviceCount = useMemo(
-    () => clampVisibleResults(devices.length, visibleDeviceCount),
-    [devices.length, visibleDeviceCount],
+  const devicePagination = useMemo(
+    () => getPaginationWindow(devices.length, devicePageIndex),
+    [devicePageIndex, devices.length],
   );
   const visibleDevices = useMemo(
-    () => devices.slice(0, boundedVisibleDeviceCount),
-    [boundedVisibleDeviceCount, devices],
+    () => devices.slice(devicePagination.pageStart, devicePagination.pageEnd),
+    [devicePagination.pageEnd, devicePagination.pageStart, devices],
   );
-  const boundedVisibleBatchCount = useMemo(
-    () => clampVisibleResults(filteredBatches.length, visibleBatchCount),
-    [filteredBatches.length, visibleBatchCount],
+  const batchPagination = useMemo(
+    () => getPaginationWindow(filteredBatches.length, batchPageIndex),
+    [batchPageIndex, filteredBatches.length],
   );
   const visibleBatches = useMemo(
-    () => filteredBatches.slice(0, boundedVisibleBatchCount),
-    [boundedVisibleBatchCount, filteredBatches],
+    () => filteredBatches.slice(batchPagination.pageStart, batchPagination.pageEnd),
+    [batchPagination.pageEnd, batchPagination.pageStart, filteredBatches],
   );
 
   useEffect(() => {
@@ -161,20 +161,18 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
   }, [batchDeviceOptions, selectedBatchDeviceId]);
 
   useEffect(() => {
-    if (devices.length === 0) return;
-    const nextVisibleCount = clampVisibleResults(devices.length, visibleDeviceCount);
-    if (nextVisibleCount !== visibleDeviceCount) {
-      setVisibleDeviceCount(nextVisibleCount);
+    const nextPageIndex = clampPageIndex(devices.length, devicePageIndex);
+    if (nextPageIndex !== devicePageIndex) {
+      setDevicePageIndex(nextPageIndex);
     }
-  }, [devices.length, visibleDeviceCount]);
+  }, [devicePageIndex, devices.length]);
 
   useEffect(() => {
-    if (filteredBatches.length === 0) return;
-    const nextVisibleCount = clampVisibleResults(filteredBatches.length, visibleBatchCount);
-    if (nextVisibleCount !== visibleBatchCount) {
-      setVisibleBatchCount(nextVisibleCount);
+    const nextPageIndex = clampPageIndex(filteredBatches.length, batchPageIndex);
+    if (nextPageIndex !== batchPageIndex) {
+      setBatchPageIndex(nextPageIndex);
     }
-  }, [filteredBatches.length, visibleBatchCount]);
+  }, [batchPageIndex, filteredBatches.length]);
 
   const handleDefaultVisibilityChange = useCallback(async (nextValue: string) => {
     const next = nextValue as BatchVisibility;
@@ -424,10 +422,11 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
             <ResultCountControl
               itemLabelSingular="device"
               itemLabelPlural="devices"
-              visibleCount={boundedVisibleDeviceCount}
+              pageStart={devicePagination.pageStart}
+              pageEnd={devicePagination.pageEnd}
               totalCount={devices.length}
-              onShowLess={() => setVisibleDeviceCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
-              onShowMore={() => setVisibleDeviceCount((current) => Math.min(DEFAULT_VISIBLE_RESULTS, current + 1))}
+              onShowLess={() => setDevicePageIndex((current) => clampPageIndex(devices.length, current - 1))}
+              onShowMore={() => setDevicePageIndex((current) => clampPageIndex(devices.length, current + 1))}
             />
           </Flex>
           <Separator my="2" size="4" />
@@ -509,10 +508,11 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
               <ResultCountControl
                 itemLabelSingular="batch"
                 itemLabelPlural="batches"
-                visibleCount={boundedVisibleBatchCount}
+                pageStart={batchPagination.pageStart}
+                pageEnd={batchPagination.pageEnd}
                 totalCount={filteredBatches.length}
-                onShowLess={() => setVisibleBatchCount((current) => Math.max(MIN_VISIBLE_RESULTS, current - 1))}
-                onShowMore={() => setVisibleBatchCount((current) => Math.min(DEFAULT_VISIBLE_RESULTS, current + 1))}
+                onShowLess={() => setBatchPageIndex((current) => clampPageIndex(filteredBatches.length, current - 1))}
+                onShowMore={() => setBatchPageIndex((current) => clampPageIndex(filteredBatches.length, current + 1))}
               />
               <Button variant="soft" onClick={refreshBatches} disabled={isLoadingBatches}>
                 <ReloadIcon /> {isLoadingBatches ? "Refreshing" : "Refresh"}


### PR DESCRIPTION
Now mimics behavior outline by Jaron:

_well it shouldn't add or subtract how many are viewable, it should view the first set of 1-10 then arrow moves what is viewable to second set 11-20. Unless you are doing some rolling effect or something, I am not sure_

Correctly uses a page count system that displays 1-10 results (or up to n results if less than upper limit) and clicking the arrow to show more shifts the page by 1. This then shows the next (11-20) results instead of having them appear below the 1-10 results.

This change was applied to the PaginationControl.tsx component as well as the UserDashboard.tsx and AdminModeration.tsx lists.