### PR TITLE
Make map shell theme-aware

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -347,9 +347,10 @@ export default function App() {
             gap: 10,
             padding: "var(--space-3) var(--space-4)",
             paddingLeft: "calc(var(--space-4) + 2.5px)",
+            color: "var(--gray-12)",
             background: activeTab === "map"
-              ? "linear-gradient(180deg, rgba(0,0,0,0.55) 0%, rgba(0,0,0,0) 100%)"
-              : "rgba(0, 0, 0, 0.75)",
+              ? "linear-gradient(180deg, color-mix(in srgb, var(--color-panel-solid) 82%, transparent) 0%, transparent 100%)"
+              : "color-mix(in srgb, var(--color-panel-solid) 88%, transparent)",
             backdropFilter: activeTab === "map" ? "none" : "blur(12px)",
             WebkitBackdropFilter: activeTab === "map" ? "none" : "blur(12px)",
             pointerEvents: "auto",
@@ -375,7 +376,7 @@ export default function App() {
               <circle cx="14" cy="14" r="13" stroke="var(--accent-9)" strokeWidth="1.5" fill="none" opacity="0.7" />
               <path
                 d="M8 17a3.5 3.5 0 0 1 .5-6.95A5 5 0 0 1 18 10a4 4 0 0 1 2 7.5"
-                stroke="white"
+                stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"
                 fill="none"
@@ -388,9 +389,9 @@ export default function App() {
               style={{
                 fontSize: "var(--font-size-4)",
                 fontWeight: 700,
-                color: "white",
-                letterSpacing: "-0.02em",
-                textShadow: "0 1px 4px rgba(0,0,0,0.5)",
+                color: "var(--gray-12)",
+                letterSpacing: 0,
+                textShadow: "0 1px 4px var(--gray-a6)",
               }}
             >
               CrowdPM
@@ -398,9 +399,9 @@ export default function App() {
             <span
               style={{
                 fontSize: "var(--font-size-1)",
-                color: "rgba(255,255,255,0.6)",
+                color: "var(--gray-11)",
                 fontWeight: 400,
-                letterSpacing: "0.04em",
+                letterSpacing: 0,
                 textTransform: "uppercase",
               }}
             >
@@ -420,10 +421,10 @@ export default function App() {
               aria-label="Navigation menu"
               style={{
                 backdropFilter: "blur(12px)",
-                backgroundColor: "rgba(0, 0, 0, 0.75)",
-                color: "white",
-                boxShadow: "0 2px 12px rgba(0,0,0,0.4)",
-                border: "1px solid rgba(255,255,255,0.12)",
+                backgroundColor: "color-mix(in srgb, var(--color-panel-solid) 88%, transparent)",
+                color: "var(--gray-12)",
+                boxShadow: "var(--shadow-4)",
+                border: "1px solid var(--gray-a6)",
               }}
             >
               <HamburgerMenuIcon width={18} height={18} />

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -42,6 +42,9 @@ const VIDEO_EXPORT_MIN_POINT_MS = 160;
 const VIDEO_EXPORT_FINAL_POINT_MS = 320;
 const MIN_PERSISTED_MAP_ZOOM = 0;
 const MAX_PERSISTED_MAP_ZOOM = 22;
+const MAP_PANEL_BACKGROUND = "color-mix(in srgb, var(--color-panel-solid) 88%, transparent)";
+const MAP_PANEL_BORDER = "1px solid var(--gray-a6)";
+const MAP_PANEL_BLUR = "blur(12px)";
 
 // React Query cache keys. Keeping them as helpers avoids typos across the file.
 const BATCHES_QUERY_KEY = (uid: string | null | undefined) => ["batches", uid ?? "guest"] as const;
@@ -1086,9 +1089,10 @@ export default function MapPage({
           <div
             style={{
               pointerEvents: "auto",
-              background: "rgba(0, 0, 0, 0.7)",
+              background: MAP_PANEL_BACKGROUND,
               backdropFilter: "blur(16px)",
               WebkitBackdropFilter: "blur(16px)",
+              border: MAP_PANEL_BORDER,
               borderRadius: "var(--radius-4)",
               padding: "var(--space-6)",
               maxWidth: 460,
@@ -1102,7 +1106,7 @@ export default function MapPage({
               <circle cx="14" cy="14" r="13" stroke="var(--accent-9)" strokeWidth="1.5" fill="none" opacity="0.7" />
               <path
                 d="M8 17a3.5 3.5 0 0 1 .5-6.95A5 5 0 0 1 18 10a4 4 0 0 1 2 7.5"
-                stroke="white"
+                stroke="currentColor"
                 strokeWidth="1.5"
                 strokeLinecap="round"
                 fill="none"
@@ -1126,7 +1130,7 @@ export default function MapPage({
                   borderRadius: "var(--radius-3)",
                   border: "none",
                   background: "var(--accent-9)",
-                  color: "white",
+                  color: "var(--accent-contrast)",
                   fontWeight: 600,
                   fontSize: "var(--font-size-2)",
                   cursor: "pointer",
@@ -1191,9 +1195,10 @@ export default function MapPage({
           style={{
             padding: "var(--space-4)",
             borderRadius: "var(--radius-3)",
-            background: "rgba(0, 0, 0, 0.7)",
-            backdropFilter: "blur(12px)",
-            WebkitBackdropFilter: "blur(12px)",
+            background: MAP_PANEL_BACKGROUND,
+            backdropFilter: MAP_PANEL_BLUR,
+            WebkitBackdropFilter: MAP_PANEL_BLUR,
+            border: MAP_PANEL_BORDER,
             boxShadow: "var(--shadow-3)",
           }}
         >
@@ -1276,9 +1281,10 @@ export default function MapPage({
             style={{
               padding: "var(--space-4)",
               borderRadius: "var(--radius-3)",
-              background: "rgba(0, 0, 0, 0.7)",
-              backdropFilter: "blur(12px)",
-              WebkitBackdropFilter: "blur(12px)",
+              background: MAP_PANEL_BACKGROUND,
+              backdropFilter: MAP_PANEL_BLUR,
+              WebkitBackdropFilter: MAP_PANEL_BLUR,
+              border: MAP_PANEL_BORDER,
               boxShadow: "var(--shadow-3)",
               color: "var(--gray-12)",
             }}
@@ -1329,7 +1335,7 @@ export default function MapPage({
                       padding: "var(--space-1) var(--space-3)",
                       borderRadius: "var(--radius-2)",
                       background: "var(--accent-9)",
-                      color: "white",
+                      color: "var(--accent-contrast)",
                       fontWeight: 600,
                       fontSize: "var(--font-size-1)",
                       textDecoration: "none",
@@ -1369,7 +1375,7 @@ export default function MapPage({
                     borderRadius: "var(--radius-2)",
                     border: "none",
                     background: canStartExport ? "var(--accent-9)" : "var(--gray-a5)",
-                    color: canStartExport ? "white" : "var(--gray-11)",
+                    color: canStartExport ? "var(--accent-contrast)" : "var(--gray-11)",
                     fontWeight: 600,
                     fontSize: "var(--font-size-1)",
                     cursor: canStartExport ? "pointer" : "not-allowed",
@@ -1393,9 +1399,10 @@ export default function MapPage({
             style={{
               padding: "var(--space-3)",
               borderRadius: "var(--radius-3)",
-              background: "rgba(0, 0, 0, 0.7)",
-              backdropFilter: "blur(12px)",
-              WebkitBackdropFilter: "blur(12px)",
+              background: MAP_PANEL_BACKGROUND,
+              backdropFilter: MAP_PANEL_BLUR,
+              WebkitBackdropFilter: MAP_PANEL_BLUR,
+              border: MAP_PANEL_BORDER,
               boxShadow: "var(--shadow-3)",
               color: "var(--gray-12)",
             }}
@@ -1467,9 +1474,10 @@ export default function MapPage({
             style={{
               padding: "var(--space-3)",
               borderRadius: "var(--radius-3)",
-              background: "rgba(0, 0, 0, 0.7)",
-              backdropFilter: "blur(12px)",
-              WebkitBackdropFilter: "blur(12px)",
+              background: MAP_PANEL_BACKGROUND,
+              backdropFilter: MAP_PANEL_BLUR,
+              WebkitBackdropFilter: MAP_PANEL_BLUR,
+              border: MAP_PANEL_BORDER,
               color: "var(--gray-11)",
               fontSize: "var(--font-size-2)",
             }}
@@ -1492,9 +1500,10 @@ export default function MapPage({
           gap: "var(--space-3)",
           padding: "var(--space-2) var(--space-4)",
           borderRadius: "var(--radius-3)",
-          background: "rgba(0, 0, 0, 0.6)",
+          background: MAP_PANEL_BACKGROUND,
           backdropFilter: "blur(8px)",
           WebkitBackdropFilter: "blur(8px)",
+          border: MAP_PANEL_BORDER,
           color: "var(--gray-11)",
           fontSize: "var(--font-size-1)",
         }}


### PR DESCRIPTION
## Summary
- Replace hardcoded dark map/index shell backgrounds with theme-aware panel tokens
- Update the fixed header, hamburger button, welcome card, floating controls, and stats strip for light theme
- Use Radix contrast tokens for accent buttons

## Verification
- pnpm --filter crowdpm-frontend build
- pnpm lint