### PR TITLE
Parse .firebaserc as JSON in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           project_id="$CONFIGURED_FIREBASE_PROJECT_ID"
           if [ -z "$project_id" ]; then
-            project_id="$(node -p "const config = require('./.firebaserc'); config.projects?.deployed || ''")"
+            project_id="$(node -e "const fs = require('node:fs'); const config = JSON.parse(fs.readFileSync('.firebaserc', 'utf8')); process.stdout.write(config.projects?.deployed || '')")"
           fi
           test -n "$project_id" || { echo "Set FIREBASE_PROJECT_ID in repository/environment secrets or variables, or define a deployed alias in .firebaserc."; exit 1; }
           echo "project_id=$project_id" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- fix the deploy workflow fallback that reads `.firebaserc`
- parse `.firebaserc` as JSON text instead of loading it through `require()`
- preserve the existing fallback to the committed `deployed` Firebase alias

## Why
The `Deploy Firebase` workflow on merged commit `b00bc53` failed in the `Resolve deployment configuration` step because `.firebaserc` is JSON, not CommonJS. Node 24 tried to parse it as JavaScript and threw a syntax error.

## Testing
- git diff --check
- parsed `.github/workflows/deploy.yml` with PyYAML
- executed the new Node command locally to read `.firebaserc`
