### PR TITLE
Persist user theme settings

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,11 @@
-import { lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { AuthDialog, type AuthMode } from "./components/AuthDialog";
+import { ThemeSettingsControls } from "./components/ThemeSettingsControls";
 import { useAuth } from "./providers/AuthProvider";
+import { useUserSettings } from "./providers/UserSettingsProvider";
 import { type IngestSmokeTestCleanupResponse, type IngestSmokeTestResponse } from "./lib/api";
 import {
   Theme,
-  ThemePanel,
   Box,
   DropdownMenu,
   Flex,
@@ -93,6 +94,16 @@ const RESOURCE_LINKS: Array<{ label: string; href: string }> = [
   },
 ];
 
+const THEME_SHORTCUT_IGNORED_SELECTOR = [
+  "[contenteditable]",
+  '[role="combobox"]',
+  '[role="listbox"]',
+  '[role="menu"]',
+  'input:not([type="radio"], [type="checkbox"])',
+  "select",
+  "textarea",
+].join(",");
+
 const MapPage = lazy(() => import("./pages/MapPage"));
 const UserDashboard = lazy(() => import("./pages/UserDashboard"));
 const SmokeTestLab = lazy(() => import("./pages/SmokeTestLab"));
@@ -107,6 +118,7 @@ const NodePage = lazy(() => import("./pages/NodePage"));
 
 export default function App() {
   const { user, isLoading, signOut, isModerator, isSuperAdmin } = useAuth();
+  const { settings } = useUserSettings();
   const userScopedKey = user?.uid ?? "anon";
   const initialPairingGuidePath = typeof window !== "undefined" && window.location.pathname.toLowerCase().startsWith("/pairing-guide");
   const initialAboutPath = typeof window !== "undefined" && window.location.pathname.toLowerCase().startsWith("/about");
@@ -117,6 +129,7 @@ export default function App() {
   const initialActivationPath = typeof window !== "undefined" && window.location.pathname.toLowerCase().startsWith("/activate");
   const [isActivationModalOpen, setActivationModalOpen] = useState(initialActivationPath);
   const [isTeamModalOpen, setTeamModalOpen] = useState(false);
+  const [isThemeModalOpen, setThemeModalOpen] = useState(false);
   const [dashboardRefreshToken, setDashboardRefreshToken] = useState(0);
   const [pendingSmokeResult, setPendingSmokeResult] = useState<IngestSmokeTestResponse | null>(null);
   const [pendingSmokeCleanup, setPendingSmokeCleanup] = useState<IngestSmokeTestCleanupResponse | null>(null);
@@ -139,6 +152,10 @@ export default function App() {
     setAuthDialogOpen(true);
   };
 
+  const toggleThemeModal = useCallback(() => {
+    setThemeModalOpen((open) => !open);
+  }, []);
+
   const handleProtectedTabClick = (target: "dashboard" | "smoke" | "admin") => {
     if (user) {
       if (target === "smoke" && !canUseSmokeTests) return;
@@ -158,6 +175,25 @@ export default function App() {
       console.warn("Sign out failed", err);
     }
   };
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleThemeShortcut = (event: KeyboardEvent) => {
+      const isModifierActive = event.altKey || event.ctrlKey || event.shiftKey || event.metaKey;
+      if (event.key?.toUpperCase() !== "T" || isModifierActive) return;
+
+      const activeElement = document.activeElement;
+      if (activeElement instanceof Element && activeElement.closest(THEME_SHORTCUT_IGNORED_SELECTOR)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      toggleThemeModal();
+    };
+
+    window.addEventListener("keydown", handleThemeShortcut, true);
+    return () => window.removeEventListener("keydown", handleThemeShortcut, true);
+  }, [toggleThemeModal]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -266,14 +302,21 @@ export default function App() {
   );
 
   return (
-    <Theme appearance="dark" accentColor="iris" radius="full" panelBackground="translucent" scaling="100%">
-      {import.meta.env.DEV ? <ThemePanel defaultOpen={false} /> : null}
+    <Theme
+      appearance={settings.theme.appearance}
+      accentColor={settings.theme.accentColor}
+      grayColor={settings.theme.grayColor}
+      radius={settings.theme.radius}
+      panelBackground={settings.theme.panelBackground}
+      scaling={settings.theme.scaling}
+    >
       <ActivationModal
         open={isActivationModalOpen}
         onOpenChange={setActivationModalOpen}
         onActivationComplete={handleActivationComplete}
       />
       <TeamModal open={isTeamModalOpen} onOpenChange={setTeamModalOpen} isSignedIn={isSignedIn} />
+      <ThemePreferencesModal open={isThemeModalOpen} onOpenChange={setThemeModalOpen} />
 
       {/* ---- Branded top bar (fixed across all pages) ---- */}
       <div
@@ -585,6 +628,49 @@ function ActivationModal({ open, onOpenChange, onActivationComplete }: Activatio
         <Suspense fallback={<Text size="2" color="gray">Loading activation...</Text>}>
           <ActivationPage layout="dialog" onActivationComplete={onActivationComplete} />
         </Suspense>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}
+
+type ThemePreferencesModalProps = {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+};
+
+function ThemePreferencesModal({ open, onOpenChange }: ThemePreferencesModalProps) {
+  const { user } = useAuth();
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setMessage(null);
+    setError(null);
+  }, [open]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Content
+        size="3"
+        style={{
+          width: "min(460px, 96vw)",
+          maxWidth: "460px",
+          maxHeight: "90vh",
+          overflowY: "auto",
+        }}
+      >
+        <Dialog.Title>Theme</Dialog.Title>
+        {!user ? (
+          <Dialog.Description>Sign in to save theme preferences.</Dialog.Description>
+        ) : null}
+        <ThemeSettingsControls onMessage={setMessage} onError={setError} />
+        {error ? (
+          <Text color="tomato" size="2" mt="3">{error}</Text>
+        ) : null}
+        {message ? (
+          <Text color="green" size="2" mt="3">{message}</Text>
+        ) : null}
       </Dialog.Content>
     </Dialog.Root>
   );

--- a/frontend/src/components/ThemeSettingsControls.tsx
+++ b/frontend/src/components/ThemeSettingsControls.tsx
@@ -1,0 +1,177 @@
+import { Flex, Select, SegmentedControl, Text } from "@radix-ui/themes";
+import type {
+  UserThemeAccentColor,
+  UserThemeAppearance,
+  UserThemeGrayColor,
+  UserThemePanelBackground,
+  UserThemeRadius,
+  UserThemeScaling,
+  UserThemeSettings,
+} from "@crowdpm/types";
+import { useAuth } from "../providers/AuthProvider";
+import { useUserSettings } from "../providers/UserSettingsProvider";
+
+const APPEARANCES = ["light", "dark"] as const satisfies readonly UserThemeAppearance[];
+const ACCENT_COLORS = [
+  "gray",
+  "gold",
+  "bronze",
+  "brown",
+  "yellow",
+  "amber",
+  "orange",
+  "tomato",
+  "red",
+  "ruby",
+  "crimson",
+  "pink",
+  "plum",
+  "purple",
+  "violet",
+  "iris",
+  "indigo",
+  "blue",
+  "cyan",
+  "teal",
+  "jade",
+  "green",
+  "grass",
+  "lime",
+  "mint",
+  "sky",
+] as const satisfies readonly UserThemeAccentColor[];
+const GRAY_COLORS = ["auto", "gray", "mauve", "slate", "sage", "olive", "sand"] as const satisfies readonly UserThemeGrayColor[];
+const PANEL_BACKGROUNDS = ["solid", "translucent"] as const satisfies readonly UserThemePanelBackground[];
+const RADII = ["none", "small", "medium", "large", "full"] as const satisfies readonly UserThemeRadius[];
+const SCALINGS = ["90%", "95%", "100%", "105%", "110%"] as const satisfies readonly UserThemeScaling[];
+
+type ThemeSettingsControlsProps = {
+  disabled?: boolean;
+  onError?: (message: string | null) => void;
+  onMessage?: (message: string | null) => void;
+};
+
+function labelFor(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export function ThemeSettingsControls({ disabled = false, onError, onMessage }: ThemeSettingsControlsProps) {
+  const { user } = useAuth();
+  const { settings, isLoading, isSaving, updateSettings } = useUserSettings();
+  const controlsDisabled = disabled || isLoading || isSaving || !user;
+
+  const saveTheme = async (nextTheme: UserThemeSettings) => {
+    if (!user) {
+      onMessage?.(null);
+      onError?.("Sign in to save theme preferences.");
+      return;
+    }
+    if (JSON.stringify(nextTheme) === JSON.stringify(settings.theme)) return;
+
+    onMessage?.(null);
+    onError?.(null);
+    try {
+      await updateSettings({ theme: nextTheme });
+      onMessage?.("Theme preferences saved.");
+    }
+    catch (err) {
+      onError?.(err instanceof Error ? err.message : "Unable to update theme preferences.");
+    }
+  };
+
+  const updateTheme = (patch: Partial<UserThemeSettings>) => {
+    void saveTheme({ ...settings.theme, ...patch });
+  };
+
+  return (
+    <Flex direction="column" gap="3">
+      <Text size="2" color="gray">Theme appearance</Text>
+      <SegmentedControl.Root
+        value={settings.theme.appearance}
+        onValueChange={(value) => updateTheme({ appearance: value as UserThemeAppearance })}
+        disabled={controlsDisabled}
+      >
+        {APPEARANCES.map((value) => (
+          <SegmentedControl.Item key={value} value={value}>{labelFor(value)}</SegmentedControl.Item>
+        ))}
+      </SegmentedControl.Root>
+
+      <Flex direction={{ initial: "column", sm: "row" }} gap="3">
+        <Flex direction="column" gap="2" flexGrow="1">
+          <Text size="2" color="gray">Accent color</Text>
+          <Select.Root
+            value={settings.theme.accentColor}
+            onValueChange={(value) => updateTheme({ accentColor: value as UserThemeAccentColor })}
+            disabled={controlsDisabled}
+          >
+            <Select.Trigger />
+            <Select.Content>
+              {ACCENT_COLORS.map((value) => (
+                <Select.Item key={value} value={value}>{labelFor(value)}</Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+        <Flex direction="column" gap="2" flexGrow="1">
+          <Text size="2" color="gray">Gray color</Text>
+          <Select.Root
+            value={settings.theme.grayColor}
+            onValueChange={(value) => updateTheme({ grayColor: value as UserThemeGrayColor })}
+            disabled={controlsDisabled}
+          >
+            <Select.Trigger />
+            <Select.Content>
+              {GRAY_COLORS.map((value) => (
+                <Select.Item key={value} value={value}>{labelFor(value)}</Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+      </Flex>
+
+      <Flex direction={{ initial: "column", sm: "row" }} gap="3">
+        <Flex direction="column" gap="2" flexGrow="1">
+          <Text size="2" color="gray">Radius</Text>
+          <Select.Root
+            value={settings.theme.radius}
+            onValueChange={(value) => updateTheme({ radius: value as UserThemeRadius })}
+            disabled={controlsDisabled}
+          >
+            <Select.Trigger />
+            <Select.Content>
+              {RADII.map((value) => (
+                <Select.Item key={value} value={value}>{labelFor(value)}</Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+        <Flex direction="column" gap="2" flexGrow="1">
+          <Text size="2" color="gray">Scaling</Text>
+          <Select.Root
+            value={settings.theme.scaling}
+            onValueChange={(value) => updateTheme({ scaling: value as UserThemeScaling })}
+            disabled={controlsDisabled}
+          >
+            <Select.Trigger />
+            <Select.Content>
+              {SCALINGS.map((value) => (
+                <Select.Item key={value} value={value}>{value}</Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+      </Flex>
+
+      <Text size="2" color="gray">Panel background</Text>
+      <SegmentedControl.Root
+        value={settings.theme.panelBackground}
+        onValueChange={(value) => updateTheme({ panelBackground: value as UserThemePanelBackground })}
+        disabled={controlsDisabled}
+      >
+        {PANEL_BACKGROUNDS.map((value) => (
+          <SegmentedControl.Item key={value} value={value}>{labelFor(value)}</SegmentedControl.Item>
+        ))}
+      </SegmentedControl.Root>
+    </Flex>
+  );
+}

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "../providers/AuthProvider";
 import { useUserSettings } from "../providers/UserSettingsProvider";
 import { buildActivationLink } from "../lib/activation";
 import { clampPageIndex, getPaginationWindow, ResultCountControl } from "../components/PaginationControl";
+import { ThemeSettingsControls } from "../components/ThemeSettingsControls";
 
 type UserDashboardProps = {
   onRequestActivation: () => void;
@@ -374,8 +375,14 @@ export default function UserDashboard({ onRequestActivation, refreshToken = 0 }:
       <Card id="user-settings">
         <Flex direction="column" gap="3">
           <Heading as="h3" size="4">User settings</Heading>
-          <Text color="gray">Choose the default visibility applied to new ingest batches.</Text>
+          <Text color="gray">Theme choices and rendering preferences are stored with your account.</Text>
           <Separator my="2" size="4" />
+          <ThemeSettingsControls
+            disabled={isSettingsBusy}
+            onMessage={setSettingsMessage}
+            onError={setSettingsLocalError}
+          />
+          <Separator my="3" size="4" />
           <Text size="2" color="gray">Default batch visibility</Text>
           <SegmentedControl.Root
             value={settings.defaultBatchVisibility}

--- a/frontend/src/providers/UserSettingsProvider.tsx
+++ b/frontend/src/providers/UserSettingsProvider.tsx
@@ -14,7 +14,26 @@ type UserSettingsContextValue = {
 export const DEFAULT_USER_SETTINGS: UserSettings = {
   defaultBatchVisibility: "private",
   interleavedRendering: false,
+  theme: {
+    appearance: "dark",
+    accentColor: "iris",
+    grayColor: "auto",
+    panelBackground: "translucent",
+    radius: "full",
+    scaling: "100%",
+  },
 };
+
+function applyUserSettingsDefaults(next: Partial<UserSettings>): UserSettings {
+  return {
+    ...DEFAULT_USER_SETTINGS,
+    ...next,
+    theme: {
+      ...DEFAULT_USER_SETTINGS.theme,
+      ...(next.theme ?? {}),
+    },
+  };
+}
 
 const UserSettingsContext = createContext<UserSettingsContextValue | undefined>(undefined);
 
@@ -36,7 +55,7 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
     setError(null);
     try {
       const next = await fetchUserSettings();
-      setSettings(next);
+      setSettings(applyUserSettingsDefaults(next));
     }
     catch (err) {
       const message = err instanceof Error ? err.message : "Unable to load user settings";
@@ -58,8 +77,9 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
     setError(null);
     try {
       const updated = await updateUserSettings(next);
-      setSettings(updated);
-      return updated;
+      const normalized = applyUserSettingsDefaults(updated);
+      setSettings(normalized);
+      return normalized;
     }
     catch (err) {
       const message = err instanceof Error ? err.message : "Unable to update settings";

--- a/functions/src/openapi.yaml
+++ b/functions/src/openapi.yaml
@@ -728,7 +728,7 @@ paths:
     get:
       operationId: getUserSettings
       summary: Retrieve user settings
-      description: Returns the ingest preferences configured for the authenticated user.
+      description: Returns account preferences configured for the authenticated user.
       security:
         - BearerAuth: []
       responses:
@@ -743,7 +743,7 @@ paths:
     put:
       operationId: updateUserSettings
       summary: Update user settings
-      description: Sets the preferences applied to new batches created by the authenticated user.
+      description: Sets account preferences for batches, map rendering, and theme.
       security:
         - BearerAuth: []
       requestBody:
@@ -751,7 +751,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserSettings'
+              $ref: '#/components/schemas/UserSettingsUpdate'
       responses:
         '200':
           description: Updated settings returned.
@@ -1274,6 +1274,69 @@ components:
         interleavedRendering:
           type: boolean
           description: Whether the map should render deck.gl interleaved with Google Maps (may be less stable on some GPUs).
+        theme:
+          $ref: '#/components/schemas/UserThemeSettings'
       required:
         - defaultBatchVisibility
         - interleavedRendering
+        - theme
+    UserThemeSettings:
+      type: object
+      properties:
+        appearance:
+          type: string
+          enum: [light, dark]
+        accentColor:
+          type: string
+          enum: [gray, gold, bronze, brown, yellow, amber, orange, tomato, red, ruby, crimson, pink, plum, purple, violet, iris, indigo, blue, cyan, teal, jade, green, grass, lime, mint, sky]
+        grayColor:
+          type: string
+          enum: [auto, gray, mauve, slate, sage, olive, sand]
+        panelBackground:
+          type: string
+          enum: [solid, translucent]
+        radius:
+          type: string
+          enum: [none, small, medium, large, full]
+        scaling:
+          type: string
+          enum: [90%, 95%, 100%, 105%, 110%]
+      required:
+        - appearance
+        - accentColor
+        - grayColor
+        - panelBackground
+        - radius
+        - scaling
+    UserSettingsUpdate:
+      type: object
+      properties:
+        defaultBatchVisibility:
+          $ref: '#/components/schemas/BatchVisibility'
+        interleavedRendering:
+          type: boolean
+        theme:
+          $ref: '#/components/schemas/UserThemeSettingsUpdate'
+      additionalProperties: false
+    UserThemeSettingsUpdate:
+      type: object
+      properties:
+        appearance:
+          type: string
+          enum: [light, dark]
+        accentColor:
+          type: string
+          enum: [gray, gold, bronze, brown, yellow, amber, orange, tomato, red, ruby, crimson, pink, plum, purple, violet, iris, indigo, blue, cyan, teal, jade, green, grass, lime, mint, sky]
+        grayColor:
+          type: string
+          enum: [auto, gray, mauve, slate, sage, olive, sand]
+        panelBackground:
+          type: string
+          enum: [solid, translucent]
+        radius:
+          type: string
+          enum: [none, small, medium, large, full]
+        scaling:
+          type: string
+          enum: [90%, 95%, 100%, 105%, 110%]
+      additionalProperties: false

--- a/functions/src/routes/userSettings.ts
+++ b/functions/src/routes/userSettings.ts
@@ -1,4 +1,13 @@
-import type { UserSettings } from "@crowdpm/types";
+import type {
+  UserSettings,
+  UserThemeAccentColor,
+  UserThemeAppearance,
+  UserThemeGrayColor,
+  UserThemePanelBackground,
+  UserThemeRadius,
+  UserThemeScaling,
+  UserThemeSettings,
+} from "@crowdpm/types";
 import type { FastifyPluginAsync } from "fastify";
 import { db } from "../lib/fire.js";
 import type { BatchVisibility } from "../lib/batchVisibility.js";
@@ -7,6 +16,48 @@ import { httpError } from "../lib/httpError.js";
 import { rateLimitGuard, requireUserGuard, requestUserId } from "../lib/routeGuards.js";
 
 const DEFAULT_INTERLEAVED_RENDERING = false;
+const DEFAULT_THEME_SETTINGS: UserThemeSettings = {
+  appearance: "dark",
+  accentColor: "iris",
+  grayColor: "auto",
+  panelBackground: "translucent",
+  radius: "full",
+  scaling: "100%",
+};
+
+const THEME_APPEARANCES = ["light", "dark"] as const satisfies readonly UserThemeAppearance[];
+const THEME_ACCENT_COLORS = [
+  "gray",
+  "gold",
+  "bronze",
+  "brown",
+  "yellow",
+  "amber",
+  "orange",
+  "tomato",
+  "red",
+  "ruby",
+  "crimson",
+  "pink",
+  "plum",
+  "purple",
+  "violet",
+  "iris",
+  "indigo",
+  "blue",
+  "cyan",
+  "teal",
+  "jade",
+  "green",
+  "grass",
+  "lime",
+  "mint",
+  "sky",
+] as const satisfies readonly UserThemeAccentColor[];
+const THEME_GRAY_COLORS = ["auto", "gray", "mauve", "slate", "sage", "olive", "sand"] as const satisfies readonly UserThemeGrayColor[];
+const THEME_PANEL_BACKGROUNDS = ["solid", "translucent"] as const satisfies readonly UserThemePanelBackground[];
+const THEME_RADII = ["none", "small", "medium", "large", "full"] as const satisfies readonly UserThemeRadius[];
+const THEME_SCALINGS = ["90%", "95%", "100%", "105%", "110%"] as const satisfies readonly UserThemeScaling[];
 
 function normalizeInterleavedRendering(value: unknown): boolean | null {
   if (typeof value === "boolean") return value;
@@ -18,11 +69,47 @@ function normalizeInterleavedRendering(value: unknown): boolean | null {
   return null;
 }
 
+function normalizeStringUnion<T extends string>(value: unknown, values: readonly T[]): T | null {
+  return typeof value === "string" && (values as readonly string[]).includes(value) ? value as T : null;
+}
+
+function normalizeThemeSettings(value: unknown, base: UserThemeSettings = DEFAULT_THEME_SETTINGS): UserThemeSettings | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const input = value as Record<string, unknown>;
+
+  const appearance = "appearance" in input
+    ? normalizeStringUnion(input.appearance, THEME_APPEARANCES)
+    : base.appearance;
+  const accentColor = "accentColor" in input
+    ? normalizeStringUnion(input.accentColor, THEME_ACCENT_COLORS)
+    : base.accentColor;
+  const grayColor = "grayColor" in input
+    ? normalizeStringUnion(input.grayColor, THEME_GRAY_COLORS)
+    : base.grayColor;
+  const panelBackground = "panelBackground" in input
+    ? normalizeStringUnion(input.panelBackground, THEME_PANEL_BACKGROUNDS)
+    : base.panelBackground;
+  const radius = "radius" in input
+    ? normalizeStringUnion(input.radius, THEME_RADII)
+    : base.radius;
+  const scaling = "scaling" in input
+    ? normalizeStringUnion(input.scaling, THEME_SCALINGS)
+    : base.scaling;
+
+  if (!appearance || !accentColor || !grayColor || !panelBackground || !radius || !scaling) return null;
+  return { appearance, accentColor, grayColor, panelBackground, radius, scaling };
+}
+
+function readThemeSettings(value: unknown): UserThemeSettings {
+  return normalizeThemeSettings(value, DEFAULT_THEME_SETTINGS) ?? DEFAULT_THEME_SETTINGS;
+}
+
 type UserSettingsResponse = UserSettings;
 
 type UserSettingsBody = {
   defaultBatchVisibility?: unknown;
   interleavedRendering?: unknown;
+  theme?: unknown;
 };
 
 export const userSettingsRoutes: FastifyPluginAsync = async (app) => {
@@ -38,7 +125,8 @@ export const userSettingsRoutes: FastifyPluginAsync = async (app) => {
     const interleavedRendering = snap.exists
       ? normalizeInterleavedRendering(snap.get("interleavedRendering")) ?? DEFAULT_INTERLEAVED_RENDERING
       : DEFAULT_INTERLEAVED_RENDERING;
-    return { defaultBatchVisibility: visibility, interleavedRendering } satisfies UserSettingsResponse;
+    const theme = snap.exists ? readThemeSettings(snap.get("theme")) : DEFAULT_THEME_SETTINGS;
+    return { defaultBatchVisibility: visibility, interleavedRendering, theme } satisfies UserSettingsResponse;
   });
 
   app.put<{ Body: UserSettingsBody }>("/v1/user/settings", {
@@ -50,9 +138,10 @@ export const userSettingsRoutes: FastifyPluginAsync = async (app) => {
   }, async (req) => {
     const hasVisibility = "defaultBatchVisibility" in (req.body ?? {});
     const hasInterleaved = "interleavedRendering" in (req.body ?? {});
+    const hasTheme = "theme" in (req.body ?? {});
 
-    if (!hasVisibility && !hasInterleaved) {
-      throw httpError(400, "missing_fields", "Provide defaultBatchVisibility or interleavedRendering to update.");
+    if (!hasVisibility && !hasInterleaved && !hasTheme) {
+      throw httpError(400, "missing_fields", "Provide defaultBatchVisibility, interleavedRendering, or theme to update.");
     }
 
     let visibility: BatchVisibility | null = null;
@@ -72,17 +161,29 @@ export const userSettingsRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const docRef = db().collection("userSettings").doc(requestUserId(req));
+    let theme: UserThemeSettings | null = null;
+    if (hasTheme) {
+      const existingSnap = await docRef.get();
+      theme = normalizeThemeSettings(req.body?.theme, readThemeSettings(existingSnap.get("theme")));
+      if (!theme) {
+        throw httpError(400, "invalid_theme", "theme contains an unsupported value.");
+      }
+    }
+
     const payload: Record<string, unknown> = { updatedAt: new Date().toISOString() };
     if (visibility) payload.defaultBatchVisibility = visibility;
     if (interleavedRendering !== null) payload.interleavedRendering = interleavedRendering;
+    if (theme) payload.theme = theme;
     await docRef.set(payload, { merge: true });
 
     const snap = await docRef.get();
     const nextVisibility = normalizeVisibility(snap.get("defaultBatchVisibility"));
     const nextInterleaved = normalizeInterleavedRendering(snap.get("interleavedRendering")) ?? DEFAULT_INTERLEAVED_RENDERING;
+    const nextTheme = readThemeSettings(snap.get("theme"));
     return {
       defaultBatchVisibility: nextVisibility,
       interleavedRendering: nextInterleaved,
+      theme: nextTheme,
     } satisfies UserSettingsResponse;
   });
 };

--- a/functions/test/routes/userSettings.test.ts
+++ b/functions/test/routes/userSettings.test.ts
@@ -13,6 +13,15 @@ const mocks = vi.hoisted(() => ({
 let dbStore = new Map<string, Record<string, unknown>>();
 let nextGetError: Error | null = null;
 
+const defaultTheme = {
+  appearance: "dark",
+  accentColor: "iris",
+  grayColor: "auto",
+  panelBackground: "translucent",
+  radius: "full",
+  scaling: "100%",
+};
+
 function makeDocRef(path: string) {
   return {
     get: vi.fn(async () => {
@@ -94,7 +103,11 @@ describe("user settings routes", () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ defaultBatchVisibility: "private", interleavedRendering: false });
+    expect(res.json()).toEqual({
+      defaultBatchVisibility: "private",
+      interleavedRendering: false,
+      theme: defaultTheme,
+    });
     await app.close();
   });
 
@@ -109,7 +122,65 @@ describe("user settings routes", () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ defaultBatchVisibility: "public", interleavedRendering: true });
+    expect(res.json()).toEqual({
+      defaultBatchVisibility: "public",
+      interleavedRendering: true,
+      theme: defaultTheme,
+    });
+    await app.close();
+  });
+
+  it("PUT /v1/user/settings updates and merges theme preferences", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: "/v1/user/settings",
+      payload: {
+        theme: {
+          appearance: "light",
+          accentColor: "blue",
+          grayColor: "slate",
+          panelBackground: "solid",
+          radius: "medium",
+          scaling: "105%",
+        },
+      },
+      headers: { authorization: "Bearer ok" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      defaultBatchVisibility: "private",
+      interleavedRendering: false,
+      theme: {
+        appearance: "light",
+        accentColor: "blue",
+        grayColor: "slate",
+        panelBackground: "solid",
+        radius: "medium",
+        scaling: "105%",
+      },
+    });
+
+    const partial = await app.inject({
+      method: "PUT",
+      url: "/v1/user/settings",
+      payload: { theme: { accentColor: "teal" } },
+      headers: { authorization: "Bearer ok" },
+    });
+
+    expect(partial.statusCode).toBe(200);
+    expect(partial.json()).toMatchObject({
+      theme: {
+        appearance: "light",
+        accentColor: "teal",
+        grayColor: "slate",
+        panelBackground: "solid",
+        radius: "medium",
+        scaling: "105%",
+      },
+    });
     await app.close();
   });
 
@@ -126,8 +197,8 @@ describe("user settings routes", () => {
     expect(res.statusCode).toBe(400);
     expect(res.json()).toEqual({
       error: "missing_fields",
-      message: "Provide defaultBatchVisibility or interleavedRendering to update.",
-      error_description: "Provide defaultBatchVisibility or interleavedRendering to update.",
+      message: "Provide defaultBatchVisibility, interleavedRendering, or theme to update.",
+      error_description: "Provide defaultBatchVisibility, interleavedRendering, or theme to update.",
     });
     await app.close();
   });
@@ -166,6 +237,25 @@ describe("user settings routes", () => {
       error: "invalid_interleaved",
       message: "interleavedRendering must be boolean.",
       error_description: "interleavedRendering must be boolean.",
+    });
+    await app.close();
+  });
+
+  it("validation: invalid theme returns 400", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: "/v1/user/settings",
+      payload: { theme: { accentColor: "neon" } },
+      headers: { authorization: "Bearer ok" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({
+      error: "invalid_theme",
+      message: "theme contains an unsupported value.",
+      error_description: "theme contains an unsupported value.",
     });
     await app.close();
   });

--- a/shared-types/src/index.ts
+++ b/shared-types/src/index.ts
@@ -164,9 +164,57 @@ export type AdminSubmissionUpdateRequest = {
   reason?: string | null;
 };
 
+export type UserThemeAppearance = "light" | "dark";
+
+export type UserThemeAccentColor =
+  | "gray"
+  | "gold"
+  | "bronze"
+  | "brown"
+  | "yellow"
+  | "amber"
+  | "orange"
+  | "tomato"
+  | "red"
+  | "ruby"
+  | "crimson"
+  | "pink"
+  | "plum"
+  | "purple"
+  | "violet"
+  | "iris"
+  | "indigo"
+  | "blue"
+  | "cyan"
+  | "teal"
+  | "jade"
+  | "green"
+  | "grass"
+  | "lime"
+  | "mint"
+  | "sky";
+
+export type UserThemeGrayColor = "auto" | "gray" | "mauve" | "slate" | "sage" | "olive" | "sand";
+
+export type UserThemePanelBackground = "solid" | "translucent";
+
+export type UserThemeRadius = "none" | "small" | "medium" | "large" | "full";
+
+export type UserThemeScaling = "90%" | "95%" | "100%" | "105%" | "110%";
+
+export type UserThemeSettings = {
+  appearance: UserThemeAppearance;
+  accentColor: UserThemeAccentColor;
+  grayColor: UserThemeGrayColor;
+  panelBackground: UserThemePanelBackground;
+  radius: UserThemeRadius;
+  scaling: UserThemeScaling;
+};
+
 export type UserSettings = {
   defaultBatchVisibility: BatchVisibility;
   interleavedRendering: boolean;
+  theme: UserThemeSettings;
 };
 
 export type SmokeTestRequestBody = {


### PR DESCRIPTION
## Summary
- Add account-backed theme preferences to the user settings API and shared types
- Apply saved theme settings at the app root and expose controls in the user dashboard
- Replace the dev-only Radix ThemePanel shortcut with a persisted Theme dialog opened by T

## Verification
- pnpm --filter @crowdpm/types build
- pnpm --filter crowdpm-functions test -- userSettings
- pnpm --filter crowdpm-frontend build
- pnpm lint
- pnpm --filter crowdpm-functions build
- Browser smoke: T opens the custom Theme dialog and old ThemePanel is absent