### PR TITLE
Resolve Firebase project ID from .firebaserc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: deployed
     env:
-      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || vars.FIREBASE_PROJECT_ID }}
       FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
       FIREBASE_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.FIREBASE_WORKLOAD_IDENTITY_PROVIDER || vars.FIREBASE_WORKLOAD_IDENTITY_PROVIDER }}
       FIREBASE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EMAIL || vars.FIREBASE_SERVICE_ACCOUNT_EMAIL }}
@@ -50,10 +49,22 @@ jobs:
       - name: Install dependencies
         run: corepack pnpm install --frozen-lockfile
 
+      - name: Resolve deployment configuration
+        id: deploy_config
+        env:
+          CONFIGURED_FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID || vars.FIREBASE_PROJECT_ID }}
+        run: |
+          project_id="$CONFIGURED_FIREBASE_PROJECT_ID"
+          if [ -z "$project_id" ]; then
+            project_id="$(node -p "const config = require('./.firebaserc'); config.projects?.deployed || ''")"
+          fi
+          test -n "$project_id" || { echo "Set FIREBASE_PROJECT_ID in repository/environment secrets or variables, or define a deployed alias in .firebaserc."; exit 1; }
+          echo "project_id=$project_id" >> "$GITHUB_OUTPUT"
+          echo "FIREBASE_PROJECT_ID=$project_id" >> "$GITHUB_ENV"
+
       - name: Validate deployment authentication
         id: auth_config
         run: |
-          test -n "$FIREBASE_PROJECT_ID" || { echo "Set FIREBASE_PROJECT_ID in repository/environment secrets or variables before deploying."; exit 1; }
           if [ -n "$FIREBASE_SERVICE_ACCOUNT_JSON" ]; then
             echo "method=credentials_json" >> "$GITHUB_OUTPUT"
             exit 0
@@ -71,7 +82,7 @@ jobs:
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ env.FIREBASE_SERVICE_ACCOUNT_JSON }}
-          project_id: ${{ env.FIREBASE_PROJECT_ID }}
+          project_id: ${{ steps.deploy_config.outputs.project_id }}
 
       - name: Authenticate to Google Cloud with Workload Identity Federation
         if: ${{ steps.auth_config.outputs.method == 'workload_identity' }}
@@ -79,7 +90,7 @@ jobs:
         with:
           workload_identity_provider: ${{ env.FIREBASE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.FIREBASE_SERVICE_ACCOUNT_EMAIL }}
-          project_id: ${{ env.FIREBASE_PROJECT_ID }}
+          project_id: ${{ steps.deploy_config.outputs.project_id }}
 
       - name: Setup gcloud SDK
         uses: google-github-actions/setup-gcloud@v3

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,7 +76,7 @@ firebase deploy --only firestore:indexes --project "$FIREBASE_PROJECT_ID"
 firebase deploy --only firestore:rules,storage --project "$FIREBASE_PROJECT_ID"
 ```
 
-The GitHub Actions workflow at `.github/workflows/deploy.yml` also deploys from `main` using the `deployed` GitHub environment. Required GitHub configuration includes `FIREBASE_PROJECT_ID` and one of these authentication options:
+The GitHub Actions workflow at `.github/workflows/deploy.yml` also deploys from `main` using the `deployed` GitHub environment. It resolves `FIREBASE_PROJECT_ID` from GitHub secrets or variables first, then falls back to the committed `deployed` alias in `.firebaserc`. Required GitHub authentication configuration is one of these options:
 
 - `FIREBASE_SERVICE_ACCOUNT_JSON`
 - `FIREBASE_WORKLOAD_IDENTITY_PROVIDER` plus `FIREBASE_SERVICE_ACCOUNT_EMAIL`


### PR DESCRIPTION
## Summary
- resolve the deploy workflow project ID from GitHub config when present
- fall back to the committed `.firebaserc` `deployed` alias when GitHub does not define `FIREBASE_PROJECT_ID`
- keep the workflow aligned with the repo's existing deployed Firebase configuration

## Why
The post-merge deploy run on commit `2996a66` failed because PR #194 merged before this follow-up commit existed. The merged workflow still required `FIREBASE_PROJECT_ID` to be present in GitHub config.

## Testing
- git diff --check
- parsed `.github/workflows/deploy.yml` with PyYAML
