### PR TITLE
Fix Firebase deploy workflow auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,17 +25,20 @@ jobs:
     environment: deployed
     env:
       FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || vars.FIREBASE_PROJECT_ID }}
+      FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+      FIREBASE_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.FIREBASE_WORKLOAD_IDENTITY_PROVIDER || vars.FIREBASE_WORKLOAD_IDENTITY_PROVIDER }}
+      FIREBASE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EMAIL || vars.FIREBASE_SERVICE_ACCOUNT_EMAIL }}
     permissions:
       contents: read
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 
@@ -47,17 +50,42 @@ jobs:
       - name: Install dependencies
         run: corepack pnpm install --frozen-lockfile
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+      - name: Validate deployment authentication
+        id: auth_config
+        run: |
+          test -n "$FIREBASE_PROJECT_ID" || { echo "Set FIREBASE_PROJECT_ID in repository/environment secrets or variables before deploying."; exit 1; }
+          if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
+            echo "method=credentials_json" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -n "$FIREBASE_WORKLOAD_IDENTITY_PROVIDER" ]; then
+            test -n "$FIREBASE_SERVICE_ACCOUNT_EMAIL" || { echo "Set FIREBASE_SERVICE_ACCOUNT_EMAIL in repository/environment secrets or variables when using Workload Identity Federation."; exit 1; }
+            echo "method=workload_identity" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Set FIREBASE_SERVICE_ACCOUNT_JSON or FIREBASE_WORKLOAD_IDENTITY_PROVIDER before deploying." >&2
+          exit 1
+
+      - name: Authenticate to Google Cloud with service account key
+        if: ${{ steps.auth_config.outputs.method == 'credentials_json' }}
+        uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          credentials_json: ${{ env.FIREBASE_SERVICE_ACCOUNT_JSON }}
+          project_id: ${{ env.FIREBASE_PROJECT_ID }}
+
+      - name: Authenticate to Google Cloud with Workload Identity Federation
+        if: ${{ steps.auth_config.outputs.method == 'workload_identity' }}
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ env.FIREBASE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.FIREBASE_SERVICE_ACCOUNT_EMAIL }}
+          project_id: ${{ env.FIREBASE_PROJECT_ID }}
 
       - name: Setup gcloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Validate configuration
         run: |
-          test -n "$FIREBASE_PROJECT_ID" || { echo "Set FIREBASE_PROJECT_ID in repository/environment secrets or variables before deploying."; exit 1; }
           gcloud config set project "$FIREBASE_PROJECT_ID"
 
       - name: Install Firebase CLI

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,7 +76,10 @@ firebase deploy --only firestore:indexes --project "$FIREBASE_PROJECT_ID"
 firebase deploy --only firestore:rules,storage --project "$FIREBASE_PROJECT_ID"
 ```
 
-The GitHub Actions workflow at `.github/workflows/deploy.yml` also deploys from `main` using the `deployed` GitHub environment. Required GitHub configuration includes `FIREBASE_PROJECT_ID` and `FIREBASE_SERVICE_ACCOUNT_JSON`.
+The GitHub Actions workflow at `.github/workflows/deploy.yml` also deploys from `main` using the `deployed` GitHub environment. Required GitHub configuration includes `FIREBASE_PROJECT_ID` and one of these authentication options:
+
+- `FIREBASE_SERVICE_ACCOUNT_JSON`
+- `FIREBASE_WORKLOAD_IDENTITY_PROVIDER` plus `FIREBASE_SERVICE_ACCOUNT_EMAIL`
 
 ## Post-Deploy Validation
 


### PR DESCRIPTION
## Summary
- fail early with a clear message when Firebase deploy auth is not configured
- support either service account JSON or Workload Identity Federation in the deploy workflow
- upgrade GitHub Actions versions used by deploy and lint to Node 24-capable majors

## Testing
- git diff --check
- parsed .github/workflows/deploy.yml and .github/workflows/lint.yml with PyYAML