### PR TITLE
Improve landing page startup performance

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,7 @@
       name="description"
       content="CrowdPM Platform visualizes crowd-sourced PM2.5 air quality data and device insights."
     />
+    <link rel="preconnect" href="https://us-central1-crowdpmplatform.cloudfunctions.net" crossorigin />
     <link rel="canonical" href="https://crowdpmplatform.web.app/" />
     <meta name="robots" content="index,follow" />
     <title>CrowdPM</title>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
-import { AuthDialog, type AuthMode } from "./components/AuthDialog";
+import type { AuthMode } from "./components/AuthDialog";
 import { ExternalAnchor, ExternalLink } from "./components/ExternalLink";
 import { APP_ROUTES, getDeepLinkedAppTab, getRouteForDeepLinkedAppTab, isActivationRoute, isDeepLinkedAppRoute, type DeepLinkedAppTab } from "./lib/appRoutes";
-import { ThemeSettingsControls } from "./components/ThemeSettingsControls";
 import { PROJECT_LINKS, PROJECT_RESOURCE_LINKS } from "./lib/projectLinks";
 import { useAuth } from "./providers/AuthProvider";
 import { useUserSettings } from "./providers/UserSettingsProvider";
@@ -80,6 +79,10 @@ const MapPage = lazy(() => import("./pages/MapPage"));
 const UserDashboard = lazy(() => import("./pages/UserDashboard"));
 const SmokeTestLab = lazy(() => import("./pages/SmokeTestLab"));
 const AdminModerationPage = lazy(() => import("./pages/AdminModerationPage"));
+const AuthDialog = lazy(async () => {
+  const module = await import("./components/AuthDialog");
+  return { default: module.AuthDialog };
+});
 const ActivationPage = lazy(async () => {
   const module = await import("./pages/ActivationPage");
   return { default: module.ActivationPage };
@@ -87,6 +90,10 @@ const ActivationPage = lazy(async () => {
 const PairingInfoPage = lazy(() => import("./pages/PairingInfoPage"));
 const AboutPage = lazy(() => import("./pages/AboutPage"));
 const NodePage = lazy(() => import("./pages/NodePage"));
+const ThemeSettingsControls = lazy(async () => {
+  const module = await import("./components/ThemeSettingsControls");
+  return { default: module.ThemeSettingsControls };
+});
 const MAP_VIEWPORT_BOTTOM_INSET = "max(12px, env(safe-area-inset-bottom, 0px))";
 
 type AppTab = "map" | "dashboard" | "smoke" | "admin" | DeepLinkedAppTab;
@@ -557,13 +564,17 @@ export default function App() {
           </Box>
         )}
       </main>
-      <AuthDialog
-        open={isAuthDialogOpen}
-        mode={authMode}
-        onModeChange={setAuthMode}
-        onOpenChange={setAuthDialogOpen}
-        onAuthenticated={() => setTab("dashboard")}
-      />
+      <Suspense fallback={null}>
+        {isAuthDialogOpen ? (
+          <AuthDialog
+            open={isAuthDialogOpen}
+            mode={authMode}
+            onModeChange={setAuthMode}
+            onOpenChange={setAuthDialogOpen}
+            onAuthenticated={() => setTab("dashboard")}
+          />
+        ) : null}
+      </Suspense>
     </Theme>
   );
 }
@@ -636,7 +647,11 @@ function ThemePreferencesModal({ open, onOpenChange }: ThemePreferencesModalProp
         {!user ? (
           <Dialog.Description>Sign in to save theme preferences.</Dialog.Description>
         ) : null}
-        <ThemeSettingsControls onMessage={setMessage} onError={setError} />
+        {open ? (
+          <Suspense fallback={<Text size="2" color="gray">Loading theme settings...</Text>}>
+            <ThemeSettingsControls onMessage={setMessage} onError={setError} />
+          </Suspense>
+        ) : null}
         {error ? (
           <Text color="tomato" size="2" mt="3">{error}</Text>
         ) : null}

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, startTransition, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { timestampToIsoString, timestampToMillis } from "@crowdpm/types";
 import { Button, Dialog, Flex, Select, Switch, Text } from "@radix-ui/themes";
@@ -46,6 +46,10 @@ const MAX_PERSISTED_MAP_ZOOM = 22;
 const MAP_PANEL_BACKGROUND = "color-mix(in srgb, var(--color-panel-solid) 88%, transparent)";
 const MAP_PANEL_BORDER = "1px solid var(--gray-a6)";
 const MAP_PANEL_BLUR = "blur(12px)";
+const MAP_VIEWPORT_BACKGROUND =
+  "radial-gradient(120% 120% at 0% 0%, color-mix(in srgb, var(--accent-8) 20%, transparent), transparent 55%), "
+  + "radial-gradient(100% 100% at 100% 0%, color-mix(in srgb, var(--gray-7) 14%, transparent), transparent 60%), "
+  + "linear-gradient(180deg, color-mix(in srgb, var(--color-panel-solid) 82%, var(--gray-1)), var(--color-surface))";
 const MAP_EMPTY_STATE_TITLE = "Hyper-local community air quality, mapped in 3D";
 const MAP_EMPTY_STATE_DESCRIPTION = "Explore public sensor data below, or pair your own node to start contributing measurements.";
 
@@ -303,6 +307,7 @@ export default function MapPage({
   const [renderedVideoName, setRenderedVideoName] = useState<string | null>(null);
   const [, setRenderedVideoMimeType] = useState<string | null>(null);
   const recordingSupport = useMemo(() => detectCanvasVideoExportSupport(), []);
+  const [isMapViewportActivated, setMapViewportActivated] = useState(false);
 
 
   const getCachedBatch = useCallback(() => {
@@ -629,6 +634,11 @@ export default function MapPage({
   }, [getCachedBatch, queryClient, user, userScopedCacheKey]);
 
   const handleBatchSelect = useCallback((value: string) => {
+    if (value && !isMapViewportActivated) {
+      startTransition(() => {
+        setMapViewportActivated(true);
+      });
+    }
     setSelectedBatchKey(value);
     if (value) {
       safeLocalStorageSet(
@@ -643,7 +653,7 @@ export default function MapPage({
         { context: "map:selected-batch:clear", userId: user?.uid }
       );
     }
-  }, [user?.uid, userScopedSelectionKey]);
+  }, [isMapViewportActivated, user?.uid, userScopedSelectionKey]);
 
   const handleMapZoomChange = useCallback((zoom: number) => {
     const nextZoom = Math.min(Math.max(zoom, MIN_PERSISTED_MAP_ZOOM), MAX_PERSISTED_MAP_ZOOM);
@@ -887,8 +897,10 @@ export default function MapPage({
     ).size
   ), [rows]);
 
-  // Always render the map — use all-public mode by default when nothing is selected
+  // Use all-public mode by default when nothing is selected, but defer the heavy 3D viewport on the anonymous hero.
   const effectiveShowAllMode = isShowingAllPublic24h || !selectedBatchKey;
+  const isAnonymousHeroState = !user && !selectedBatchKey && !rows.length;
+  const shouldRenderMapViewport = isMapViewportActivated || !isAnonymousHeroState;
   const isMapZoomHydrated = !isAuthLoading && zoomHydrationKey === userScopedZoomKey;
   const isExportSectionVisible = Boolean(selectedBatchKey) && !isShowingAllPublic24h;
   const canExportSelection = useMemo(() => {
@@ -919,6 +931,13 @@ export default function MapPage({
     user,
   ]);
   const canStartExport = isExportSectionVisible && !isExporting && !exportDisabledReason;
+
+  useEffect(() => {
+    if (isAnonymousHeroState || isMapViewportActivated) return;
+    startTransition(() => {
+      setMapViewportActivated(true);
+    });
+  }, [isAnonymousHeroState, isMapViewportActivated]);
 
   useEffect(() => {
     if (!isExportSectionVisible) {
@@ -1060,9 +1079,17 @@ export default function MapPage({
 
   return (
     <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          inset: 0,
+          background: MAP_VIEWPORT_BACKGROUND,
+        }}
+      />
       {/* ---- Always-visible map ---- */}
-      <Suspense fallback={<div style={{ width: "100%", height: "100%", background: "var(--color-surface)" }} />}>
-        {isMapZoomHydrated ? (
+      <Suspense fallback={<div style={{ width: "100%", height: "100%", background: MAP_VIEWPORT_BACKGROUND }} />}>
+        {shouldRenderMapViewport && isMapZoomHydrated ? (
           <Map3D
             ref={map3DRef}
             data={data}
@@ -1080,7 +1107,7 @@ export default function MapPage({
       </Suspense>
 
       {/* ---- Welcome hero overlay (when no batch selected and no data) ---- */}
-      {!user && !selectedBatchKey && !rows.length ? (
+      {isAnonymousHeroState ? (
         <div
           style={{
             position: "absolute",

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -1,17 +1,8 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode, useCallback } from "react";
-import {
-  onIdTokenChanged,
-  signInWithEmailAndPassword,
-  createUserWithEmailAndPassword,
-  signOut as firebaseSignOut,
-  type User,
-  type UserCredential,
-  type IdTokenResult,
-} from "firebase/auth";
 import { useQueryClient } from "@tanstack/react-query";
-import { auth } from "../lib/firebase";
 import { safeLocalStorageRemove } from "../lib/storage";
 import type { AdminRole } from "@crowdpm/types";
+import type { IdTokenResult, User, UserCredential } from "firebase/auth";
 
 type AuthContextValue = {
   user: User | null;
@@ -25,6 +16,15 @@ type AuthContextValue = {
 };
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+async function loadFirebaseAuth() {
+  const [{ auth }, firebaseAuth] = await Promise.all([
+    import("../lib/firebase"),
+    import("firebase/auth"),
+  ]);
+
+  return { auth, ...firebaseAuth };
+}
 
 function normalizeRole(value: unknown): AdminRole | null {
   if (typeof value !== "string") return null;
@@ -62,33 +62,47 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let isActive = true;
-    const unsubscribe = onIdTokenChanged(auth, (nextUser) => {
-      setUser(nextUser);
-      if (!nextUser) {
+    let unsubscribe = () => {};
+
+    void loadFirebaseAuth()
+      .then(({ auth, onIdTokenChanged }) => {
+        if (!isActive) return;
+        unsubscribe = onIdTokenChanged(auth, (nextUser) => {
+          setUser(nextUser);
+          if (!nextUser) {
+            setIsLoading(false);
+            setRoles([]);
+            queryClient.clear();
+            safeLocalStorageRemove(
+              ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache", "crowdpm:lastMapZoom", "crowdpm:lastTimelineIndex"],
+              { context: "auth:clear-storage" }
+            );
+            return;
+          }
+          setIsLoading(true);
+          void nextUser.getIdTokenResult()
+            .then((tokenResult) => {
+              if (!isActive) return;
+              setRoles(extractRoles(tokenResult));
+            })
+            .catch(() => {
+              if (!isActive) return;
+              setRoles([]);
+            })
+            .finally(() => {
+              if (!isActive) return;
+              setIsLoading(false);
+            });
+        });
+      })
+      .catch((error) => {
+        console.error("Unable to initialize Firebase Auth.", error);
+        if (!isActive) return;
+        setUser(null);
         setIsLoading(false);
         setRoles([]);
-        queryClient.clear();
-        safeLocalStorageRemove(
-          ["crowdpm:lastSmokeSelection", "crowdpm:lastSmokeBatchCache", "crowdpm:lastMapZoom", "crowdpm:lastTimelineIndex"],
-          { context: "auth:clear-storage" }
-        );
-        return;
-      }
-      setIsLoading(true);
-      void nextUser.getIdTokenResult()
-        .then((tokenResult) => {
-          if (!isActive) return;
-          setRoles(extractRoles(tokenResult));
-        })
-        .catch(() => {
-          if (!isActive) return;
-          setRoles([]);
-        })
-        .finally(() => {
-          if (!isActive) return;
-          setIsLoading(false);
-        });
-    });
+      });
+
     return () => {
       isActive = false;
       unsubscribe();
@@ -103,6 +117,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     );
   }, [queryClient]);
 
+  const signIn = useCallback(async (email: string, password: string) => {
+    const { auth, signInWithEmailAndPassword } = await loadFirebaseAuth();
+    return signInWithEmailAndPassword(auth, email.trim(), password);
+  }, []);
+
+  const signUp = useCallback(async (email: string, password: string) => {
+    const { auth, createUserWithEmailAndPassword } = await loadFirebaseAuth();
+    return createUserWithEmailAndPassword(auth, email.trim(), password);
+  }, []);
+
+  const signOut = useCallback(async () => {
+    const { auth, signOut: firebaseSignOut } = await loadFirebaseAuth();
+    clearCachesOnSignOut();
+    setRoles([]);
+    await firebaseSignOut(auth);
+  }, [clearCachesOnSignOut]);
+
   const value = useMemo<AuthContextValue>(
     () => ({
       user,
@@ -110,15 +141,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       roles,
       isModerator: roles.includes("moderator") || roles.includes("super_admin"),
       isSuperAdmin: roles.includes("super_admin"),
-      signIn: (email, password) => signInWithEmailAndPassword(auth, email.trim(), password),
-      signUp: (email, password) => createUserWithEmailAndPassword(auth, email.trim(), password),
-      signOut: async () => {
-        clearCachesOnSignOut();
-        setRoles([]);
-        await firebaseSignOut(auth);
-      },
+      signIn,
+      signUp,
+      signOut,
     }),
-    [user, isLoading, roles, clearCachesOnSignOut],
+    [user, isLoading, roles, signIn, signOut, signUp],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/providers/UserSettingsProvider.tsx
+++ b/frontend/src/providers/UserSettingsProvider.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
-import { fetchUserSettings, updateUserSettings, type UserSettings } from "../lib/api";
+import type { UserSettings } from "../lib/api";
 import { useAuth } from "./AuthProvider";
 
 type UserSettingsContextValue = {
@@ -37,6 +37,11 @@ function applyUserSettingsDefaults(next: Partial<UserSettings>): UserSettings {
 
 const UserSettingsContext = createContext<UserSettingsContextValue | undefined>(undefined);
 
+async function loadUserSettingsApi() {
+  const { fetchUserSettings, updateUserSettings } = await import("../lib/api");
+  return { fetchUserSettings, updateUserSettings };
+}
+
 export function UserSettingsProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth();
   const [settings, setSettings] = useState<UserSettings>(DEFAULT_USER_SETTINGS);
@@ -54,6 +59,7 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
     setIsLoading(true);
     setError(null);
     try {
+      const { fetchUserSettings } = await loadUserSettingsApi();
       const next = await fetchUserSettings();
       setSettings(applyUserSettingsDefaults(next));
     }
@@ -76,6 +82,7 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
     setIsSaving(true);
     setError(null);
     try {
+      const { updateUserSettings } = await loadUserSettingsApi();
       const updated = await updateUserSettings(next);
       const normalized = applyUserSettingsDefaults(updated);
       setSettings(normalized);


### PR DESCRIPTION
## Summary
- defer the anonymous landing route's 3D map initialization until the viewport is actually needed
- lazy-load auth and theme modal code, and defer Firebase auth and user settings API imports off the root startup path
- add a preconnect hint for the Cloud Functions origin used by the frontend

## Verification
- pnpm --filter crowdpm-frontend build
- pnpm lint
- local Lighthouse run against the built preview: score 63, TBT 520 ms, SI 2.8 s, CLS 0