### PR TITLE
Unify Firebase deploy config handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,35 +5,37 @@ on:
     branches:
       - main
 
-env:
-  FRONTEND_URL: ${{ secrets.FRONTEND_URL || vars.FRONTEND_URL }}
-  FUNCTIONS_HEALTH_URL: ${{ secrets.FUNCTIONS_HEALTH_URL || vars.FUNCTIONS_HEALTH_URL }}
-  DEVICE_ACTIVATION_URL: ${{ secrets.DEVICE_ACTIVATION_URL }}
-  DEVICE_VERIFICATION_URI: ${{ secrets.DEVICE_VERIFICATION_URI }}
-  DEVICE_TOKEN_ISSUER: ${{ secrets.DEVICE_TOKEN_ISSUER }}
-  DEVICE_TOKEN_AUDIENCE: ${{ secrets.DEVICE_TOKEN_AUDIENCE }}
-  DEVICE_ACCESS_TOKEN_TTL_SECONDS: ${{ secrets.DEVICE_ACCESS_TOKEN_TTL_SECONDS }}
-  DEVICE_REGISTRATION_TOKEN_TTL_SECONDS: ${{ secrets.DEVICE_REGISTRATION_TOKEN_TTL_SECONDS }}
-  SMOKE_TEST_USER_EMAIL: ${{ secrets.SMOKE_TEST_USER_EMAIL }}
-  SMOKE_TEST_USER_EMAILS: ${{ secrets.SMOKE_TEST_USER_EMAILS }}
-  STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-  STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
-  VITE_API_BASE: ${{ secrets.VITE_API_BASE }}
-  VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
-  VITE_GOOGLE_MAP_ID: ${{ secrets.VITE_GOOGLE_MAP_ID }}
-  VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
-  VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
-  VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
-  VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
-  VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
-  VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
-
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     environment: deployed
     env:
+      FRONTEND_URL: ${{ secrets.FRONTEND_URL || vars.FRONTEND_URL }}
+      FUNCTIONS_HEALTH_URL: ${{ secrets.FUNCTIONS_HEALTH_URL || vars.FUNCTIONS_HEALTH_URL }}
+      PUBLIC_APP_BASE_URL: ${{ secrets.PUBLIC_APP_BASE_URL || vars.PUBLIC_APP_BASE_URL }}
+      DEVICE_ACTIVATION_URL: ${{ secrets.DEVICE_ACTIVATION_URL || vars.DEVICE_ACTIVATION_URL }}
+      DEVICE_VERIFICATION_URI: ${{ secrets.DEVICE_VERIFICATION_URI || vars.DEVICE_VERIFICATION_URI }}
+      DEVICE_TOKEN_ISSUER: ${{ secrets.DEVICE_TOKEN_ISSUER || vars.DEVICE_TOKEN_ISSUER }}
+      DEVICE_TOKEN_AUDIENCE: ${{ secrets.DEVICE_TOKEN_AUDIENCE || vars.DEVICE_TOKEN_AUDIENCE }}
+      DEVICE_ACCESS_TOKEN_TTL_SECONDS: ${{ secrets.DEVICE_ACCESS_TOKEN_TTL_SECONDS || vars.DEVICE_ACCESS_TOKEN_TTL_SECONDS }}
+      DEVICE_REGISTRATION_TOKEN_TTL_SECONDS: ${{ secrets.DEVICE_REGISTRATION_TOKEN_TTL_SECONDS || vars.DEVICE_REGISTRATION_TOKEN_TTL_SECONDS }}
+      SMOKE_TEST_USER_EMAIL: ${{ secrets.SMOKE_TEST_USER_EMAIL || vars.SMOKE_TEST_USER_EMAIL }}
+      SMOKE_TEST_USER_EMAILS: ${{ secrets.SMOKE_TEST_USER_EMAILS || vars.SMOKE_TEST_USER_EMAILS }}
+      DEVICE_TOKEN_PRIVATE_KEY: ${{ secrets.DEVICE_TOKEN_PRIVATE_KEY }}
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+      VITE_API_BASE: ${{ secrets.VITE_API_BASE || vars.VITE_API_BASE }}
+      VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY || vars.VITE_GOOGLE_MAPS_API_KEY }}
+      VITE_GOOGLE_MAP_ID: ${{ secrets.VITE_GOOGLE_MAP_ID || vars.VITE_GOOGLE_MAP_ID }}
+      VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY || vars.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN || vars.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID || vars.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET || vars.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID || vars.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID || vars.VITE_FIREBASE_APP_ID }}
+      VITE_SMOKE_TEST_USER_EMAIL: ${{ secrets.VITE_SMOKE_TEST_USER_EMAIL || vars.VITE_SMOKE_TEST_USER_EMAIL }}
+      VITE_SMOKE_TEST_USER_EMAILS: ${{ secrets.VITE_SMOKE_TEST_USER_EMAILS || vars.VITE_SMOKE_TEST_USER_EMAILS }}
       FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
       FIREBASE_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.FIREBASE_WORKLOAD_IDENTITY_PROVIDER || vars.FIREBASE_WORKLOAD_IDENTITY_PROVIDER }}
       FIREBASE_SERVICE_ACCOUNT_EMAIL: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EMAIL || vars.FIREBASE_SERVICE_ACCOUNT_EMAIL }}
@@ -72,30 +74,6 @@ jobs:
           echo "project_id=$project_id" >> "$GITHUB_OUTPUT"
           echo "FIREBASE_PROJECT_ID=$project_id" >> "$GITHUB_ENV"
 
-      - name: Write functions deploy env file
-        run: |
-          test -n "$STRIPE_SECRET_KEY" || { echo "Set STRIPE_SECRET_KEY in GitHub secrets."; exit 1; }
-          test -n "$STRIPE_WEBHOOK_SECRET" || { echo "Set STRIPE_WEBHOOK_SECRET in GitHub secrets."; exit 1; }
-
-          public_app_base_url="${FRONTEND_URL%/}"
-          test -n "$public_app_base_url" || { echo "Set FRONTEND_URL in GitHub variables or secrets."; exit 1; }
-
-          env_file="functions/.env.${FIREBASE_PROJECT_ID}"
-
-          {
-            [ -n "$DEVICE_ACTIVATION_URL" ] && printf 'DEVICE_ACTIVATION_URL=%s\n' "$DEVICE_ACTIVATION_URL"
-            [ -n "$DEVICE_VERIFICATION_URI" ] && printf 'DEVICE_VERIFICATION_URI=%s\n' "$DEVICE_VERIFICATION_URI"
-            [ -n "$DEVICE_TOKEN_ISSUER" ] && printf 'DEVICE_TOKEN_ISSUER=%s\n' "$DEVICE_TOKEN_ISSUER"
-            [ -n "$DEVICE_TOKEN_AUDIENCE" ] && printf 'DEVICE_TOKEN_AUDIENCE=%s\n' "$DEVICE_TOKEN_AUDIENCE"
-            [ -n "$DEVICE_ACCESS_TOKEN_TTL_SECONDS" ] && printf 'DEVICE_ACCESS_TOKEN_TTL_SECONDS=%s\n' "$DEVICE_ACCESS_TOKEN_TTL_SECONDS"
-            [ -n "$DEVICE_REGISTRATION_TOKEN_TTL_SECONDS" ] && printf 'DEVICE_REGISTRATION_TOKEN_TTL_SECONDS=%s\n' "$DEVICE_REGISTRATION_TOKEN_TTL_SECONDS"
-            [ -n "$SMOKE_TEST_USER_EMAIL" ] && printf 'SMOKE_TEST_USER_EMAIL=%s\n' "$SMOKE_TEST_USER_EMAIL"
-            [ -n "$SMOKE_TEST_USER_EMAILS" ] && printf 'SMOKE_TEST_USER_EMAILS=%s\n' "$SMOKE_TEST_USER_EMAILS"
-            printf 'PUBLIC_APP_BASE_URL=%s\n' "$public_app_base_url"
-            printf 'STRIPE_SECRET_KEY=%s\n' "$STRIPE_SECRET_KEY"
-            printf 'STRIPE_WEBHOOK_SECRET=%s\n' "$STRIPE_WEBHOOK_SECRET"
-          } > "$env_file"
-
       - name: Validate deployment authentication
         id: auth_config
         run: |
@@ -132,12 +110,63 @@ jobs:
       - name: Validate configuration
         run: |
           gcloud config set project "$FIREBASE_PROJECT_ID"
+          required_keys=(
+            FRONTEND_URL
+            VITE_API_BASE
+            VITE_GOOGLE_MAPS_API_KEY
+            VITE_GOOGLE_MAP_ID
+            VITE_FIREBASE_API_KEY
+            VITE_FIREBASE_AUTH_DOMAIN
+            VITE_FIREBASE_PROJECT_ID
+            VITE_FIREBASE_STORAGE_BUCKET
+            VITE_FIREBASE_MESSAGING_SENDER_ID
+            VITE_FIREBASE_APP_ID
+            DEVICE_TOKEN_PRIVATE_KEY
+            STRIPE_SECRET_KEY
+            STRIPE_WEBHOOK_SECRET
+          )
+          for key in "${required_keys[@]}"; do
+            if [ -z "${!key}" ]; then
+              echo "Set $key in GitHub secrets or variables before deploying." >&2
+              exit 1
+            fi
+          done
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools@15.5.1
 
       - name: Confirm Firebase target project
         run: firebase projects:list | grep "$FIREBASE_PROJECT_ID"
+
+      - name: Sync Firebase Functions secrets
+        run: |
+          printf '%s' "$DEVICE_TOKEN_PRIVATE_KEY" | firebase functions:secrets:set DEVICE_TOKEN_PRIVATE_KEY --project "$FIREBASE_PROJECT_ID" --data-file=-
+          printf '%s' "$STRIPE_SECRET_KEY" | firebase functions:secrets:set STRIPE_SECRET_KEY --project "$FIREBASE_PROJECT_ID" --data-file=-
+          printf '%s' "$STRIPE_WEBHOOK_SECRET" | firebase functions:secrets:set STRIPE_WEBHOOK_SECRET --project "$FIREBASE_PROJECT_ID" --data-file=-
+
+      - name: Write functions deploy env file
+        run: |
+          public_app_base_url="${PUBLIC_APP_BASE_URL%/}"
+          if [ -z "$public_app_base_url" ]; then
+            public_app_base_url="${FRONTEND_URL%/}"
+          fi
+          test -n "$public_app_base_url" || { echo "Set FRONTEND_URL or PUBLIC_APP_BASE_URL in GitHub variables or secrets."; exit 1; }
+
+          activation_url="${DEVICE_ACTIVATION_URL:-${public_app_base_url}/activate}"
+          verification_uri="${DEVICE_VERIFICATION_URI:-$activation_url}"
+          env_file="functions/.env.${FIREBASE_PROJECT_ID}"
+
+          {
+            printf 'DEVICE_ACTIVATION_URL=%s\n' "$activation_url"
+            printf 'DEVICE_VERIFICATION_URI=%s\n' "$verification_uri"
+            [ -n "$DEVICE_TOKEN_ISSUER" ] && printf 'DEVICE_TOKEN_ISSUER=%s\n' "$DEVICE_TOKEN_ISSUER"
+            [ -n "$DEVICE_TOKEN_AUDIENCE" ] && printf 'DEVICE_TOKEN_AUDIENCE=%s\n' "$DEVICE_TOKEN_AUDIENCE"
+            [ -n "$DEVICE_ACCESS_TOKEN_TTL_SECONDS" ] && printf 'DEVICE_ACCESS_TOKEN_TTL_SECONDS=%s\n' "$DEVICE_ACCESS_TOKEN_TTL_SECONDS"
+            [ -n "$DEVICE_REGISTRATION_TOKEN_TTL_SECONDS" ] && printf 'DEVICE_REGISTRATION_TOKEN_TTL_SECONDS=%s\n' "$DEVICE_REGISTRATION_TOKEN_TTL_SECONDS"
+            [ -n "$SMOKE_TEST_USER_EMAIL" ] && printf 'SMOKE_TEST_USER_EMAIL=%s\n' "$SMOKE_TEST_USER_EMAIL"
+            [ -n "$SMOKE_TEST_USER_EMAILS" ] && printf 'SMOKE_TEST_USER_EMAILS=%s\n' "$SMOKE_TEST_USER_EMAILS"
+            printf 'PUBLIC_APP_BASE_URL=%s\n' "$public_app_base_url"
+          } > "$env_file"
 
       - name: Lint
         run: corepack pnpm lint

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,6 @@ on:
 env:
   FRONTEND_URL: ${{ secrets.FRONTEND_URL || vars.FRONTEND_URL }}
   FUNCTIONS_HEALTH_URL: ${{ secrets.FUNCTIONS_HEALTH_URL || vars.FUNCTIONS_HEALTH_URL }}
-  DEVICE_TOKEN_PRIVATE_KEY: ${{ secrets.DEVICE_TOKEN_PRIVATE_KEY }}
   DEVICE_ACTIVATION_URL: ${{ secrets.DEVICE_ACTIVATION_URL }}
   DEVICE_VERIFICATION_URI: ${{ secrets.DEVICE_VERIFICATION_URI }}
   DEVICE_TOKEN_ISSUER: ${{ secrets.DEVICE_TOKEN_ISSUER }}
@@ -75,7 +74,6 @@ jobs:
 
       - name: Write functions deploy env file
         run: |
-          test -n "$DEVICE_TOKEN_PRIVATE_KEY" || { echo "Set DEVICE_TOKEN_PRIVATE_KEY in GitHub secrets."; exit 1; }
           test -n "$STRIPE_SECRET_KEY" || { echo "Set STRIPE_SECRET_KEY in GitHub secrets."; exit 1; }
           test -n "$STRIPE_WEBHOOK_SECRET" || { echo "Set STRIPE_WEBHOOK_SECRET in GitHub secrets."; exit 1; }
 
@@ -85,7 +83,6 @@ jobs:
           env_file="functions/.env.${FIREBASE_PROJECT_ID}"
 
           {
-            printf 'DEVICE_TOKEN_PRIVATE_KEY=%s\n' "$DEVICE_TOKEN_PRIVATE_KEY"
             [ -n "$DEVICE_ACTIVATION_URL" ] && printf 'DEVICE_ACTIVATION_URL=%s\n' "$DEVICE_ACTIVATION_URL"
             [ -n "$DEVICE_VERIFICATION_URI" ] && printf 'DEVICE_VERIFICATION_URI=%s\n' "$DEVICE_VERIFICATION_URI"
             [ -n "$DEVICE_TOKEN_ISSUER" ] && printf 'DEVICE_TOKEN_ISSUER=%s\n' "$DEVICE_TOKEN_ISSUER"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,7 +9,7 @@ This guide covers the single deployed Firebase environment. Use explicit project
 - Clean `main` checkout at the commit being released.
 - CI green or equivalent local checks passing.
 - Frontend environment values ready for the deployed Firebase project.
-- Functions runtime configuration ready, especially the `DEVICE_TOKEN_PRIVATE_KEY` Firebase secret.
+- Functions runtime configuration ready, especially the Firebase secrets used by deployed functions.
 - Stripe runtime values ready for node checkout: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, and a public app base URL.
 
 ```bash
@@ -45,9 +45,11 @@ For a new deployed Firebase project, verify these services before the first rele
 
 The functions code reads runtime values from `process.env`.
 
-Required deployed secret:
+Required deployed Firebase secrets:
 
 - `DEVICE_TOKEN_PRIVATE_KEY`: Ed25519 PKCS8 PEM used to sign device registration and access tokens.
+- `STRIPE_SECRET_KEY`: Stripe secret key for creating node checkout sessions.
+- `STRIPE_WEBHOOK_SECRET`: Stripe webhook signing secret for `checkout.session.completed`.
 
 Common optional values:
 
@@ -57,12 +59,11 @@ Common optional values:
 - `DEVICE_TOKEN_AUDIENCE`
 - `DEVICE_ACCESS_TOKEN_TTL_SECONDS`
 - `DEVICE_REGISTRATION_TOKEN_TTL_SECONDS`
+- `SMOKE_TEST_USER_EMAIL`
 - `SMOKE_TEST_USER_EMAILS`
 - `PUBLIC_APP_BASE_URL`
-- `STRIPE_SECRET_KEY`
-- `STRIPE_WEBHOOK_SECRET`
 
-Keep secrets out of git. `DEVICE_TOKEN_PRIVATE_KEY` is deployed as a Firebase Secret Manager secret and bound directly to the HTTP functions. The CI workflow writes only non-secret runtime env vars and the Stripe values into `functions/.env.$FIREBASE_PROJECT_ID`. Keep project-specific `.env.*` files local or in the deployment secret store.
+Keep secrets out of git. Deployed functions use Firebase Secret Manager for `DEVICE_TOKEN_PRIVATE_KEY`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET`. The CI workflow syncs those three secrets from GitHub Actions into Firebase, then writes only non-secret runtime env vars into `functions/.env.$FIREBASE_PROJECT_ID`. Keep project-specific `.env.*` files local or in the deployment secret store.
 
 ## Build And Deploy
 
@@ -70,6 +71,9 @@ Keep secrets out of git. `DEVICE_TOKEN_PRIVATE_KEY` is deployed as a Firebase Se
 pnpm install --frozen-lockfile
 pnpm lint
 pnpm build
+printf '%s' "$DEVICE_TOKEN_PRIVATE_KEY" | firebase functions:secrets:set DEVICE_TOKEN_PRIVATE_KEY --project "$FIREBASE_PROJECT_ID" --data-file=-
+printf '%s' "$STRIPE_SECRET_KEY" | firebase functions:secrets:set STRIPE_SECRET_KEY --project "$FIREBASE_PROJECT_ID" --data-file=-
+printf '%s' "$STRIPE_WEBHOOK_SECRET" | firebase functions:secrets:set STRIPE_WEBHOOK_SECRET --project "$FIREBASE_PROJECT_ID" --data-file=-
 firebase deploy --only hosting,functions --project "$FIREBASE_PROJECT_ID"
 ```
 
@@ -85,7 +89,14 @@ The GitHub Actions workflow at `.github/workflows/deploy.yml` also deploys from 
 - `FIREBASE_SERVICE_ACCOUNT_JSON`
 - `FIREBASE_WORKLOAD_IDENTITY_PROVIDER` plus `FIREBASE_SERVICE_ACCOUNT_EMAIL`
 
-For functions runtime config, the workflow now writes `functions/.env.$FIREBASE_PROJECT_ID` during CI from GitHub secrets plus `FRONTEND_URL`. That file should provide:
+For functions runtime config, the workflow now follows one model:
+
+- GitHub Actions secrets are the source of truth for Firebase function secrets.
+- CI syncs `DEVICE_TOKEN_PRIVATE_KEY`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET` into Firebase Secret Manager.
+- CI writes `functions/.env.$FIREBASE_PROJECT_ID` only for non-secret function env vars.
+- Frontend build config is resolved from GitHub secrets or variables.
+
+The generated `functions/.env.$FIREBASE_PROJECT_ID` file should provide:
 
 - `DEVICE_ACTIVATION_URL`
 - `DEVICE_VERIFICATION_URI`
@@ -95,10 +106,8 @@ For functions runtime config, the workflow now writes `functions/.env.$FIREBASE_
 - `DEVICE_REGISTRATION_TOKEN_TTL_SECONDS`
 - `SMOKE_TEST_USER_EMAIL` or `SMOKE_TEST_USER_EMAILS`
 - `PUBLIC_APP_BASE_URL`
-- `STRIPE_SECRET_KEY`
-- `STRIPE_WEBHOOK_SECRET`
 
-The `DEVICE_TOKEN_PRIVATE_KEY` secret must exist in Firebase Secret Manager and is referenced by the `secrets` option on `crowdpmApi` and `ingestGateway`.
+The three function secrets must exist in Firebase Secret Manager and are referenced by deployed functions through the `secrets` option.
 
 ## Post-Deploy Validation
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,7 +9,7 @@ This guide covers the single deployed Firebase environment. Use explicit project
 - Clean `main` checkout at the commit being released.
 - CI green or equivalent local checks passing.
 - Frontend environment values ready for the deployed Firebase project.
-- Functions runtime environment values ready, especially `DEVICE_TOKEN_PRIVATE_KEY`.
+- Functions runtime configuration ready, especially the `DEVICE_TOKEN_PRIVATE_KEY` Firebase secret.
 - Stripe runtime values ready for node checkout: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, and a public app base URL.
 
 ```bash
@@ -45,7 +45,7 @@ For a new deployed Firebase project, verify these services before the first rele
 
 The functions code reads runtime values from `process.env`.
 
-Required deployed value:
+Required deployed secret:
 
 - `DEVICE_TOKEN_PRIVATE_KEY`: Ed25519 PKCS8 PEM used to sign device registration and access tokens.
 
@@ -62,7 +62,7 @@ Common optional values:
 - `STRIPE_SECRET_KEY`
 - `STRIPE_WEBHOOK_SECRET`
 
-Keep secrets out of git. If using Firebase dotenv files for deploy-time environment variables, keep project-specific `.env.*` files local or in the deployment secret store. If migrating to Cloud Secret Manager-backed parameters, update the functions code to bind those secrets before relying on `firebase functions:secrets:set`.
+Keep secrets out of git. `DEVICE_TOKEN_PRIVATE_KEY` is deployed as a Firebase Secret Manager secret and bound directly to the HTTP functions. The CI workflow writes only non-secret runtime env vars and the Stripe values into `functions/.env.$FIREBASE_PROJECT_ID`. Keep project-specific `.env.*` files local or in the deployment secret store.
 
 ## Build And Deploy
 
@@ -87,7 +87,6 @@ The GitHub Actions workflow at `.github/workflows/deploy.yml` also deploys from 
 
 For functions runtime config, the workflow now writes `functions/.env.$FIREBASE_PROJECT_ID` during CI from GitHub secrets plus `FRONTEND_URL`. That file should provide:
 
-- `DEVICE_TOKEN_PRIVATE_KEY`
 - `DEVICE_ACTIVATION_URL`
 - `DEVICE_VERIFICATION_URI`
 - `DEVICE_TOKEN_ISSUER`
@@ -98,6 +97,8 @@ For functions runtime config, the workflow now writes `functions/.env.$FIREBASE_
 - `PUBLIC_APP_BASE_URL`
 - `STRIPE_SECRET_KEY`
 - `STRIPE_WEBHOOK_SECRET`
+
+The `DEVICE_TOKEN_PRIVATE_KEY` secret must exist in Firebase Secret Manager and is referenced by the `secrets` option on `crowdpmApi` and `ingestGateway`.
 
 ## Post-Deploy Validation
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -34,7 +34,7 @@ Important values:
 - `DEV_AUTH_USER_EMAIL`, `DEV_AUTH_USER_PASSWORD`, `DEV_AUTH_USER_DISPLAY_NAME`: local Auth emulator seed user.
 - `SMOKE_TEST_USER_EMAILS`: optional comma-separated allowlist for smoke-test routes.
 
-The code reads these values from `process.env`. In deployed Firebase Functions, `DEVICE_TOKEN_PRIVATE_KEY` is expected to come from Secret Manager via each function's `secrets` binding, while the remaining runtime values can come from dotenv-backed env files.
+The code reads these values from `process.env`. In deployed Firebase Functions, `DEVICE_TOKEN_PRIVATE_KEY`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET` are expected to come from Secret Manager via each function's `secrets` binding, while the remaining runtime values can come from dotenv-backed env files.
 
 ## API Surface
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -34,7 +34,7 @@ Important values:
 - `DEV_AUTH_USER_EMAIL`, `DEV_AUTH_USER_PASSWORD`, `DEV_AUTH_USER_DISPLAY_NAME`: local Auth emulator seed user.
 - `SMOKE_TEST_USER_EMAILS`: optional comma-separated allowlist for smoke-test routes.
 
-The code reads these values from `process.env`. Keep deployed secrets out of git and ensure the deploy process injects required runtime values.
+The code reads these values from `process.env`. In deployed Firebase Functions, `DEVICE_TOKEN_PRIVATE_KEY` is expected to come from Secret Manager via each function's `secrets` binding, while the remaining runtime values can come from dotenv-backed env files.
 
 ## API Surface
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -96,7 +96,7 @@ const apiSetup = (async () => {
   throw err;
 });
 
-export const crowdpmApi = https.onRequest({ cors: true }, (req, res) => {
+export const crowdpmApi = https.onRequest({ cors: true, secrets: ["DEVICE_TOKEN_PRIVATE_KEY"] }, (req, res) => {
   const requestWithRawBody = req as RequestWithRawBody;
   requestWithRawBody.rawBody = requestWithRawBody.rawBody ?? undefined;
   apiSetup.then(() => api.server.emit("request", req, res));

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -96,7 +96,10 @@ const apiSetup = (async () => {
   throw err;
 });
 
-export const crowdpmApi = https.onRequest({ cors: true, secrets: ["DEVICE_TOKEN_PRIVATE_KEY"] }, (req, res) => {
+export const crowdpmApi = https.onRequest({
+  cors: true,
+  secrets: ["DEVICE_TOKEN_PRIVATE_KEY", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
+}, (req, res) => {
   const requestWithRawBody = req as RequestWithRawBody;
   requestWithRawBody.rawBody = requestWithRawBody.rawBody ?? undefined;
   apiSetup.then(() => api.server.emit("request", req, res));

--- a/functions/src/services/ingestGateway.ts
+++ b/functions/src/services/ingestGateway.ts
@@ -111,6 +111,6 @@ export async function ingestGatewayHandler(
   }
 }
 
-export const ingestGateway = onRequest({ cors: true }, async (req, res) => {
+export const ingestGateway = onRequest({ cors: true, secrets: ["DEVICE_TOKEN_PRIVATE_KEY"] }, async (req, res) => {
   await ingestGatewayHandler(req as RequestWithRawBody, res as unknown as GatewayResponse);
 });


### PR DESCRIPTION
## Summary
- add the Stripe node checkout flow and purchase button work from the earlier branch
- unify deploy-time configuration so GitHub Actions is the source of truth for frontend config and Firebase Functions runtime config
- sync function secrets into Firebase Secret Manager during CI and keep generated dotenv files limited to non-secret values
- explicitly bind deploy-time secrets in function source to match the deployed runtime model

## Audit findings addressed
- remove the mixed secret/non-secret overlap that broke Functions deploys
- move deploy config resolution into the job environment so GitHub environment-scoped secrets and vars resolve consistently
- add required config validation for frontend build inputs and function secrets
- document the manual and CI deploy flows with the unified secret model

## Testing
- corepack pnpm lint
- corepack pnpm --filter crowdpm-functions build
- corepack pnpm --filter crowdpm-frontend build

Supersedes #199.