### PR TITLE
Feature: Local Storage Implementation 

### DIFF
--- a/frontend/src/components/Map3D.tsx
+++ b/frontend/src/components/Map3D.tsx
@@ -40,6 +40,7 @@ type Map3DProps = {
   selectedIndex: number;
   onSelectIndex?: (index: number) => void;
   onSelectPoint?: (point: MeasurementPoint) => void;
+  onZoomChange?: (zoom: number) => void;
   autoCenterKey?: string;
   interleaved?: boolean;
   showAllMode?: boolean;
@@ -466,6 +467,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
   selectedIndex,
   onSelectIndex,
   onSelectPoint,
+  onZoomChange,
   autoCenterKey,
   interleaved = false,
   showAllMode = false,
@@ -481,10 +483,12 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
   const selectedIndexRef = useRef<number>(selectedIndex);
   const onSelectRef = useRef<typeof onSelectIndex>(onSelectIndex);
   const onSelectPointRef = useRef<typeof onSelectPoint>(onSelectPoint);
+  const onZoomChangeRef = useRef<typeof onZoomChange>(onZoomChange);
   const showAllModeRef = useRef(showAllMode);
   const playbackPathModeRef = useRef(playbackPathMode);
   const sphereGeometryRef = useRef<SphereGeometry | null>(null);
-  const hasUserControlRef = useRef(false);
+  const hasUserControlRef = useRef(typeof defaultZoom === "number");
+  const initialDefaultZoomRef = useRef(defaultZoom);
   const dataSignatureRef = useRef(signature(data));
   const defaultCenterLat = defaultCenter?.lat;
   const defaultCenterLng = defaultCenter?.lng;
@@ -494,6 +498,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
   useEffect(() => { selectedIndexRef.current = selectedIndex; }, [selectedIndex]);
   useEffect(() => { onSelectRef.current = onSelectIndex; }, [onSelectIndex]);
   useEffect(() => { onSelectPointRef.current = onSelectPoint; }, [onSelectPoint]);
+  useEffect(() => { onZoomChangeRef.current = onZoomChange; }, [onZoomChange]);
   useEffect(() => { showAllModeRef.current = showAllMode; }, [showAllMode]);
   useEffect(() => { playbackPathModeRef.current = playbackPathMode; }, [playbackPathMode]);
   useEffect(() => {
@@ -608,9 +613,10 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       const resolvedCenter = (typeof defaultCenterLat === "number" && typeof defaultCenterLng === "number")
         ? { lat: defaultCenterLat, lng: defaultCenterLng }
         : FALLBACK_CENTER;
-      const resolvedZoom = defaultZoom ?? FALLBACK_ZOOM;
+      const initialDefaultZoom = initialDefaultZoomRef.current;
+      const resolvedZoom = initialDefaultZoom ?? FALLBACK_ZOOM;
       const center = firstPoint ? { lat: firstPoint.lat, lng: firstPoint.lon } : resolvedCenter;
-      const initialZoom = firstPoint ? 15 : resolvedZoom;
+      const initialZoom = firstPoint ? (initialDefaultZoom ?? 15) : resolvedZoom;
       const initialTilt = firstPoint ? 67.5 : 0;
 
       const MapCtor = mapsLib.Map as typeof google.maps.Map;
@@ -629,9 +635,16 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       mapRef.current = map;
 
       const markUserControl = () => { hasUserControlRef.current = true; };
+      const handleZoomChange = () => {
+        markUserControl();
+        const zoom = map.getZoom();
+        if (typeof zoom === "number" && Number.isFinite(zoom)) {
+          onZoomChangeRef.current?.(zoom);
+        }
+      };
       listeners = [
         map.addListener("dragstart", markUserControl),
-        map.addListener("zoom_changed", markUserControl),
+        map.addListener("zoom_changed", handleZoomChange),
         map.addListener("tilt_changed", markUserControl),
         map.addListener("heading_changed", markUserControl)
       ];
@@ -675,7 +688,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       }
 
       if (currentSeries.length && typeof map.moveCamera === "function") {
-        map.moveCamera({ tilt: 67.5, heading: 0, zoom: 18 });
+        map.moveCamera({ tilt: 67.5, heading: 0, zoom: initialDefaultZoom ?? 18 });
       }
       overlayRef.current = overlay;
       syncOverlayRef.current?.();
@@ -696,7 +709,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       if (overlayRef.current === localOverlay) overlayRef.current = null;
       if (mapRef.current === localMap) mapRef.current = null;
     };
-  }, [interleaved, defaultCenterLat, defaultCenterLng, defaultZoom]);
+  }, [interleaved, defaultCenterLat, defaultCenterLng]);
 
   return <div ref={divRef} style={{ width: "100%", height: "100%" }} />;
 });

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -234,6 +234,7 @@ export default function MapPage({
   const [isBatchBrowserOpen, setBatchBrowserOpen] = useState(false);
   const [batchBrowserPageIndex, setBatchBrowserPageIndex] = useState(0);
   const cacheHydratedRef = useRef<string | null>(null);
+  const selectionHydratedRef = useRef<string | null>(null);
   const skipIndexResetRef = useRef(false);
   const map3DRef = useRef<Map3DHandle | null>(null);
   const [captureAvailable, setCaptureAvailable] = useState(false);
@@ -377,9 +378,21 @@ export default function MapPage({
       const parsed = decodeBatchKey(selectedBatchKey);
       if (!parsed) return [];
 
-      const shouldUsePrivateDetail = Boolean(user) && selectedSummary !== null && selectedSummary.visibility !== "public";
-      const fetchDetail = shouldUsePrivateDetail ? fetchBatchDetail : fetchPublicBatchDetail;
-      const detail = await fetchDetail(parsed.deviceId, parsed.batchId);
+      const detail = await (async () => {
+        if (!user) {
+          return fetchPublicBatchDetail(parsed.deviceId, parsed.batchId);
+        }
+        if (selectedSummary?.visibility === "public") {
+          return fetchPublicBatchDetail(parsed.deviceId, parsed.batchId);
+        }
+        try {
+          return await fetchBatchDetail(parsed.deviceId, parsed.batchId);
+        }
+        catch (err) {
+          if (selectedSummary) throw err;
+          return fetchPublicBatchDetail(parsed.deviceId, parsed.batchId);
+        }
+      })();
       return pointsToMeasurementRecords(detail.points, detail.deviceId, detail.batchId, { batchKey: selectedBatchKey });
     },
     retryOnMount: false,
@@ -426,6 +439,68 @@ export default function MapPage({
     }
   }, [batchBrowserBatches.length, batchBrowserPageIndex]);
 
+  useEffect(() => {
+    if (isAuthLoading) return;
+    if (selectionHydratedRef.current === userScopedSelectionKey) return;
+    selectionHydratedRef.current = userScopedSelectionKey;
+
+    const storedSelection = safeLocalStorageGet(
+      userScopedSelectionKey,
+      null,
+      { context: "map:selected-batch:hydrate", userId: user?.uid }
+    );
+    if (!storedSelection) {
+      setSelectedBatchKey("");
+      return;
+    }
+
+    if (storedSelection === SHOW_ALL_PUBLIC_24H_KEY || decodeBatchKey(storedSelection)) {
+      setSelectedBatchKey(storedSelection);
+      return;
+    }
+
+    setSelectedBatchKey("");
+    safeLocalStorageRemove(
+      userScopedSelectionKey,
+      { context: "map:selected-batch:clear-invalid", userId: user?.uid }
+    );
+  }, [isAuthLoading, user?.uid, userScopedSelectionKey]);
+
+  useEffect(() => {
+    if (
+      isAuthLoading
+      || !isBatchBrowserOpen
+      || !batchBrowserQuery.isSuccess
+      || batchBrowserQuery.isFetching
+    ) {
+      return;
+    }
+    if (!selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY) return;
+
+    const parsed = decodeBatchKey(selectedBatchKey);
+    const selectionExists = parsed
+      ? (batchBrowserQuery.data ?? []).some((batch) => batch.deviceId === parsed.deviceId && batch.batchId === parsed.batchId)
+      : false;
+
+    if (selectionExists) return;
+
+    setSelectedBatchKey("");
+    setIndexOverride(0);
+    safeLocalStorageRemove(
+      userScopedSelectionKey,
+      { context: "map:selected-batch:clear-missing", userId: user?.uid }
+    );
+  }, [
+    batchBrowserQuery.data,
+    batchBrowserQuery.isFetching,
+    batchBrowserQuery.isSuccess,
+    isBatchBrowserOpen,
+    isAuthLoading,
+    selectedBatchKey,
+    user?.uid,
+    userScopedSelectionKey,
+  ]);
+
   // // Reset override when data changes
   // useEffect(() => {
   //   setIndexOverride(null);
@@ -452,22 +527,20 @@ export default function MapPage({
 
   const handleBatchSelect = useCallback((value: string) => {
     setSelectedBatchKey(value);
-    if (user) {
-      if (value) {
-        safeLocalStorageSet(
-          userScopedSelectionKey,
-          value,
-          { context: "map:selected-batch:update", userId: user.uid }
-        );
-      }
-      else {
-        safeLocalStorageRemove(
-          userScopedSelectionKey,
-          { context: "map:selected-batch:clear", userId: user.uid }
-        );
-      }
+    if (value) {
+      safeLocalStorageSet(
+        userScopedSelectionKey,
+        value,
+        { context: "map:selected-batch:update", userId: user?.uid }
+      );
     }
-  }, [user, userScopedSelectionKey]);
+    else {
+      safeLocalStorageRemove(
+        userScopedSelectionKey,
+        { context: "map:selected-batch:clear", userId: user?.uid }
+      );
+    }
+  }, [user?.uid, userScopedSelectionKey]);
 
   const upsertBatchSummary = useCallback((summary: BatchSummary) => {
     queryClient.setQueryData<BatchSummary[]>(BATCHES_QUERY_KEY(user?.uid ?? null), (prev = []) => {
@@ -853,7 +926,7 @@ export default function MapPage({
       </Suspense>
 
       {/* ---- Welcome hero overlay (when no batch selected and no data) ---- */}
-      {!selectedBatchKey && !rows.length ? (
+      {!user && !selectedBatchKey && !rows.length ? (
         <div
           style={{
             position: "absolute",

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -28,6 +28,7 @@ import { clampPageIndex, getPaginationWindow, ResultCountControl } from "../comp
 const LAST_SELECTION_KEY = "crowdpm:lastSmokeSelection";
 const LAST_SMOKE_CACHE_KEY = "crowdpm:lastSmokeBatchCache";
 const LAST_MAP_ZOOM_KEY = "crowdpm:lastMapZoom";
+const LAST_TIMELINE_INDEX_KEY = "crowdpm:lastTimelineIndex";
 const BATCH_LIST_STALE_MS = 30_000; // keep batch list warm for 30 seconds to avoid redundant refetches
 const DROPDOWN_BATCH_LIMIT = 20;
 const NO_BATCH_SELECTED_KEY = "__no_batch_selected__";
@@ -56,6 +57,8 @@ type MapMeasurementRecord = MeasurementRecord & {
   batchKey?: string;
   batchPointIndex?: number;
 };
+
+type StoredTimelineIndexes = Record<string, number>;
 
 // Safely parse a cached smoke batch so stale/invalid JSON never breaks the UI.
 function parseStoredSmokeBatch(raw: string | null): StoredSmokeBatch | null {
@@ -220,6 +223,32 @@ function parseStoredMapZoom(raw: string | null): number | null {
   return Math.min(Math.max(parsed, MIN_PERSISTED_MAP_ZOOM), MAX_PERSISTED_MAP_ZOOM);
 }
 
+function parseStoredTimelineIndexes(raw: string | null): StoredTimelineIndexes {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown> | null;
+    if (!parsed || typeof parsed !== "object") return {};
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .filter((entry): entry is [string, number] => typeof entry[1] === "number" && Number.isFinite(entry[1]))
+    );
+  }
+  catch {
+    return {};
+  }
+}
+
+function getStoredTimelineIndex(storageKey: string, batchKey: string, maxIndex: number, userId?: string | null): number | null {
+  const stored = parseStoredTimelineIndexes(safeLocalStorageGet(
+    storageKey,
+    null,
+    { context: "map:timeline:read", userId }
+  ));
+  const index = stored[batchKey];
+  if (typeof index !== "number" || !Number.isFinite(index)) return null;
+  return Math.min(Math.max(Math.round(index), 0), maxIndex);
+}
+
 export default function MapPage({
   pendingSmokeResult = null,
   onSmokeResultConsumed,
@@ -242,6 +271,10 @@ export default function MapPage({
     () => scopedStorageKey(LAST_MAP_ZOOM_KEY, user?.uid ?? undefined),
     [user?.uid]
   );
+  const userScopedTimelineKey = useMemo(
+    () => scopedStorageKey(LAST_TIMELINE_INDEX_KEY, user?.uid ?? undefined),
+    [user?.uid]
+  );
 
   // Keep track of which batch is selected plus the position in the measurement timeline.
   const [selectedBatchKey, setSelectedBatchKey] = useState<string>("");
@@ -252,6 +285,7 @@ export default function MapPage({
   const cacheHydratedRef = useRef<string | null>(null);
   const selectionHydratedRef = useRef<string | null>(null);
   const zoomHydratedRef = useRef<string | null>(null);
+  const timelineHydratedRef = useRef<string | null>(null);
   const skipIndexResetRef = useRef(false);
   const map3DRef = useRef<Map3DHandle | null>(null);
   const [captureAvailable, setCaptureAvailable] = useState(false);
@@ -438,16 +472,36 @@ export default function MapPage({
   const selectedIndex = indexOverride ?? (rows.length ? rows.length - 1 : 0);
   const [trackBall, setTrackBall] = useState(true);
 
-  // Only reset override when the BATCH changes, not when data changes
   useEffect(() => {
-    deferStateUpdate(() => {
-      if (skipIndexResetRef.current) {
-        skipIndexResetRef.current = false;
-        return;
-      }
+    if (skipIndexResetRef.current) {
+      skipIndexResetRef.current = false;
+      timelineHydratedRef.current = null;
+      return;
+    }
+    if (!selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY) {
+      timelineHydratedRef.current = null;
       setIndexOverride(null);
-    });
-  }, [selectedBatchKey]); // Remove rows.length from dependencies
+      return;
+    }
+    if (!rows.length) return;
+
+    const hydrationKey = `${userScopedTimelineKey}:${selectedBatchKey}:${rows.length}`;
+    if (timelineHydratedRef.current === hydrationKey) return;
+    timelineHydratedRef.current = hydrationKey;
+
+    const storedIndex = getStoredTimelineIndex(
+      userScopedTimelineKey,
+      selectedBatchKey,
+      rows.length - 1,
+      user?.uid
+    );
+    if (storedIndex !== null) {
+      setIndexOverride(storedIndex);
+      return;
+    }
+
+    setIndexOverride(null);
+  }, [rows.length, selectedBatchKey, user?.uid, userScopedTimelineKey]);
 
   useEffect(() => {
     const nextPageIndex = clampPageIndex(batchBrowserBatches.length, batchBrowserPageIndex);
@@ -588,6 +642,27 @@ export default function MapPage({
       { context: "map:zoom:update", userId: user?.uid }
     );
   }, [user?.uid, userScopedZoomKey]);
+
+  const handleTimelineIndexChange = useCallback((nextIndex: number) => {
+    const maxIndex = Math.max(rows.length - 1, 0);
+    const clampedIndex = Math.min(Math.max(Math.round(nextIndex), 0), maxIndex);
+    setIndexOverride(clampedIndex);
+
+    if (!selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY || !rows.length) return;
+    const stored = parseStoredTimelineIndexes(safeLocalStorageGet(
+      userScopedTimelineKey,
+      null,
+      { context: "map:timeline:read", userId: user?.uid }
+    ));
+    safeLocalStorageSet(
+      userScopedTimelineKey,
+      JSON.stringify({
+        ...stored,
+        [selectedBatchKey]: clampedIndex,
+      }),
+      { context: "map:timeline:update", userId: user?.uid }
+    );
+  }, [rows.length, selectedBatchKey, user?.uid, userScopedTimelineKey]);
 
   const upsertBatchSummary = useCallback((summary: BatchSummary) => {
     queryClient.setQueryData<BatchSummary[]>(BATCHES_QUERY_KEY(user?.uid ?? null), (prev = []) => {
@@ -733,6 +808,21 @@ export default function MapPage({
     setSelectedBatchKey(point.batchKey);
     const pointIndex = typeof point.batchPointIndex === "number" ? point.batchPointIndex : null;
     setIndexOverride(pointIndex);
+    if (pointIndex !== null) {
+      const stored = parseStoredTimelineIndexes(safeLocalStorageGet(
+        userScopedTimelineKey,
+        null,
+        { context: "map:timeline:read-from-all", userId: user?.uid }
+      ));
+      safeLocalStorageSet(
+        userScopedTimelineKey,
+        JSON.stringify({
+          ...stored,
+          [point.batchKey]: pointIndex,
+        }),
+        { context: "map:timeline:update-from-all", userId: user?.uid }
+      );
+    }
     if (user) {
       safeLocalStorageSet(
         userScopedSelectionKey,
@@ -740,7 +830,7 @@ export default function MapPage({
         { context: "map:selected-batch:from-all", userId: user.uid }
       );
     }
-  }, [isShowingAllPublic24h, user, userScopedSelectionKey]);
+  }, [isShowingAllPublic24h, user, userScopedSelectionKey, userScopedTimelineKey]);
 
   const data = useMemo(
     () => {
@@ -965,7 +1055,7 @@ export default function MapPage({
             ref={map3DRef}
             data={data}
             selectedIndex={selectedIndex}
-            onSelectIndex={effectiveShowAllMode ? undefined : setIndexOverride}
+            onSelectIndex={effectiveShowAllMode ? undefined : handleTimelineIndexChange}
             onSelectPoint={handleMapPointSelect}
             onZoomChange={handleMapZoomChange}
             autoCenterKey={autoCenterKey}
@@ -1332,7 +1422,7 @@ export default function MapPage({
                   max={rows.length - 1}
                   step={1}
                   value={selectedIndex}
-                  onChange={(e) => setIndexOverride(Number(e.target.value))}
+                  onChange={(e) => handleTimelineIndexChange(Number(e.target.value))}
                   style={{ width: "100%", marginTop: 4 }}
                 />
                 <div

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -27,6 +27,7 @@ import { clampPageIndex, getPaginationWindow, ResultCountControl } from "../comp
 // Keys used to scope localStorage entries per user so shared browsers do not mix data.
 const LAST_SELECTION_KEY = "crowdpm:lastSmokeSelection";
 const LAST_SMOKE_CACHE_KEY = "crowdpm:lastSmokeBatchCache";
+const LAST_MAP_ZOOM_KEY = "crowdpm:lastMapZoom";
 const BATCH_LIST_STALE_MS = 30_000; // keep batch list warm for 30 seconds to avoid redundant refetches
 const DROPDOWN_BATCH_LIMIT = 20;
 const NO_BATCH_SELECTED_KEY = "__no_batch_selected__";
@@ -38,6 +39,8 @@ const VIDEO_EXPORT_DURATION_MS = 12_000;
 const VIDEO_EXPORT_FPS = 30;
 const VIDEO_EXPORT_MIN_POINT_MS = 160;
 const VIDEO_EXPORT_FINAL_POINT_MS = 320;
+const MIN_PERSISTED_MAP_ZOOM = 0;
+const MAX_PERSISTED_MAP_ZOOM = 22;
 
 // React Query cache keys. Keeping them as helpers avoids typos across the file.
 const BATCHES_QUERY_KEY = (uid: string | null | undefined) => ["batches", uid ?? "guest"] as const;
@@ -210,6 +213,13 @@ function sanitizeFileSegment(value: string | null | undefined): string {
   return normalized || "batch";
 }
 
+function parseStoredMapZoom(raw: string | null): number | null {
+  if (!raw) return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.min(Math.max(parsed, MIN_PERSISTED_MAP_ZOOM), MAX_PERSISTED_MAP_ZOOM);
+}
+
 export default function MapPage({
   pendingSmokeResult = null,
   onSmokeResultConsumed,
@@ -228,13 +238,20 @@ export default function MapPage({
     () => scopedStorageKey(LAST_SMOKE_CACHE_KEY, user?.uid ?? undefined),
     [user?.uid]
   );
+  const userScopedZoomKey = useMemo(
+    () => scopedStorageKey(LAST_MAP_ZOOM_KEY, user?.uid ?? undefined),
+    [user?.uid]
+  );
 
   // Keep track of which batch is selected plus the position in the measurement timeline.
   const [selectedBatchKey, setSelectedBatchKey] = useState<string>("");
+  const [persistedMapZoom, setPersistedMapZoom] = useState<number | null>(null);
+  const [zoomHydrationKey, setZoomHydrationKey] = useState<string | null>(null);
   const [isBatchBrowserOpen, setBatchBrowserOpen] = useState(false);
   const [batchBrowserPageIndex, setBatchBrowserPageIndex] = useState(0);
   const cacheHydratedRef = useRef<string | null>(null);
   const selectionHydratedRef = useRef<string | null>(null);
+  const zoomHydratedRef = useRef<string | null>(null);
   const skipIndexResetRef = useRef(false);
   const map3DRef = useRef<Map3DHandle | null>(null);
   const [captureAvailable, setCaptureAvailable] = useState(false);
@@ -467,6 +484,26 @@ export default function MapPage({
   }, [isAuthLoading, user?.uid, userScopedSelectionKey]);
 
   useEffect(() => {
+    if (isAuthLoading) return;
+    if (zoomHydratedRef.current === userScopedZoomKey) return;
+    zoomHydratedRef.current = userScopedZoomKey;
+
+    const storedZoom = parseStoredMapZoom(safeLocalStorageGet(
+      userScopedZoomKey,
+      null,
+      { context: "map:zoom:hydrate", userId: user?.uid }
+    ));
+    setPersistedMapZoom(storedZoom);
+    setZoomHydrationKey(userScopedZoomKey);
+    if (storedZoom === null) {
+      safeLocalStorageRemove(
+        userScopedZoomKey,
+        { context: "map:zoom:clear-invalid", userId: user?.uid }
+      );
+    }
+  }, [isAuthLoading, user?.uid, userScopedZoomKey]);
+
+  useEffect(() => {
     if (
       isAuthLoading
       || !isBatchBrowserOpen
@@ -541,6 +578,16 @@ export default function MapPage({
       );
     }
   }, [user?.uid, userScopedSelectionKey]);
+
+  const handleMapZoomChange = useCallback((zoom: number) => {
+    const nextZoom = Math.min(Math.max(zoom, MIN_PERSISTED_MAP_ZOOM), MAX_PERSISTED_MAP_ZOOM);
+    setPersistedMapZoom(nextZoom);
+    safeLocalStorageSet(
+      userScopedZoomKey,
+      String(nextZoom),
+      { context: "map:zoom:update", userId: user?.uid }
+    );
+  }, [user?.uid, userScopedZoomKey]);
 
   const upsertBatchSummary = useCallback((summary: BatchSummary) => {
     queryClient.setQueryData<BatchSummary[]>(BATCHES_QUERY_KEY(user?.uid ?? null), (prev = []) => {
@@ -740,6 +787,7 @@ export default function MapPage({
 
   // Always render the map — use all-public mode by default when nothing is selected
   const effectiveShowAllMode = isShowingAllPublic24h || !selectedBatchKey;
+  const isMapZoomHydrated = !isAuthLoading && zoomHydrationKey === userScopedZoomKey;
   const isExportSectionVisible = Boolean(selectedBatchKey) && !isShowingAllPublic24h;
   const canExportSelection = useMemo(() => {
     if (!selectedBatchKey || isShowingAllPublic24h) return false;
@@ -912,17 +960,21 @@ export default function MapPage({
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
       {/* ---- Always-visible map ---- */}
       <Suspense fallback={<div style={{ width: "100%", height: "100%", background: "var(--color-surface)" }} />}>
-        <Map3D
-          ref={map3DRef}
-          data={data}
-          selectedIndex={selectedIndex}
-          onSelectIndex={effectiveShowAllMode ? undefined : setIndexOverride}
-          onSelectPoint={handleMapPointSelect}
-          autoCenterKey={autoCenterKey}
-          interleaved={settings.interleavedRendering}
-          showAllMode={effectiveShowAllMode}
-          forceFollowSelection={!effectiveShowAllMode && (trackBall || isExporting)}
-        />
+        {isMapZoomHydrated ? (
+          <Map3D
+            ref={map3DRef}
+            data={data}
+            selectedIndex={selectedIndex}
+            onSelectIndex={effectiveShowAllMode ? undefined : setIndexOverride}
+            onSelectPoint={handleMapPointSelect}
+            onZoomChange={handleMapZoomChange}
+            autoCenterKey={autoCenterKey}
+            interleaved={settings.interleavedRendering}
+            showAllMode={effectiveShowAllMode}
+            defaultZoom={persistedMapZoom ?? undefined}
+            forceFollowSelection={!effectiveShowAllMode && (trackBall || isExporting)}
+          />
+        ) : null}
       </Suspense>
 
       {/* ---- Welcome hero overlay (when no batch selected and no data) ---- */}

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -69,7 +69,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setRoles([]);
         queryClient.clear();
         safeLocalStorageRemove(
-          ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache", "crowdpm:lastMapZoom"],
+          ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache", "crowdpm:lastMapZoom", "crowdpm:lastTimelineIndex"],
           { context: "auth:clear-storage" }
         );
         return;
@@ -98,7 +98,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const clearCachesOnSignOut = useCallback(() => {
     queryClient.clear();
     safeLocalStorageRemove(
-      ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache", "crowdpm:lastMapZoom"],
+      ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache", "crowdpm:lastMapZoom", "crowdpm:lastTimelineIndex"],
       { context: "auth:sign-out-clear" }
     );
   }, [queryClient]);

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -69,7 +69,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setRoles([]);
         queryClient.clear();
         safeLocalStorageRemove(
-          ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache"],
+          ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache", "crowdpm:lastMapZoom"],
           { context: "auth:clear-storage" }
         );
         return;
@@ -98,7 +98,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const clearCachesOnSignOut = useCallback(() => {
     queryClient.clear();
     safeLocalStorageRemove(
-      ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache"],
+      ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache", "crowdpm:lastMapZoom"],
       { context: "auth:sign-out-clear" }
     );
   }, [queryClient]);


### PR DESCRIPTION
Misleading branch name, the feature uses localStorage soley instead of a cookie implementation.

Implemented three localStorage-based map persistence updates:

1. Batch dropdown selection
  - Saves selected batch in crowdpm:lastSmokeSelection.
  - Restores it when returning to the map.
  - Scopes storage per signed-in user.
  - Keeps guest selection separate.
  - Avoids clearing valid saved selections just because the compact dropdown list has not loaded them yet.
  - Map zoom level

2. Saves Google Maps zoom in crowdpm:lastMapZoom.
- Restores zoom before initializing the map, so returning to the map keeps the same zoom.
- Scopes zoom per signed-in user.
- Clears guest zoom on sign-out with other guest map state.
- Timeline position

3. Saves timeline slider position in crowdpm:lastTimelineIndex.
- Stores positions per selected batch, so each batch restores its own timeline point.
- Updates from both slider movement and map point selection.
- Fixed the reset race that was forcing the slider back to the end after restore.

The welcome/title card is hidden for signed-in users.

Implemented using ChatGPT's Codex Agent