### PR TITLE
chore(frontend): normalize copy, links, and app routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,9 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import { AuthDialog, type AuthMode } from "./components/AuthDialog";
+import { ExternalAnchor, ExternalLink } from "./components/ExternalLink";
+import { APP_ROUTES, getDeepLinkedAppTab, getRouteForDeepLinkedAppTab, isActivationRoute, isDeepLinkedAppRoute, type DeepLinkedAppTab } from "./lib/appRoutes";
 import { ThemeSettingsControls } from "./components/ThemeSettingsControls";
+import { PROJECT_LINKS, PROJECT_RESOURCE_LINKS } from "./lib/projectLinks";
 import { useAuth } from "./providers/AuthProvider";
 import { useUserSettings } from "./providers/UserSettingsProvider";
 import { type IngestSmokeTestCleanupResponse, type IngestSmokeTestResponse } from "./lib/api";
@@ -63,37 +66,6 @@ const TEAM_MEMBERS: Array<{
   },
 ];
 
-const RESOURCE_LINKS: Array<{ label: string; href: string }> = [
-  {
-    label: "Capstone Portal",
-    href: "https://eecs.engineering.oregonstate.edu/capstone/submission/pages/viewSingleProject.php?id=WHBsGlAFvH7HrCiH",
-  },
-  {
-    label: "Capstone Drive",
-    href: "https://drive.google.com/drive/folders/1Yh_4dku-TqYAlbGtKzT0UM0-LubAig17?usp=sharing",
-  },
-  {
-    label: "Technical Requirements Doc",
-    href: "https://docs.google.com/document/d/1i0fjx2_IagNerPkSPpG9JzbErKNKuu0caAm-F-koBTo/edit?usp=sharing",
-  },
-  {
-    label: "GitHub Monorepo",
-    href: "https://github.com/Denuo-Web/CrowdPMPlatform/",
-  },
-  {
-    label: "Deep Wiki",
-    href: "https://deepwiki.com/Denuo-Web/CrowdPMPlatform",
-  },
-  {
-    label: "Asana Board",
-    href: "https://app.asana.com/1/941689499454829/project/1211814553979599/board",
-  },
-  {
-    label: "Discord Invite",
-    href: "https://discord.gg/cEbGw8HAUQ",
-  },
-];
-
 const THEME_SHORTCUT_IGNORED_SELECTOR = [
   "[contenteditable]",
   '[role="combobox"]',
@@ -117,17 +89,23 @@ const AboutPage = lazy(() => import("./pages/AboutPage"));
 const NodePage = lazy(() => import("./pages/NodePage"));
 const MAP_VIEWPORT_BOTTOM_INSET = "max(12px, env(safe-area-inset-bottom, 0px))";
 
+type AppTab = "map" | "dashboard" | "smoke" | "admin" | DeepLinkedAppTab;
+
+function isDeepLinkedTab(tab: AppTab): tab is DeepLinkedAppTab {
+  return tab === "pairing-info" || tab === "about" || tab === "node";
+}
+
 export default function App() {
   const { user, isLoading, signOut, isModerator, isSuperAdmin } = useAuth();
   const { settings } = useUserSettings();
   const userScopedKey = user?.uid ?? "anon";
-  const initialPairingGuidePath = typeof window !== "undefined" && window.location.pathname.toLowerCase().startsWith("/pairing-guide");
-  const initialAboutPath = typeof window !== "undefined" && window.location.pathname.toLowerCase().startsWith("/about");
-  const initialNodePath = typeof window !== "undefined" && window.location.pathname.toLowerCase().startsWith("/node");
-  const [tab, setTab] = useState<"map" | "dashboard" | "smoke" | "admin" | "pairing-info" | "about" | "node">(initialNodePath ? "node" : initialAboutPath ? "about" : initialPairingGuidePath ? "pairing-info" : "map");
+  const initialDeepLinkedTab = typeof window !== "undefined"
+    ? getDeepLinkedAppTab(window.location.pathname)
+    : null;
+  const [tab, setTab] = useState<AppTab>(initialDeepLinkedTab ?? "map");
   const [authMode, setAuthMode] = useState<AuthMode>("login");
   const [isAuthDialogOpen, setAuthDialogOpen] = useState(false);
-  const initialActivationPath = typeof window !== "undefined" && window.location.pathname.toLowerCase().startsWith("/activate");
+  const initialActivationPath = typeof window !== "undefined" && isActivationRoute(window.location.pathname);
   const [isActivationModalOpen, setActivationModalOpen] = useState(initialActivationPath);
   const [isTeamModalOpen, setTeamModalOpen] = useState(false);
   const [isThemeModalOpen, setThemeModalOpen] = useState(false);
@@ -207,35 +185,26 @@ export default function App() {
   useEffect(() => {
     if (typeof window === "undefined") return;
     if (isActivationModalOpen) {
-      if (!window.location.pathname.toLowerCase().startsWith("/activate")) {
-        window.history.pushState({}, "", "/activate");
+      if (!isActivationRoute(window.location.pathname)) {
+        window.history.pushState({}, "", APP_ROUTES.activation);
       }
     }
-    else if (window.location.pathname.toLowerCase().startsWith("/activate")) {
-      window.history.replaceState({}, "", "/");
+    else if (isActivationRoute(window.location.pathname)) {
+      window.history.replaceState({}, "", APP_ROUTES.home);
     }
   }, [isActivationModalOpen]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
     const pathname = window.location.pathname.toLowerCase();
-    if (tab === "pairing-info") {
-      if (!pathname.startsWith("/pairing-guide")) {
-        window.history.pushState({}, "", "/pairing-guide");
+    if (isDeepLinkedTab(tab)) {
+      const targetRoute = getRouteForDeepLinkedAppTab(tab);
+      if (!pathname.startsWith(targetRoute)) {
+        window.history.pushState({}, "", targetRoute);
       }
     }
-    else if (tab === "about") {
-      if (!pathname.startsWith("/about")) {
-        window.history.pushState({}, "", "/about");
-      }
-    }
-    else if (tab === "node") {
-      if (!pathname.startsWith("/node")) {
-        window.history.pushState({}, "", "/node");
-      }
-    }
-    else if (pathname.startsWith("/pairing-guide") || pathname.startsWith("/about") || pathname.startsWith("/node")) {
-      window.history.replaceState({}, "", "/");
+    else if (isDeepLinkedAppRoute(pathname)) {
+      window.history.replaceState({}, "", APP_ROUTES.home);
     }
   }, [tab]);
 
@@ -243,17 +212,12 @@ export default function App() {
     if (typeof window === "undefined") return;
     const handlePopState = () => {
       const pathname = window.location.pathname.toLowerCase();
-      setActivationModalOpen(pathname.startsWith("/activate"));
-      if (pathname.startsWith("/pairing-guide")) {
-        setTab("pairing-info");
+      const deepLinkedTab = getDeepLinkedAppTab(pathname);
+      setActivationModalOpen(isActivationRoute(pathname));
+      if (deepLinkedTab) {
+        setTab(deepLinkedTab);
       }
-      else if (pathname.startsWith("/about")) {
-        setTab("about");
-      }
-      else if (pathname.startsWith("/node")) {
-        setTab("node");
-      }
-      else if (tab === "pairing-info" || tab === "about" || tab === "node") {
+      else if (isDeepLinkedTab(tab)) {
         setTab("map");
       }
     };
@@ -703,15 +667,9 @@ function TeamModal({ open, onOpenChange, isSignedIn }: TeamModalProps) {
         }}
       >
         <Heading as="h2" size="5" trim="start">
-          <Link
-            href="https://ecampus.oregonstate.edu/online-degrees/undergraduate/electrical-computer-engineering/"
-            target="_blank"
-            rel="noreferrer"
-            color="iris"
-            highContrast
-          >
+          <ExternalLink href={PROJECT_LINKS.osuEecsProgram} color="iris" highContrast>
             OSU EECS
-          </Link>{" "}
+          </ExternalLink>{" "}
           Capstone Team
         </Heading>
         <Text size="2" color="gray" mt="2">
@@ -747,9 +705,9 @@ function TeamModal({ open, onOpenChange, isSignedIn }: TeamModalProps) {
                   radius="full"
                   aria-label={`${member.name} GitHub profile`}
                 >
-                  <a href={member.github} target="_blank" rel="noreferrer">
+                  <ExternalAnchor href={member.github}>
                     <GitHubLogoIcon />
-                  </a>
+                  </ExternalAnchor>
                 </IconButton>
                 <IconButton
                   asChild
@@ -758,9 +716,9 @@ function TeamModal({ open, onOpenChange, isSignedIn }: TeamModalProps) {
                   radius="full"
                   aria-label={`${member.name} LinkedIn profile`}
                 >
-                  <a href={member.linkedin} target="_blank" rel="noreferrer">
+                  <ExternalAnchor href={member.linkedin}>
                     <LinkedInLogoIcon />
-                  </a>
+                  </ExternalAnchor>
                 </IconButton>
               </Flex>
             </Flex>
@@ -773,17 +731,16 @@ function TeamModal({ open, onOpenChange, isSignedIn }: TeamModalProps) {
               Coordination links
             </Text>
             <Flex direction="column" gap="2" mt="2">
-              {RESOURCE_LINKS.map((resource) => (
-                <Link
+              {PROJECT_RESOURCE_LINKS.map((resource) => (
+                <ExternalLink
                   key={resource.href}
                   href={resource.href}
-                  target="_blank"
-                  rel="noreferrer"
                   color="iris"
+                  highContrast
                   size="2"
                 >
                   {resource.label}
-                </Link>
+                </ExternalLink>
               ))}
             </Flex>
           </>

--- a/frontend/src/components/ExternalLink.tsx
+++ b/frontend/src/components/ExternalLink.tsx
@@ -1,0 +1,15 @@
+import type { ComponentProps, ComponentPropsWithoutRef } from "react";
+import { Link } from "@radix-ui/themes";
+
+type ExternalLinkProps = Omit<ComponentProps<typeof Link>, "target" | "rel">;
+type ExternalAnchorProps = Omit<ComponentPropsWithoutRef<"a">, "target" | "rel">;
+
+const EXTERNAL_LINK_REL = "noopener noreferrer";
+
+export function ExternalLink(props: ExternalLinkProps) {
+  return <Link target="_blank" rel={EXTERNAL_LINK_REL} {...props} />;
+}
+
+export function ExternalAnchor(props: ExternalAnchorProps) {
+  return <a target="_blank" rel={EXTERNAL_LINK_REL} {...props} />;
+}

--- a/frontend/src/components/InternalLink.tsx
+++ b/frontend/src/components/InternalLink.tsx
@@ -1,0 +1,9 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+type InternalNewTabAnchorProps = Omit<ComponentPropsWithoutRef<"a">, "target" | "rel">;
+
+const INTERNAL_NEW_TAB_REL = "noopener noreferrer";
+
+export function InternalNewTabAnchor(props: InternalNewTabAnchorProps) {
+  return <a target="_blank" rel={INTERNAL_NEW_TAB_REL} {...props} />;
+}

--- a/frontend/src/components/LegalDocumentDialog.tsx
+++ b/frontend/src/components/LegalDocumentDialog.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 import { Box, Dialog, Flex, Heading, Link, Separator, Text } from "@radix-ui/themes";
+import { ExternalLink } from "./ExternalLink";
+import { PROJECT_LINKS } from "../lib/projectLinks";
 
 export type LegalDocumentId = "terms" | "privacy" | "license";
 
@@ -19,9 +21,6 @@ const COMPANY_NAME = "Denuo Web, LLC";
 const COMPANY_CONTACT_EMAIL = "info@denuoweb.com";
 const COMPANY_LICENSE_EMAIL = "license@denuoweb.com";
 const COMPANY_MAILING_ADDRESS = "1292 High Street PMB 222, Eugene, OR 97401";
-const PROJECT_REPOSITORY_URL = "https://github.com/Denuo-Web/CrowdPMPlatform/";
-const PROJECT_LICENSE_URL = "https://github.com/Denuo-Web/CrowdPMPlatform/blob/main/LICENSE.md";
-const AGPL_URL = "https://www.gnu.org/licenses/agpl-3.0.html";
 
 const legalDocumentTitles: Record<LegalDocumentId, string> = {
   terms: "Terms of Service",
@@ -354,9 +353,9 @@ function LicenseTerms() {
       <Section title="1. Source Code">
         <P>
           CrowdPM source code is available in the{" "}
-          <Link href={PROJECT_REPOSITORY_URL} target="_blank" rel="noreferrer" color="iris" highContrast>
+          <ExternalLink href={PROJECT_LINKS.repository} color="iris" highContrast>
             Denuo-Web/CrowdPMPlatform repository
-          </Link>{" "}
+          </ExternalLink>{" "}
           and is dual-licensed under the GNU Affero General Public License version 3.0 or later and a
           separate commercial license from {COMPANY_NAME}.
         </P>
@@ -364,13 +363,13 @@ function LicenseTerms() {
           The AGPL option lets you copy, modify, run, and distribute covered code if you comply with
           the AGPL, including its source availability requirements for modified network services.
           Review the{" "}
-          <Link href={AGPL_URL} target="_blank" rel="noreferrer" color="iris" highContrast>
+          <ExternalLink href={PROJECT_LINKS.agpl3} color="iris" highContrast>
             GNU AGPL v3.0
-          </Link>{" "}
+          </ExternalLink>{" "}
           and the{" "}
-          <Link href={PROJECT_LICENSE_URL} target="_blank" rel="noreferrer" color="iris" highContrast>
+          <ExternalLink href={PROJECT_LINKS.licenseFile} color="iris" highContrast>
             repository license
-          </Link>{" "}
+          </ExternalLink>{" "}
           for the complete terms.
         </P>
       </Section>

--- a/frontend/src/lib/activation.ts
+++ b/frontend/src/lib/activation.ts
@@ -1,9 +1,11 @@
+import { APP_ROUTES } from "./appRoutes";
+
 export function buildActivationLink(): string {
   if (typeof window === "undefined") {
-    return "https://crowdpmplatform.web.app/activate";
+    return `https://crowdpmplatform.web.app${APP_ROUTES.activation}`;
   }
   const url = new URL(window.location.href);
-  url.pathname = "/activate";
+  url.pathname = APP_ROUTES.activation;
   url.search = "";
   url.hash = "";
   return url.toString();

--- a/frontend/src/lib/appRoutes.ts
+++ b/frontend/src/lib/appRoutes.ts
@@ -1,0 +1,48 @@
+export const APP_ROUTES = {
+  home: "/",
+  activation: "/activate",
+  pairingGuide: "/pairing-guide",
+  about: "/about",
+  node: "/node",
+} as const;
+
+export type DeepLinkedAppTab = "pairing-info" | "about" | "node";
+
+const DEEP_LINKED_TAB_ROUTES: Record<DeepLinkedAppTab, string> = {
+  "pairing-info": APP_ROUTES.pairingGuide,
+  about: APP_ROUTES.about,
+  node: APP_ROUTES.node,
+};
+
+const DEEP_LINKED_TAB_ROUTE_ENTRIES = Object.entries(DEEP_LINKED_TAB_ROUTES) as Array<[DeepLinkedAppTab, string]>;
+
+function normalizeAppPathname(pathname: string): string {
+  return pathname.toLowerCase();
+}
+
+export function matchesAppRoute(pathname: string, route: string): boolean {
+  return normalizeAppPathname(pathname).startsWith(normalizeAppPathname(route));
+}
+
+export function getDeepLinkedAppTab(pathname: string): DeepLinkedAppTab | null {
+  const normalizedPathname = normalizeAppPathname(pathname);
+  const match = DEEP_LINKED_TAB_ROUTE_ENTRIES.find((entry) => normalizedPathname.startsWith(entry[1]));
+  return match?.[0] ?? null;
+}
+
+export function getRouteForDeepLinkedAppTab(tab: DeepLinkedAppTab): string {
+  return DEEP_LINKED_TAB_ROUTES[tab];
+}
+
+export function isActivationRoute(pathname: string): boolean {
+  return matchesAppRoute(pathname, APP_ROUTES.activation);
+}
+
+export function isDeepLinkedAppRoute(pathname: string): boolean {
+  return getDeepLinkedAppTab(pathname) !== null;
+}
+
+export function openAppRouteInNewTab(route: string): void {
+  if (typeof window === "undefined") return;
+  window.open(route, "_blank", "noopener,noreferrer");
+}

--- a/frontend/src/lib/projectLinks.ts
+++ b/frontend/src/lib/projectLinks.ts
@@ -1,0 +1,22 @@
+export const PROJECT_LINKS = {
+  agpl3: "https://www.gnu.org/licenses/agpl-3.0.html",
+  asanaBoard: "https://app.asana.com/1/941689499454829/project/1211814553979599/board",
+  capstoneDrive: "https://drive.google.com/drive/folders/1Yh_4dku-TqYAlbGtKzT0UM0-LubAig17?usp=sharing",
+  capstonePortal: "https://eecs.engineering.oregonstate.edu/capstone/submission/pages/viewSingleProject.php?id=WHBsGlAFvH7HrCiH",
+  deepWiki: "https://deepwiki.com/Denuo-Web/CrowdPMPlatform",
+  discord: "https://discord.gg/cEbGw8HAUQ",
+  licenseFile: "https://github.com/Denuo-Web/CrowdPMPlatform/blob/main/LICENSE.md",
+  osuEecsProgram: "https://ecampus.oregonstate.edu/online-degrees/undergraduate/electrical-computer-engineering/",
+  repository: "https://github.com/Denuo-Web/CrowdPMPlatform/",
+  technicalRequirementsDoc: "https://docs.google.com/document/d/1i0fjx2_IagNerPkSPpG9JzbErKNKuu0caAm-F-koBTo/edit?usp=sharing",
+} as const;
+
+export const PROJECT_RESOURCE_LINKS = [
+  { label: "Capstone Portal", href: PROJECT_LINKS.capstonePortal },
+  { label: "Capstone Drive", href: PROJECT_LINKS.capstoneDrive },
+  { label: "Technical Requirements Doc", href: PROJECT_LINKS.technicalRequirementsDoc },
+  { label: "GitHub Monorepo", href: PROJECT_LINKS.repository },
+  { label: "Deep Wiki", href: PROJECT_LINKS.deepWiki },
+  { label: "Asana Board", href: PROJECT_LINKS.asanaBoard },
+  { label: "Discord Invite", href: PROJECT_LINKS.discord },
+] as const;

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -13,10 +13,45 @@ import {
   LegalDocumentLink,
   type LegalDocumentId,
 } from "../components/LegalDocumentDialog";
+import { ExternalLink } from "../components/ExternalLink";
+import { PROJECT_LINKS } from "../lib/projectLinks";
 
 type AboutPageProps = {
   onOpenTeamModal: () => void;
 };
+
+const HOW_IT_WORKS_STEPS = [
+  {
+    title: "1. Pair a sensor node",
+    description: "Connect a CrowdPM-compatible air quality sensor to your account using our secure device pairing flow.",
+  },
+  {
+    title: "2. Stream measurements",
+    description: "Your node automatically collects PM2.5 readings along with GPS coordinates and streams them to the CrowdPM backend.",
+  },
+  {
+    title: "3. Visualize on the map",
+    description: "All public measurements appear on the interactive 3D map, color-coded by air quality level.",
+  },
+  {
+    title: "4. Export & share",
+    description: "Render flythrough videos of batch data or browse historical measurements from the dashboard.",
+  },
+] as const;
+
+const TECHNOLOGY_STACK = [
+  { label: "Frontend", value: "React, Vite, Radix UI, deck.gl with Google Maps" },
+  { label: "Backend", value: "Firebase Cloud Functions (Node.js / TypeScript)" },
+  { label: "Database", value: "Cloud Firestore" },
+  { label: "Auth", value: "Firebase Authentication + OAuth 2.0 Device Authorization Grant with DPoP" },
+  { label: "Hardware", value: "ESP32-based sensor nodes with PM2.5 sensors and GPS modules" },
+] as const;
+
+const LEGAL_DOCUMENT_LINKS = [
+  { documentId: "terms", label: "Terms of Service" },
+  { documentId: "license", label: "License" },
+  { documentId: "privacy", label: "Privacy Policy" },
+] as const satisfies readonly { documentId: LegalDocumentId; label: string }[];
 
 export default function AboutPage({ onOpenTeamModal }: AboutPageProps) {
   const [openLegalDocument, setOpenLegalDocument] = useState<LegalDocumentId | null>(null);
@@ -58,22 +93,11 @@ export default function AboutPage({ onOpenTeamModal }: AboutPageProps) {
           <Flex direction="column" gap="3">
             <Heading as="h2" size="4">How It Works</Heading>
             <Flex direction="column" gap="2" pl="2">
-              <Text size="2" as="p">
-                <strong>1. Pair a sensor node</strong>&ensp;— Connect a CrowdPM-compatible air quality
-                sensor to your account using our secure device pairing flow.
-              </Text>
-              <Text size="2" as="p">
-                <strong>2. Stream measurements</strong>&ensp;— Your node automatically collects PM2.5
-                readings along with GPS coordinates and streams them to the CrowdPM backend.
-              </Text>
-              <Text size="2" as="p">
-                <strong>3. Visualize on the map</strong>&ensp;— All public measurements appear on the
-                interactive 3D map, color-coded by air quality level.
-              </Text>
-              <Text size="2" as="p">
-                <strong>4. Export &amp; share</strong>&ensp;— Render flythrough videos of batch data or
-                browse historical measurements from the dashboard.
-              </Text>
+              {HOW_IT_WORKS_STEPS.map((step) => (
+                <Text key={step.title} size="2" as="p">
+                  <strong>{step.title}</strong>&ensp;— {step.description}
+                </Text>
+              ))}
             </Flex>
           </Flex>
         </Card>
@@ -86,11 +110,11 @@ export default function AboutPage({ onOpenTeamModal }: AboutPageProps) {
               CrowdPM is built with a modern, open-source stack:
             </Text>
             <Flex direction="column" gap="1" pl="2">
-              <Text size="2" as="p">• <strong>Frontend</strong> — React, Vite, Radix UI, deck.gl with Google Maps</Text>
-              <Text size="2" as="p">• <strong>Backend</strong> — Firebase Cloud Functions (Node.js / TypeScript)</Text>
-              <Text size="2" as="p">• <strong>Database</strong> — Cloud Firestore</Text>
-              <Text size="2" as="p">• <strong>Auth</strong> — Firebase Authentication + OAuth 2.0 Device Authorization Grant with DPoP</Text>
-              <Text size="2" as="p">• <strong>Hardware</strong> — ESP32-based sensor nodes with PM2.5 sensors and GPS modules</Text>
+              {TECHNOLOGY_STACK.map((item) => (
+                <Text key={item.label} size="2" as="p">
+                  • <strong>{item.label}</strong> — {item.value}
+                </Text>
+              ))}
             </Flex>
           </Flex>
         </Card>
@@ -101,28 +125,16 @@ export default function AboutPage({ onOpenTeamModal }: AboutPageProps) {
             <Heading as="h2" size="4">Origin</Heading>
             <Text size="2" as="p">
               CrowdPM began as an{" "}
-              <Link
-                href="https://eecs.engineering.oregonstate.edu/capstone/submission/pages/viewSingleProject.php?id=WHBsGlAFvH7HrCiH"
-                target="_blank"
-                rel="noreferrer"
-                color="iris"
-                highContrast
-              >
+              <ExternalLink href={PROJECT_LINKS.capstonePortal} color="iris" highContrast>
                 Oregon State University EECS Capstone
-              </Link>{" "}
+              </ExternalLink>{" "}
               project. The platform is actively developed and maintained as an open-source effort.
             </Text>
             <Text size="2" as="p">
               The source code is available on{" "}
-              <Link
-                href="https://github.com/Denuo-Web/CrowdPMPlatform/"
-                target="_blank"
-                rel="noreferrer"
-                color="iris"
-                highContrast
-              >
+              <ExternalLink href={PROJECT_LINKS.repository} color="iris" highContrast>
                 GitHub
-              </Link>.
+              </ExternalLink>.
             </Text>
             <Text size="2" as="p">
               Meet the people behind the project in the{" "}
@@ -149,15 +161,15 @@ export default function AboutPage({ onOpenTeamModal }: AboutPageProps) {
               Review the hosted service terms, project license, and data practices:
             </Text>
             <Flex gap="3" wrap="wrap">
-              <LegalDocumentLink documentId="terms" onOpen={setOpenLegalDocument}>
-                Terms of Service
-              </LegalDocumentLink>
-              <LegalDocumentLink documentId="license" onOpen={setOpenLegalDocument}>
-                License
-              </LegalDocumentLink>
-              <LegalDocumentLink documentId="privacy" onOpen={setOpenLegalDocument}>
-                Privacy Policy
-              </LegalDocumentLink>
+              {LEGAL_DOCUMENT_LINKS.map((document) => (
+                <LegalDocumentLink
+                  key={document.documentId}
+                  documentId={document.documentId}
+                  onOpen={setOpenLegalDocument}
+                >
+                  {document.label}
+                </LegalDocumentLink>
+              ))}
             </Flex>
           </Flex>
         </Card>
@@ -169,25 +181,13 @@ export default function AboutPage({ onOpenTeamModal }: AboutPageProps) {
           <Heading as="h2" size="4" mb="2">Get Involved</Heading>
           <Text size="2" color="gray" as="p">
             Interested in contributing, deploying your own node, or just learning more? Join the{" "}
-            <Link
-              href="https://discord.gg/cEbGw8HAUQ"
-              target="_blank"
-              rel="noreferrer"
-              color="iris"
-              highContrast
-            >
+            <ExternalLink href={PROJECT_LINKS.discord} color="iris" highContrast>
               CrowdPM Discord
-            </Link>{" "}
+            </ExternalLink>{" "}
             or check out the project on{" "}
-            <Link
-              href="https://github.com/Denuo-Web/CrowdPMPlatform/"
-              target="_blank"
-              rel="noreferrer"
-              color="iris"
-              highContrast
-            >
+            <ExternalLink href={PROJECT_LINKS.repository} color="iris" highContrast>
               GitHub
-            </Link>.
+            </ExternalLink>.
           </Text>
         </Box>
       </Flex>

--- a/frontend/src/pages/ActivationPage.tsx
+++ b/frontend/src/pages/ActivationPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Button, Callout, Card, Flex, Heading, Separator, Text, TextField } from "@radix-ui/themes";
 import { timestampToMillis } from "@crowdpm/types";
+import { InternalNewTabAnchor } from "../components/InternalLink";
 import { useAuth } from "../providers/AuthProvider";
 import { AuthDialog, type AuthMode } from "../components/AuthDialog";
 import {
@@ -8,6 +9,7 @@ import {
   fetchActivationSession,
   type ActivationSession,
 } from "../lib/api";
+import { APP_ROUTES } from "../lib/appRoutes";
 
 type ActivationPageProps = {
   layout?: "standalone" | "dialog";
@@ -220,9 +222,9 @@ export function ActivationPage({ layout = "standalone", onActivationComplete }: 
         </Text>
         <Text size="2" mt="2" as="p">
           First time?{" "}
-          <a href="/pairing-guide" target="_blank" rel="noreferrer" style={{ color: "var(--accent-11)" }}>
+          <InternalNewTabAnchor href={APP_ROUTES.pairingGuide} style={{ color: "var(--accent-11)" }}>
             Read the pairing guide →
-          </a>
+          </InternalNewTabAnchor>
         </Text>
       </Box>
 

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -14,6 +14,7 @@ import {
   type IngestSmokeTestCleanupResponse,
 } from "../lib/api";
 import { decodeBatchKey, encodeBatchKey } from "../lib/batchKeys";
+import { APP_ROUTES, openAppRouteInNewTab } from "../lib/appRoutes";
 import { safeLocalStorageGet, safeLocalStorageRemove, safeLocalStorageSet, scopedStorageKey } from "../lib/storage";
 import {
   detectCanvasVideoExportSupport,
@@ -45,6 +46,8 @@ const MAX_PERSISTED_MAP_ZOOM = 22;
 const MAP_PANEL_BACKGROUND = "color-mix(in srgb, var(--color-panel-solid) 88%, transparent)";
 const MAP_PANEL_BORDER = "1px solid var(--gray-a6)";
 const MAP_PANEL_BLUR = "blur(12px)";
+const MAP_EMPTY_STATE_TITLE = "Hyper-local community air quality, mapped in 3D";
+const MAP_EMPTY_STATE_DESCRIPTION = "Explore public sensor data below, or pair your own node to start contributing measurements.";
 
 // React Query cache keys. Keeping them as helpers avoids typos across the file.
 const BATCHES_QUERY_KEY = (uid: string | null | undefined) => ["batches", uid ?? "guest"] as const;
@@ -1123,10 +1126,10 @@ export default function MapPage({
               <circle cx="14" cy="23" r="0.5" fill="var(--accent-9)" opacity="0.4" />
             </svg>
             <h2 style={{ margin: 0, fontSize: "var(--font-size-6)", fontWeight: 700 }}>
-              Hyper-local community air quality, mapped in 3D
+              {MAP_EMPTY_STATE_TITLE}
             </h2>
             <p style={{ marginTop: "var(--space-3)", color: "var(--gray-11)", fontSize: "var(--font-size-3)" }}>
-              Explore public sensor data below, or pair your own node to start contributing measurements.
+              {MAP_EMPTY_STATE_DESCRIPTION}
             </p>
             <div style={{ display: "flex", gap: "var(--space-3)", justifyContent: "center", marginTop: "var(--space-4)", flexWrap: "wrap" }}>
               <button
@@ -1147,7 +1150,7 @@ export default function MapPage({
               </button>
               <button
                 type="button"
-                onClick={() => window.open("/pairing-guide", "_blank")}
+                onClick={() => openAppRouteInNewTab(APP_ROUTES.pairingGuide)}
                 style={{
                   padding: "var(--space-2) var(--space-4)",
                   borderRadius: "var(--radius-3)",

--- a/frontend/src/pages/NodePage.tsx
+++ b/frontend/src/pages/NodePage.tsx
@@ -4,10 +4,10 @@ import {
   Card,
   Flex,
   Heading,
-  Link,
   Separator,
   Text,
 } from "@radix-ui/themes";
+import { ExternalLink } from "../components/ExternalLink";
 
 type SectionProps = {
   title: string;
@@ -80,9 +80,9 @@ function ListItem({ children }: { children: ReactNode }) {
 
 function PartLink({ href, children }: { href: string; children: ReactNode }) {
   return (
-    <Link href={href} target="_blank" rel="noopener" color="iris" highContrast>
+    <ExternalLink href={href} color="iris" highContrast>
       {children}
-    </Link>
+    </ExternalLink>
   );
 }
 

--- a/frontend/src/pages/PairingInfoPage.tsx
+++ b/frontend/src/pages/PairingInfoPage.tsx
@@ -13,6 +13,8 @@ import {
   ChevronDownIcon,
   InfoCircledIcon,
 } from "@radix-ui/react-icons";
+import { ExternalAnchor } from "../components/ExternalLink";
+import { PROJECT_LINKS } from "../lib/projectLinks";
 
 type PairingInfoPageProps = {
   onOpenActivation?: () => void;
@@ -240,9 +242,9 @@ export default function PairingInfoPage({ onOpenActivation }: PairingInfoPagePro
             </Text>
             <Text size="2" as="p">
               <strong>Still stuck?</strong>&ensp;Reach out on the{" "}
-              <a href="https://discord.gg/cEbGw8HAUQ" target="_blank" rel="noreferrer" style={{ color: "var(--accent-11)" }}>
+              <ExternalAnchor href={PROJECT_LINKS.discord} style={{ color: "var(--accent-11)" }}>
                 CrowdPM Discord
-              </a>.
+              </ExternalAnchor>.
             </Text>
           </Flex>
         </Flex>

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge, Box, Button, Callout, Card, Flex, Heading, SegmentedControl, Select, Separator, Switch, Table, Text, TextField } from "@radix-ui/themes";
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { timestampToMillis } from "@crowdpm/types";
+import { InternalNewTabAnchor } from "../components/InternalLink";
 import {
   deleteBatch,
   listBatches,
@@ -12,6 +13,7 @@ import {
   type BatchVisibility,
   type DeviceSummary,
 } from "../lib/api";
+import { APP_ROUTES } from "../lib/appRoutes";
 import { useAuth } from "../providers/AuthProvider";
 import { useUserSettings } from "../providers/UserSettingsProvider";
 import { buildActivationLink } from "../lib/activation";
@@ -308,7 +310,7 @@ export default function UserDashboard({ onRequestActivation, onOpenThemeModal, r
             <Flex gap="3" wrap="wrap">
               <Button onClick={handleOpenActivation}>Open activation UI</Button>
               <Button variant="ghost" asChild>
-                <a href="/activate" target="_blank" rel="noreferrer">Open in current tab</a>
+                <InternalNewTabAnchor href={APP_ROUTES.activation}>Open in new tab</InternalNewTabAnchor>
               </Button>
             </Flex>
             <Text size="2" color="gray">Share this link with trusted teammates who can approve devices for your org:</Text>
@@ -345,7 +347,7 @@ export default function UserDashboard({ onRequestActivation, onOpenThemeModal, r
               Open activation UI
             </Button>
             <Button variant="ghost" asChild>
-              <a href="/pairing-guide" target="_blank" rel="noreferrer">How does pairing work?</a>
+              <InternalNewTabAnchor href={APP_ROUTES.pairingGuide}>How does pairing work?</InternalNewTabAnchor>
             </Button>
           </Flex>
         </Flex>


### PR DESCRIPTION
## Summary
- normalize the About and Map page copy structures so repeated content is data-driven and easier to keep consistent
- centralize external project URLs and external link behavior across app, legal, about, node, and pairing surfaces
- centralize internal app routes and internal new-tab navigation helpers for activation, pairing guide, about, and node deep links

## Verification
- `pnpm exec eslint frontend/src/App.tsx frontend/src/components/ExternalLink.tsx frontend/src/components/InternalLink.tsx frontend/src/components/LegalDocumentDialog.tsx frontend/src/lib/activation.ts frontend/src/lib/appRoutes.ts frontend/src/lib/projectLinks.ts frontend/src/pages/AboutPage.tsx frontend/src/pages/ActivationPage.tsx frontend/src/pages/MapPage.tsx frontend/src/pages/NodePage.tsx frontend/src/pages/PairingInfoPage.tsx frontend/src/pages/UserDashboard.tsx`
- `pnpm --filter crowdpm-frontend build`