### PR TITLE
Remove legacy device ownership and error compatibility paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,11 @@ Set a Firebase ID token in the `Authorization: Bearer <token>` header for authen
   - `pnpm --filter crowdpm-functions admin:grant-role -- --email you@example.com --roles super_admin`
 - Backfill legacy batch documents with moderation metadata:
   - `pnpm --filter crowdpm-functions backfill:batch-moderation`
+- Backfill legacy single-owner device records into `ownerUserIds` and remove `ownerUserId`:
+  - `pnpm --filter crowdpm-functions backfill:device-ownership`
 
 ### Error Responses
 - API and gateway failures return normalized JSON with required `error` (lower_snake_case) and optional `message`.
-- `error_description` is emitted as a temporary compatibility alias for `message` and is deprecated.
 - Some endpoints include metadata fields such as `details`, `poll_interval`, `retry_after`, and `forbiddenDeviceIds`.
 
 ## Data Model & Storage

--- a/docs/hardware-builder.md
+++ b/docs/hardware-builder.md
@@ -201,8 +201,7 @@ Guidelines:
 | `/ingestGateway` | payload device mismatch | `400 device_id mismatch` |
 | `/ingestGateway` | bad DPoP/access token | `401/403` JSON error payload |
 
-All errors now return JSON with a required `error` code and optional `message`.
-The `error_description` field is a deprecated compatibility alias for `message`.
+All errors return JSON with a required `error` code and optional `message`.
 Back off and restart the pairing flow when you see persistent `expired_token` or `rate_limited` responses.
 
 ---

--- a/examples/esp32/CrowdPMNodeESP32/CrowdPMNodeClient.cpp
+++ b/examples/esp32/CrowdPMNodeESP32/CrowdPMNodeClient.cpp
@@ -904,8 +904,6 @@ void NodeClient::extractErrorDetails(const String& body, String& errorCode, Stri
   }
   if (document["message"].is<const char*>()) {
     message = String(document["message"].as<const char*>());
-  } else if (document["error_description"].is<const char*>()) {
-    message = String(document["error_description"].as<const char*>());
   }
   if (document["poll_interval"].is<int>()) {
     pollIntervalSeconds = document["poll_interval"].as<int>();

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,13 +9,8 @@ service cloud.firestore {
       return authedUid() != null &&
         device != null &&
         device.data != null &&
-        (
-          device.data.ownerUserId == authedUid() ||
-          (
-            device.data.ownerUserIds != null &&
-            device.data.ownerUserIds.hasAny([authedUid()])
-          )
-        );
+        device.data.ownerUserIds != null &&
+        device.data.ownerUserIds.hasAny([authedUid()]);
     }
 
     function canReadDevice(deviceId) {

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,8 @@
     "emulate": "firebase emulators:start --project local",
     "test": "vitest",
     "admin:grant-role": "node ./scripts/grant-role.mjs",
-    "backfill:batch-moderation": "node ./scripts/backfill-batch-moderation.mjs"
+    "backfill:batch-moderation": "node ./scripts/backfill-batch-moderation.mjs",
+    "backfill:device-ownership": "node ./scripts/backfill-device-ownership.mjs"
   },
   "engines": {
     "node": ">=22.0.0 <25.0.0"

--- a/functions/scripts/backfill-device-ownership.mjs
+++ b/functions/scripts/backfill-device-ownership.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import admin from "firebase-admin";
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+const db = admin.firestore();
+const parsedPageSize = Number.parseInt(process.env.PAGE_SIZE ?? "300", 10);
+const PAGE_SIZE = Number.isFinite(parsedPageSize) && parsedPageSize > 0 ? parsedPageSize : 300;
+
+function hasFlag(name) {
+  return process.argv.slice(2).includes(`--${name}`);
+}
+
+function toOwnerId(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeOwnerIds(data) {
+  const ids = new Set();
+  if (Array.isArray(data.ownerUserIds)) {
+    for (const value of data.ownerUserIds) {
+      const ownerId = toOwnerId(value);
+      if (ownerId) ids.add(ownerId);
+    }
+  }
+  const legacyOwnerId = toOwnerId(data.ownerUserId);
+  if (legacyOwnerId) ids.add(legacyOwnerId);
+  return Array.from(ids);
+}
+
+function arraysEqual(left, right) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function buildUpdates(data) {
+  const updates = {};
+  const ownerIds = normalizeOwnerIds(data);
+  const currentOwnerIds = Array.isArray(data.ownerUserIds)
+    ? data.ownerUserIds.filter((value) => typeof value === "string" && value.trim().length > 0)
+    : [];
+
+  if (ownerIds.length && !arraysEqual(ownerIds, currentOwnerIds)) {
+    updates.ownerUserIds = ownerIds;
+  }
+
+  const primaryOwnerId = ownerIds[0] ?? null;
+  if (primaryOwnerId && typeof data.accId !== "string") {
+    updates.accId = primaryOwnerId;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(data, "ownerUserId")) {
+    updates.ownerUserId = admin.firestore.FieldValue.delete();
+  }
+
+  return updates;
+}
+
+async function run() {
+  const dryRun = hasFlag("dry-run");
+  let processed = 0;
+  let updated = 0;
+  let lastDoc = null;
+
+  while (true) {
+    let query = db.collection("devices")
+      .orderBy(admin.firestore.FieldPath.documentId())
+      .limit(PAGE_SIZE);
+
+    if (lastDoc) {
+      query = query.startAfter(lastDoc);
+    }
+
+    const snap = await query.get();
+    if (snap.empty) {
+      break;
+    }
+
+    const batch = db.batch();
+    let pageWrites = 0;
+
+    for (const doc of snap.docs) {
+      const updates = buildUpdates(doc.data() ?? {});
+      if (!Object.keys(updates).length) continue;
+      if (!dryRun) {
+        batch.set(doc.ref, updates, { merge: true });
+      }
+      pageWrites += 1;
+    }
+
+    if (pageWrites && !dryRun) {
+      await batch.commit();
+    }
+
+    processed += snap.size;
+    updated += pageWrites;
+    lastDoc = snap.docs[snap.docs.length - 1];
+    console.log(`[backfill-device-ownership] processed=${processed} ${dryRun ? "wouldUpdate" : "updated"}=${updated}`);
+  }
+
+  console.log(`[backfill-device-ownership] complete processed=${processed} ${dryRun ? "wouldUpdate" : "updated"}=${updated}`);
+}
+
+run().catch((err) => {
+  console.error("[backfill-device-ownership] failed", err);
+  process.exitCode = 1;
+});

--- a/functions/src/lib/deviceOwnership.ts
+++ b/functions/src/lib/deviceOwnership.ts
@@ -2,7 +2,6 @@ import type { firestore } from "firebase-admin";
 import { db } from "./fire.js";
 
 export type DeviceOwnershipFields = {
-  ownerUserId?: unknown;
   ownerUserIds?: unknown;
 };
 
@@ -17,8 +16,6 @@ function toOwnerId(value: unknown): string | null {
 export function normalizeOwnerIds(data: DeviceOwnershipFields | undefined): string[] {
   if (!data) return [];
   const ids = new Set<string>();
-  const primary = toOwnerId(data.ownerUserId);
-  if (primary) ids.add(primary);
   if (Array.isArray(data.ownerUserIds)) {
     for (const candidate of data.ownerUserIds) {
       const ownerId = toOwnerId(candidate);
@@ -38,18 +35,11 @@ export async function loadOwnedDeviceDocs(userId: string): Promise<{
   docs: Map<string, firestore.DocumentData>;
 }> {
   const collection = db().collection("devices");
-  const [multiOwnerSnap, legacySnap] = await Promise.all([
-    collection.where("ownerUserIds", "array-contains", userId).get(),
-    collection.where("ownerUserId", "==", userId).get(),
-  ]);
+  const ownedDevicesSnap = await collection.where("ownerUserIds", "array-contains", userId).get();
 
   const docs = new Map<string, firestore.DocumentData>();
-  [multiOwnerSnap, legacySnap].forEach((snap) => {
-    snap.forEach((doc) => {
-      if (!docs.has(doc.id)) {
-        docs.set(doc.id, doc.data());
-      }
-    });
+  ownedDevicesSnap.forEach((doc) => {
+    docs.set(doc.id, doc.data());
   });
 
   return { collection, docs };

--- a/functions/src/lib/httpError.ts
+++ b/functions/src/lib/httpError.ts
@@ -9,7 +9,7 @@ export type NormalizedHttpError = {
 
 type HttpErrorMeta = Record<string, unknown>;
 
-const RESERVED_BODY_KEYS = new Set(["error", "message", "error_description"]);
+const RESERVED_BODY_KEYS = new Set(["error", "message"]);
 
 const DEFAULT_ERROR_BY_STATUS: Record<number, string> = {
   400: "bad_request",
@@ -119,10 +119,9 @@ function metaFrom(err: unknown): HttpErrorMeta | undefined {
   return cleanMeta((err as { meta?: unknown }).meta);
 }
 
-function withMessageAliases(body: Record<string, unknown>, message: string | undefined): void {
+function withMessage(body: Record<string, unknown>, message: string | undefined): void {
   if (!message || message.trim().length === 0) return;
   body.message = message;
-  body.error_description = message;
 }
 
 function mergeMeta(body: Record<string, unknown>, meta: HttpErrorMeta | undefined): void {
@@ -147,7 +146,7 @@ export function toHttpError(err: unknown, fallbackStatusCode = 500): NormalizedH
   const error = errorCodeFrom(err, statusCode);
   const message = messageFrom(err);
   const body: Record<string, unknown> = { error };
-  withMessageAliases(body, message);
+  withMessage(body, message);
   mergeMeta(body, metaFrom(err));
   const headers = headersFrom(err);
   return { statusCode, body, headers };

--- a/functions/src/openapi.yaml
+++ b/functions/src/openapi.yaml
@@ -5,8 +5,7 @@ info:
   description: >
     API used by CrowdPM to manage devices and retrieve pollution measurements.
     Error responses use a normalized JSON format with a required `error` field and
-    optional `message`. The `error_description` alias is still emitted for compatibility
-    and is deprecated.
+    optional `message`.
   license:
     name: Proprietary
     url: https://crowdpmplatform.web.app
@@ -785,10 +784,6 @@ components:
         message:
           type: string
           description: Human-readable error detail.
-        error_description:
-          type: string
-          deprecated: true
-          description: Deprecated alias for `message`.
       additionalProperties: true
     DeviceStatus:
       type: string
@@ -805,9 +800,6 @@ components:
         name:
           type: string
           description: Friendly name supplied by the owner.
-        ownerUserId:
-          type: string
-          description: Primary Firebase UID associated with the device. Legacy field retained for backwards compatibility.
         ownerUserIds:
           type: array
           description: All Firebase UIDs that can access the device.
@@ -831,7 +823,7 @@ components:
       required:
         - id
         - name
-        - ownerUserId
+        - ownerUserIds
         - status
         - createdAt
     ActivationSession:

--- a/functions/src/routes/adminUsers.ts
+++ b/functions/src/routes/adminUsers.ts
@@ -61,15 +61,10 @@ function toSummary(record: FirebaseAuth.UserRecord): AdminUserSummary {
 async function revokeOwnedDeviceTokens(uid: string): Promise<string[]> {
   if (!uid) return [];
   const devices = db().collection("devices");
-  const [multiOwnerSnap, legacySnap] = await Promise.all([
-    devices.where("ownerUserIds", "array-contains", uid).get(),
-    devices.where("ownerUserId", "==", uid).get(),
-  ]);
+  const ownedDevicesSnap = await devices.where("ownerUserIds", "array-contains", uid).get();
 
   const ids = new Set<string>();
-  [multiOwnerSnap, legacySnap].forEach((snap) => {
-    snap.docs.forEach((doc) => ids.add(doc.id));
-  });
+  ownedDevicesSnap.docs.forEach((doc) => ids.add(doc.id));
 
   await Promise.all(Array.from(ids).map((deviceId) => revokeTokensForDevice(deviceId)));
   return Array.from(ids);

--- a/functions/src/services/deviceRegistry.ts
+++ b/functions/src/services/deviceRegistry.ts
@@ -9,7 +9,6 @@ type DocumentData = firestore.DocumentData;
 export type DeviceRecord = {
   id: string;
   accId: string;
-  ownerUserId: string;
   ownerUserIds: string[];
   model: string;
   version: string;
@@ -24,12 +23,11 @@ export type DeviceRecord = {
 
 function normalizeDevice(id: string, data: DocumentData | undefined): DeviceRecord | null {
   if (!data) return null;
-  const accId = typeof data.accId === "string" ? data.accId : (typeof data.ownerUserId === "string" ? data.ownerUserId : null);
+  const accId = typeof data.accId === "string" ? data.accId : null;
   if (!accId) return null;
-  const ownerUserId = typeof data.ownerUserId === "string" ? data.ownerUserId : accId;
   const ownerUserIds = Array.isArray(data.ownerUserIds)
     ? data.ownerUserIds.filter((uid): uid is string => typeof uid === "string" && uid.length > 0)
-    : [ownerUserId];
+    : [accId];
   const lowerRegistryStatus = typeof data.registryStatus === "string" ? data.registryStatus.toLowerCase() : null;
   const allowedStatuses = ["active", "revoked", "suspended"] as const;
   const normalizedStatus = (lowerRegistryStatus && allowedStatuses.includes(lowerRegistryStatus as typeof allowedStatuses[number]))
@@ -38,7 +36,6 @@ function normalizeDevice(id: string, data: DocumentData | undefined): DeviceReco
   return {
     id,
     accId,
-    ownerUserId,
     ownerUserIds,
     model: typeof data.model === "string" ? data.model : "unknown",
     version: typeof data.version === "string" ? data.version : "unknown",
@@ -69,7 +66,6 @@ export async function registerDevice(args: {
   const ownerIds = [args.accountId];
   await db().collection("devices").doc(deviceId).set({
     accId: args.accountId,
-    ownerUserId: args.accountId,
     ownerUserIds: ownerIds,
     model: args.model,
     version: args.version,

--- a/functions/src/services/devicesService.ts
+++ b/functions/src/services/devicesService.ts
@@ -48,7 +48,6 @@ export class DevicesService {
     const createdAt = this.deps.now().toISOString();
     await ref.set({
       name: params.name,
-      ownerUserId: userId,
       ownerUserIds: [userId],
       status: "ACTIVE",
       createdAt,
@@ -82,6 +81,7 @@ export class DevicesService {
       : null;
 
     const extras = data && typeof data === "object" ? { ...data } : {};
+    delete extras.ownerUserId;
 
     return {
       ...extras,
@@ -89,7 +89,6 @@ export class DevicesService {
       name: typeof data?.name === "string" ? data.name : null,
       status: typeof data?.status === "string" ? data.status : null,
       registryStatus: typeof data?.registryStatus === "string" ? data.registryStatus : null,
-      ownerUserId: typeof data?.ownerUserId === "string" ? data.ownerUserId : null,
       ownerUserIds,
       publicDeviceId: typeof data?.publicDeviceId === "string" ? data.publicDeviceId : null,
       ownerScope: typeof data?.ownerScope === "string" ? data.ownerScope : null,

--- a/functions/src/services/ingestSmokeTestService.ts
+++ b/functions/src/services/ingestSmokeTestService.ts
@@ -179,10 +179,8 @@ export class IngestSmokeTestService {
         publicDeviceId,
         ownerScope: ownerSegment,
       };
-      if (primaryOwnerId) {
-        payload.ownerUserId = primaryOwnerId;
-      }
       if (ownerIds.length) {
+        payload.accId = primaryOwnerId;
         payload.ownerUserIds = this.deps.arrayUnion(...ownerIds);
       }
       await this.deps.db.collection("devices").doc(deviceId).set(payload, { merge: true });

--- a/functions/test/lib/httpError.test.ts
+++ b/functions/test/lib/httpError.test.ts
@@ -9,7 +9,6 @@ describe("toHttpError", () => {
     expect(normalized.body).toMatchObject({
       error: "invalid_payload",
       message: "Payload failed",
-      error_description: "Payload failed",
     });
   });
 
@@ -23,14 +22,13 @@ describe("toHttpError", () => {
     expect(normalized.body).toMatchObject({
       error: "invalid_request",
       message: "Validation failed",
-      error_description: "Validation failed",
       details: { fieldErrors: { user_code: ["Required"] } },
       poll_interval: 10,
     });
     expect(normalized.body).not.toHaveProperty("ignored");
   });
 
-  it("emits aliases when message is present and omits them when absent", () => {
+  it("emits message when present and omits it when absent", () => {
     const withoutMessage = toHttpError(httpError(400, "invalid_request"));
     expect(withoutMessage.body).toEqual({ error: "invalid_request" });
 
@@ -38,7 +36,6 @@ describe("toHttpError", () => {
     expect(withMessage.body).toEqual({
       error: "invalid_request",
       message: "invalid request",
-      error_description: "invalid request",
     });
   });
 
@@ -58,7 +55,6 @@ describe("toHttpError", () => {
     expect(normalized.body).toMatchObject({
       error: "bad_request",
       message: "boom",
-      error_description: "boom",
     });
   });
 

--- a/functions/test/routes/activation.test.ts
+++ b/functions/test/routes/activation.test.ts
@@ -121,7 +121,6 @@ describe("GET /v1/device-activation", () => {
     expect(res.json()).toEqual({
       error: "unauthorized",
       message: "unauthorized",
-      error_description: "unauthorized",
     });
     expect(mocks.findSessionByUserCode).not.toHaveBeenCalled();
     await app.close();
@@ -156,7 +155,6 @@ describe("GET /v1/device-activation", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Pairing code not found",
-      error_description: "Pairing code not found",
     });
     await app.close();
   });
@@ -193,7 +191,6 @@ describe("GET /v1/device-activation", () => {
     expect(res.json()).toEqual({
       error: "unavailable",
       message: "upstream down",
-      error_description: "upstream down",
     });
     await app.close();
   });
@@ -256,7 +253,6 @@ describe("POST /v1/device-activation/authorize", () => {
     expect(res.json()).toEqual({
       error: "unauthorized",
       message: "unauthorized",
-      error_description: "unauthorized",
     });
     await app.close();
   });
@@ -275,7 +271,6 @@ describe("POST /v1/device-activation/authorize", () => {
     expect(res.json()).toEqual({
       error: "unauthorized",
       message: "second_factor_required",
-      error_description: "second_factor_required",
     });
     await app.close();
   });
@@ -311,7 +306,6 @@ describe("POST /v1/device-activation/authorize", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Pairing code not found",
-      error_description: "Pairing code not found",
     });
     await app.close();
   });
@@ -333,7 +327,6 @@ describe("POST /v1/device-activation/authorize", () => {
     expect(res.json()).toEqual({
       error: "gone",
       message: "Pairing code expired",
-      error_description: "Pairing code expired",
     });
     await app.close();
   });

--- a/functions/test/routes/admin.test.ts
+++ b/functions/test/routes/admin.test.ts
@@ -158,7 +158,6 @@ describe("POST /v1/admin/devices/:id/suspend", () => {
     expect(res.json()).toEqual({
       error: "unauthorized",
       message: "unauthorized",
-      error_description: "unauthorized",
     });
     await app.close();
   });
@@ -176,7 +175,6 @@ describe("POST /v1/admin/devices/:id/suspend", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "You do not have permission to access this resource.",
-      error_description: "You do not have permission to access this resource.",
     });
     await app.close();
   });
@@ -214,7 +212,6 @@ describe("POST /v1/admin/ingest-smoke-test", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "Caller lacks permission to run smoke tests",
-      error_description: "Caller lacks permission to run smoke tests",
     });
     await app.close();
   });
@@ -234,7 +231,6 @@ describe("POST /v1/admin/ingest-smoke-test", () => {
     expect(res.json()).toEqual({
       error: "invalid_payload",
       message: "invalid payload",
-      error_description: "invalid payload",
     });
     await app.close();
   });
@@ -243,7 +239,7 @@ describe("POST /v1/admin/ingest-smoke-test", () => {
 describe("POST /v1/admin/ingest-smoke-test/cleanup", () => {
   it("happy path clears device data", async () => {
     const app = await buildApp();
-    deviceDocs.set("device-1", { exists: true, data: { ownerUserId: "user-123" } });
+    deviceDocs.set("device-1", { exists: true, data: { ownerUserIds: ["user-123"] } });
 
     const res = await app.inject({
       method: "POST",
@@ -266,7 +262,7 @@ describe("POST /v1/admin/ingest-smoke-test/cleanup", () => {
 
   it("auth: forbidden device returns 403 with list", async () => {
     const app = await buildApp();
-    deviceDocs.set("device-1", { exists: true, data: { ownerUserId: "other-user" } });
+    deviceDocs.set("device-1", { exists: true, data: { ownerUserIds: ["other-user"] } });
     mocks.userOwnsDevice.mockReturnValue(false);
 
     const res = await app.inject({
@@ -280,7 +276,6 @@ describe("POST /v1/admin/ingest-smoke-test/cleanup", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "You do not have permission to delete one or more devices.",
-      error_description: "You do not have permission to delete one or more devices.",
       forbiddenDeviceIds: ["device-1"],
     });
     await app.close();
@@ -288,7 +283,7 @@ describe("POST /v1/admin/ingest-smoke-test/cleanup", () => {
 
   it("partial failures return 207 with failedDeletions", async () => {
     const app = await buildApp();
-    deviceDocs.set("device-1", { exists: true, data: { ownerUserId: "user-123" } });
+    deviceDocs.set("device-1", { exists: true, data: { ownerUserIds: ["user-123"] } });
     mocks.recursiveDelete.mockRejectedValue(new Error("firestore failed"));
 
     const res = await app.inject({

--- a/functions/test/routes/adminSubmissions.test.ts
+++ b/functions/test/routes/adminSubmissions.test.ts
@@ -199,7 +199,6 @@ describe("GET /v1/admin/submissions", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "You do not have permission to access this resource.",
-      error_description: "You do not have permission to access this resource.",
     });
     await app.close();
   });
@@ -246,7 +245,6 @@ describe("PATCH /v1/admin/submissions/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Batch not found.",
-      error_description: "Batch not found.",
     });
     await app.close();
   });

--- a/functions/test/routes/adminUsers.test.ts
+++ b/functions/test/routes/adminUsers.test.ts
@@ -62,14 +62,11 @@ const mockDb = {
     return {
       where: (field: string, op: string, value: string) => ({
         get: async () => {
-          if (op !== "==" && op !== "array-contains") {
+          if (op !== "array-contains") {
             throw new Error("unsupported query");
           }
           const matchingIds = Array.from(deviceOwnership.entries())
             .filter(([, owners]) => {
-              if (field === "ownerUserId" && op === "==") {
-                return owners[0] === value;
-              }
               if (field === "ownerUserIds" && op === "array-contains") {
                 return owners.includes(value);
               }
@@ -245,7 +242,6 @@ describe("PATCH /v1/admin/users/:uid", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "You do not have permission to access this resource.",
-      error_description: "You do not have permission to access this resource.",
     });
     await app.close();
   });

--- a/functions/test/routes/batches.test.ts
+++ b/functions/test/routes/batches.test.ts
@@ -331,7 +331,6 @@ describe("GET /v1/batches", () => {
     expect(res.json()).toEqual({
       error: "unauthorized",
       message: "unauthorized",
-      error_description: "unauthorized",
     });
     await app.close();
   });
@@ -350,7 +349,6 @@ describe("GET /v1/batches", () => {
     expect(res.json()).toEqual({
       error: "db_down",
       message: "db_down",
-      error_description: "db_down",
     });
     await app.close();
   });
@@ -428,7 +426,6 @@ describe("GET /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Batch not found.",
-      error_description: "Batch not found.",
     });
     await app.close();
   });
@@ -490,7 +487,6 @@ describe("GET /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Device not found",
-      error_description: "Device not found",
     });
     await app.close();
   });
@@ -509,7 +505,6 @@ describe("GET /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Batch not found.",
-      error_description: "Batch not found.",
     });
     await app.close();
   });
@@ -528,7 +523,6 @@ describe("GET /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Batch payload unavailable.",
-      error_description: "Batch payload unavailable.",
     });
     await app.close();
   });
@@ -548,7 +542,6 @@ describe("GET /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "You do not have access to this device.",
-      error_description: "You do not have access to this device.",
     });
     await app.close();
   });
@@ -572,7 +565,6 @@ describe("GET /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "storage_error",
       message: "Unable to read batch payload.",
-      error_description: "Unable to read batch payload.",
     });
     await app.close();
   });
@@ -663,7 +655,6 @@ describe("PATCH /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "invalid_visibility",
       message: "visibility must be 'public' or 'private'.",
-      error_description: "visibility must be 'public' or 'private'.",
     });
     await app.close();
   });
@@ -687,7 +678,6 @@ describe("PATCH /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Batch not found.",
-      error_description: "Batch not found.",
     });
     await app.close();
   });
@@ -796,7 +786,6 @@ describe("DELETE /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Batch not found.",
-      error_description: "Batch not found.",
     });
     await app.close();
   });
@@ -828,7 +817,6 @@ describe("DELETE /v1/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "storage_error",
       message: "Unable to delete batch payload.",
-      error_description: "Unable to delete batch payload.",
     });
     await app.close();
   });

--- a/functions/test/routes/devices.test.ts
+++ b/functions/test/routes/devices.test.ts
@@ -142,7 +142,6 @@ describe("devices routes", () => {
     expect(res.json()).toEqual({
       error: "unauthorized",
       message: "unauthorized",
-      error_description: "unauthorized",
     });
     await app.close();
   });
@@ -161,7 +160,6 @@ describe("devices routes", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "device missing",
-      error_description: "device missing",
     });
     await app.close();
   });

--- a/functions/test/routes/measurements.test.ts
+++ b/functions/test/routes/measurements.test.ts
@@ -107,7 +107,6 @@ describe("GET /v1/measurements", () => {
     expect(res.json()).toEqual({
       error: "unauthorized",
       message: "unauthorized",
-      error_description: "unauthorized",
     });
     expect(mocks.fetchRange).not.toHaveBeenCalled();
     await app.close();
@@ -126,7 +125,6 @@ describe("GET /v1/measurements", () => {
     expect(res.json()).toEqual({
       error: "unauthorized",
       message: "unauthorized",
-      error_description: "unauthorized",
     });
     expect(mocks.fetchRange).not.toHaveBeenCalled();
     await app.close();
@@ -161,7 +159,6 @@ describe("GET /v1/measurements", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "You do not have access to this device.",
-      error_description: "You do not have access to this device.",
     });
     await app.close();
   });
@@ -250,7 +247,6 @@ describe("GET /v1/measurements", () => {
     expect(res.json()).toEqual({
       error: "invalid_query",
       message: "bad query",
-      error_description: "bad query",
     });
     await app.close();
   });

--- a/functions/test/routes/pairing.test.ts
+++ b/functions/test/routes/pairing.test.ts
@@ -332,7 +332,6 @@ describe("POST /device/token", () => {
     expect(res.json()).toEqual({
       error: "invalid_dpop",
       message: "invalid_dpop",
-      error_description: "invalid_dpop",
     });
     await app.close();
   });
@@ -392,7 +391,6 @@ describe("POST /device/register", () => {
     expect(res.json()).toEqual({
       error: "invalid_request",
       message: "missing registration token",
-      error_description: "missing registration token",
     });
     await app.close();
   });
@@ -414,7 +412,6 @@ describe("POST /device/register", () => {
     expect(res.json()).toEqual({
       error: "invalid_token",
       message: "bad token",
-      error_description: "bad token",
     });
     await app.close();
   });
@@ -446,7 +443,6 @@ describe("POST /device/register", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "session not authorized for account",
-      error_description: "session not authorized for account",
     });
     await app.close();
   });
@@ -478,7 +474,6 @@ describe("POST /device/register", () => {
     expect(res.json()).toEqual({
       error: "unsupported_grant_type",
       message: "CSR enrollment is not yet supported",
-      error_description: "CSR enrollment is not yet supported",
     });
     await app.close();
   });
@@ -510,7 +505,6 @@ describe("POST /device/register", () => {
     expect(res.json()).toEqual({
       error: "invalid_request",
       message: "jwk_pub_kl is required",
-      error_description: "jwk_pub_kl is required",
     });
     await app.close();
   });
@@ -581,7 +575,6 @@ describe("POST /device/access-token", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "device not active",
-      error_description: "device not active",
     });
     await app.close();
   });
@@ -608,7 +601,6 @@ describe("POST /device/access-token", () => {
     expect(res.json()).toEqual({
       error: "forbidden",
       message: "device account disabled",
-      error_description: "device account disabled",
     });
     await app.close();
   });
@@ -635,7 +627,6 @@ describe("POST /device/access-token", () => {
     expect(res.json()).toEqual({
       error: "invalid_dpop",
       message: "invalid_dpop",
-      error_description: "invalid_dpop",
     });
     await app.close();
   });
@@ -662,7 +653,6 @@ describe("POST /device/access-token", () => {
     expect(res.json()).toEqual({
       error: "token_error",
       message: "token error",
-      error_description: "token error",
     });
     await app.close();
   });

--- a/functions/test/routes/publicBatches.test.ts
+++ b/functions/test/routes/publicBatches.test.ts
@@ -224,7 +224,6 @@ describe("GET /v1/public/batches/:deviceId/:batchId", () => {
     expect(res.json()).toEqual({
       error: "not_found",
       message: "Batch not found.",
-      error_description: "Batch not found.",
     });
     await app.close();
   });

--- a/functions/test/routes/userSettings.test.ts
+++ b/functions/test/routes/userSettings.test.ts
@@ -198,7 +198,6 @@ describe("user settings routes", () => {
     expect(res.json()).toEqual({
       error: "missing_fields",
       message: "Provide defaultBatchVisibility, interleavedRendering, or theme to update.",
-      error_description: "Provide defaultBatchVisibility, interleavedRendering, or theme to update.",
     });
     await app.close();
   });
@@ -217,7 +216,6 @@ describe("user settings routes", () => {
     expect(res.json()).toEqual({
       error: "invalid_visibility",
       message: "defaultBatchVisibility must be 'public' or 'private'.",
-      error_description: "defaultBatchVisibility must be 'public' or 'private'.",
     });
     await app.close();
   });
@@ -236,7 +234,6 @@ describe("user settings routes", () => {
     expect(res.json()).toEqual({
       error: "invalid_interleaved",
       message: "interleavedRendering must be boolean.",
-      error_description: "interleavedRendering must be boolean.",
     });
     await app.close();
   });
@@ -255,7 +252,6 @@ describe("user settings routes", () => {
     expect(res.json()).toEqual({
       error: "invalid_theme",
       message: "theme contains an unsupported value.",
-      error_description: "theme contains an unsupported value.",
     });
     await app.close();
   });
@@ -269,7 +265,6 @@ describe("user settings routes", () => {
     expect(res.json()).toEqual({
       error: "unauthorized",
       message: "unauthorized",
-      error_description: "unauthorized",
     });
     await app.close();
   });
@@ -288,7 +283,6 @@ describe("user settings routes", () => {
     expect(res.json()).toEqual({
       error: "db_down",
       message: "db_down",
-      error_description: "db_down",
     });
     await app.close();
   });

--- a/functions/test/services/ingestGateway.test.ts
+++ b/functions/test/services/ingestGateway.test.ts
@@ -76,7 +76,6 @@ describe("ingestGatewayHandler", () => {
     expect(res.payload).toMatchObject({
       error: "invalid_request",
       message: "missing bearer token",
-      error_description: "missing bearer token",
     });
   });
 
@@ -155,7 +154,6 @@ describe("ingestGatewayHandler", () => {
     expect(res.payload).toMatchObject({
       error: "device_forbidden",
       message: "device not allowed",
-      error_description: "device not allowed",
     });
   });
 });

--- a/functions/test/services/ingestSmokeTestService.test.ts
+++ b/functions/test/services/ingestSmokeTestService.test.ts
@@ -85,7 +85,7 @@ describe("IngestSmokeTestService", () => {
     expect(writes[0]).toMatchObject({
       path: "devices/scoped-device-1",
       data: expect.objectContaining({
-        ownerUserId: "user-1",
+        accId: "user-1",
         ownerScope: plan.ownerSegment,
       }),
     });

--- a/shared-types/src/index.ts
+++ b/shared-types/src/index.ts
@@ -7,7 +7,6 @@ export type DeviceSummary = {
   name?: string | null;
   status?: string | null;
   registryStatus?: string | null;
-  ownerUserId?: string | null;
   ownerUserIds?: string[] | null;
   publicDeviceId?: string | null;
   ownerScope?: string | null;


### PR DESCRIPTION
## Summary
- remove legacy `ownerUserId` reads, writes, docs, and API surface in favor of `ownerUserIds`
- add a device ownership backfill script and tighten Firestore/admin ownership checks around the array field
- stop emitting the deprecated `error_description` alias and update tests and documentation accordingly

## Testing
- source ~/.nvm/nvm.sh && nvm use 24 && pnpm --filter crowdpm-functions test -- --run