### PR TITLE
Add shipping and tax to node checkout

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,6 +40,7 @@ For a new deployed Firebase project, verify these services before the first rele
 - Firebase Auth sign-in providers required by the app are enabled.
 - Google Maps API key and vector map ID are configured for the deployed frontend.
 - Hosting site is attached to the intended Firebase project.
+- Stripe Tax is enabled in the Stripe account, with product tax behavior configured for US sales-tax collection.
 
 ## Runtime Configuration
 
@@ -120,6 +121,7 @@ Manual checks:
 
 - Open the deployed Hosting URL and confirm the app loads without console errors.
 - Sign in with a valid Firebase Auth user.
+- Start a node checkout and confirm Stripe Checkout only accepts US shipping addresses and shows tax added on top of the `$350` node price.
 - Run or replay one known ingest flow and confirm a `202` response.
 - Confirm raw storage under `ingest/<deviceId>/<batchId>.json`.
 - Confirm Firestore batch metadata and measurement rows were written.

--- a/frontend/src/pages/NodePage.tsx
+++ b/frontend/src/pages/NodePage.tsx
@@ -241,6 +241,10 @@ export default function NodePage() {
               records where and when the measurement happened, stores the reading
               locally, and uploads the data to CrowdPM when internet is available.
             </Text>
+            <Text size="2" mt="3" as="p">
+              Price: $350 per node with US shipping included. Sales tax is calculated
+              at checkout from the shipping address.
+            </Text>
           </Box>
 
           <Button
@@ -248,7 +252,7 @@ export default function NodePage() {
             onClick={() => { void handlePurchaseNode(); }}
             disabled={isStartingCheckout}
           >
-            {isStartingCheckout ? "Opening Checkout..." : "Purchase Node - Add to Cart"}
+            {isStartingCheckout ? "Opening Checkout..." : "Purchase Node - $350"}
           </Button>
         </Flex>
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -36,6 +36,8 @@ Important values:
 
 The code reads these values from `process.env`. In deployed Firebase Functions, `DEVICE_TOKEN_PRIVATE_KEY`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET` are expected to come from Secret Manager via each function's `secrets` binding, while the remaining runtime values can come from dotenv-backed env files.
 
+The node purchase flow now relies on Stripe Checkout shipping-address collection plus Stripe Tax. Configure Stripe Tax in the Stripe Dashboard so the physical-goods product can add US sales tax on top of the `$350` node price after the buyer enters a US shipping address.
+
 ## API Surface
 
 `crowdpmApi` is a Fastify app exported as an HTTPS Function:

--- a/functions/src/openapi.yaml
+++ b/functions/src/openapi.yaml
@@ -33,7 +33,9 @@ paths:
       summary: Create a Stripe Checkout session for node hardware
       description: >
         Creates a Stripe Checkout session for the one-time CrowdPM node hardware
-        purchase. The API lazily provisions the backing Stripe product + price
+        purchase. Checkout collects a US shipping address, applies Stripe Tax
+        based on that destination, and charges a $350 base price with shipping
+        included. The API lazily provisions the backing Stripe product + price
         the first time this route is used, then reuses the stored identifiers on
         later requests.
       security: []
@@ -56,8 +58,8 @@ paths:
       summary: Receive Stripe webhook events
       description: >
         Accepts Stripe webhook callbacks and records successful node purchase
-        sessions after verifying the `Stripe-Signature` header against the raw
-        request body.
+        sessions, including shipping details and calculated tax, after verifying
+        the `Stripe-Signature` header against the raw request body.
       security: []
       parameters:
         - in: header

--- a/functions/src/services/nodePurchase.ts
+++ b/functions/src/services/nodePurchase.ts
@@ -8,7 +8,12 @@ const CATALOG_DOC_ID = "nodeHardware";
 const SESSION_COLLECTION = "nodePurchaseSessions";
 const NODE_HARDWARE_PRODUCT_NAME = "CrowdPM Node Hardware";
 const NODE_HARDWARE_CURRENCY = "usd";
-const NODE_HARDWARE_UNIT_AMOUNT = 30000;
+const NODE_HARDWARE_UNIT_AMOUNT = 35000;
+const NODE_HARDWARE_PRODUCT_TAX_CODE = "txcd_99999999";
+const NODE_HARDWARE_PRICE_TAX_BEHAVIOR: Stripe.Price.TaxBehavior = "exclusive";
+const NODE_HARDWARE_ALLOWED_SHIPPING_COUNTRIES: Array<"US"> = ["US"];
+const NODE_HARDWARE_CHECKOUT_SUBMIT_MESSAGE = "Price includes US shipping. Applicable sales tax is calculated at checkout.";
+const NODE_HARDWARE_SHIPPING_ADDRESS_MESSAGE = "We currently ship CrowdPM nodes only to addresses in the United States.";
 const STRIPE_API_VERSION = "2026-04-22.dahlia";
 
 type NodeHardwareCatalog = {
@@ -16,6 +21,8 @@ type NodeHardwareCatalog = {
   defaultPriceId: string;
   currency: string;
   unitAmount: number;
+  taxCode: string;
+  taxBehavior: Stripe.Price.TaxBehavior;
 };
 
 export type NodePurchaseCheckoutSession = {
@@ -65,8 +72,18 @@ function readStoredCatalog(data: Record<string, unknown> | undefined): NodeHardw
   const defaultPriceId = typeof data?.defaultPriceId === "string" ? data.defaultPriceId.trim() : "";
   const currency = typeof data?.currency === "string" ? data.currency.trim().toLowerCase() : "";
   const unitAmount = typeof data?.unitAmount === "number" ? data.unitAmount : Number.NaN;
+  const taxCode = typeof data?.taxCode === "string" ? data.taxCode.trim() : "";
+  const taxBehavior = typeof data?.taxBehavior === "string" ? data.taxBehavior.trim() as Stripe.Price.TaxBehavior : "";
 
-  if (!productId || !defaultPriceId || !currency || !Number.isFinite(unitAmount) || unitAmount <= 0) {
+  if (
+    !productId
+    || !defaultPriceId
+    || !currency
+    || !Number.isFinite(unitAmount)
+    || unitAmount <= 0
+    || !taxCode
+    || (taxBehavior !== "exclusive" && taxBehavior !== "inclusive" && taxBehavior !== "unspecified")
+  ) {
     return null;
   }
 
@@ -75,12 +92,16 @@ function readStoredCatalog(data: Record<string, unknown> | undefined): NodeHardw
     defaultPriceId,
     currency,
     unitAmount,
+    taxCode,
+    taxBehavior,
   };
 }
 
 function isCurrentCatalog(catalog: NodeHardwareCatalog): boolean {
   return catalog.currency === NODE_HARDWARE_CURRENCY
-    && catalog.unitAmount === NODE_HARDWARE_UNIT_AMOUNT;
+    && catalog.unitAmount === NODE_HARDWARE_UNIT_AMOUNT
+    && catalog.taxCode === NODE_HARDWARE_PRODUCT_TAX_CODE
+    && catalog.taxBehavior === NODE_HARDWARE_PRICE_TAX_BEHAVIOR;
 }
 
 function checkoutRedirectUrls(): { successUrl: string; cancelUrl: string } {
@@ -88,6 +109,20 @@ function checkoutRedirectUrls(): { successUrl: string; cancelUrl: string } {
   return {
     successUrl: `${baseUrl}/node?checkout=success`,
     cancelUrl: `${baseUrl}/node?checkout=cancelled`,
+  };
+}
+
+function normalizeStripeAddress(address: Stripe.Address | null | undefined): Record<string, string | null> | null {
+  if (!address) {
+    return null;
+  }
+  return {
+    city: address.city ?? null,
+    country: address.country ?? null,
+    line1: address.line1 ?? null,
+    line2: address.line2 ?? null,
+    postalCode: address.postal_code ?? null,
+    state: address.state ?? null,
   };
 }
 
@@ -103,9 +138,12 @@ async function ensureNodeHardwareCatalog(): Promise<NodeHardwareCatalog> {
   try {
     product = await getStripeClient().products.create({
       name: NODE_HARDWARE_PRODUCT_NAME,
+      description: "Node hardware purchase with US shipping included.",
+      tax_code: NODE_HARDWARE_PRODUCT_TAX_CODE,
       default_price_data: {
         currency: NODE_HARDWARE_CURRENCY,
         unit_amount: NODE_HARDWARE_UNIT_AMOUNT,
+        tax_behavior: NODE_HARDWARE_PRICE_TAX_BEHAVIOR,
       },
     });
   }
@@ -126,6 +164,8 @@ async function ensureNodeHardwareCatalog(): Promise<NodeHardwareCatalog> {
     defaultPriceId,
     currency: NODE_HARDWARE_CURRENCY,
     unitAmount: NODE_HARDWARE_UNIT_AMOUNT,
+    taxCode: NODE_HARDWARE_PRODUCT_TAX_CODE,
+    taxBehavior: NODE_HARDWARE_PRICE_TAX_BEHAVIOR,
   };
 
   await ref.set({
@@ -150,6 +190,21 @@ export async function createNodePurchaseCheckoutSession(): Promise<NodePurchaseC
         },
       ],
       mode: "payment",
+      automatic_tax: {
+        enabled: true,
+      },
+      billing_address_collection: "required",
+      shipping_address_collection: {
+        allowed_countries: NODE_HARDWARE_ALLOWED_SHIPPING_COUNTRIES,
+      },
+      custom_text: {
+        shipping_address: {
+          message: NODE_HARDWARE_SHIPPING_ADDRESS_MESSAGE,
+        },
+        submit: {
+          message: NODE_HARDWARE_CHECKOUT_SUBMIT_MESSAGE,
+        },
+      },
       success_url: successUrl,
       cancel_url: cancelUrl,
     });
@@ -174,6 +229,7 @@ export async function createNodePurchaseCheckoutSession(): Promise<NodePurchaseC
     checkoutUrl: session.url,
     currency: session.currency ?? catalog.currency,
     unitAmount: catalog.unitAmount,
+    automaticTaxEnabled: true,
     amountSubtotal: session.amount_subtotal ?? null,
     amountTotal: session.amount_total ?? null,
     createdAt: new Date().toISOString(),
@@ -206,6 +262,7 @@ export async function handleStripeWebhook({ signature, rawBody }: StripeWebhookA
 
   if (event.type === "checkout.session.completed") {
     const session = event.data.object as Stripe.Checkout.Session;
+    const shippingDetails = session.collected_information?.shipping_details ?? null;
     await db().collection(SESSION_COLLECTION).doc(session.id).set({
       sessionId: session.id,
       status: "completed",
@@ -218,9 +275,20 @@ export async function handleStripeWebhook({ signature, rawBody }: StripeWebhookA
       currency: session.currency ?? null,
       amountSubtotal: session.amount_subtotal ?? null,
       amountTotal: session.amount_total ?? null,
+      amountDiscount: session.total_details?.amount_discount ?? null,
+      amountShipping: session.total_details?.amount_shipping ?? null,
+      amountTax: session.total_details?.amount_tax ?? null,
+      automaticTaxEnabled: session.automatic_tax?.enabled ?? null,
+      automaticTaxStatus: session.automatic_tax?.status ?? null,
       customerId: extractExpandableId(session.customer as string | { id: string } | null | undefined),
       customerEmail: session.customer_details?.email ?? session.customer_email ?? null,
       paymentIntentId: extractExpandableId(session.payment_intent as string | { id: string } | null | undefined),
+      shippingDetails: shippingDetails
+        ? {
+          name: shippingDetails.name ?? null,
+          address: normalizeStripeAddress(shippingDetails.address),
+        }
+        : null,
     }, { merge: true });
   }
 

--- a/functions/test/routes/nodePurchase.test.ts
+++ b/functions/test/routes/nodePurchase.test.ts
@@ -98,8 +98,8 @@ beforeEach(() => {
     url: "https://checkout.stripe.com/c/pay/cs_test_123",
     mode: "payment",
     currency: "usd",
-    amount_subtotal: 30000,
-    amount_total: 30000,
+    amount_subtotal: 35000,
+    amount_total: 35000,
   });
 });
 
@@ -130,9 +130,12 @@ describe("POST /v1/node-purchase/checkout-session", () => {
 
     expect(mocks.productsCreate).toHaveBeenCalledWith({
       name: "CrowdPM Node Hardware",
+      description: "Node hardware purchase with US shipping included.",
+      tax_code: "txcd_99999999",
       default_price_data: {
         currency: "usd",
-        unit_amount: 30000,
+        unit_amount: 35000,
+        tax_behavior: "exclusive",
       },
     });
     expect(mocks.checkoutSessionsCreate).toHaveBeenCalledWith({
@@ -143,6 +146,21 @@ describe("POST /v1/node-purchase/checkout-session", () => {
         },
       ],
       mode: "payment",
+      automatic_tax: {
+        enabled: true,
+      },
+      billing_address_collection: "required",
+      shipping_address_collection: {
+        allowed_countries: ["US"],
+      },
+      custom_text: {
+        shipping_address: {
+          message: "We currently ship CrowdPM nodes only to addresses in the United States.",
+        },
+        submit: {
+          message: "Price includes US shipping. Applicable sales tax is calculated at checkout.",
+        },
+      },
       success_url: "https://crowdpmplatform.web.app/node?checkout=success",
       cancel_url: "https://crowdpmplatform.web.app/node?checkout=cancelled",
     });
@@ -150,7 +168,9 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       productId: "prod_node_123",
       defaultPriceId: "price_node_123",
       currency: "usd",
-      unitAmount: 30000,
+      unitAmount: 35000,
+      taxCode: "txcd_99999999",
+      taxBehavior: "exclusive",
     });
     expect(dbStore.get("nodePurchaseSessions/cs_test_123")).toMatchObject({
       sessionId: "cs_test_123",
@@ -160,9 +180,10 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       mode: "payment",
       checkoutUrl: "https://checkout.stripe.com/c/pay/cs_test_123",
       currency: "usd",
-      unitAmount: 30000,
-      amountSubtotal: 30000,
-      amountTotal: 30000,
+      unitAmount: 35000,
+      automaticTaxEnabled: true,
+      amountSubtotal: 35000,
+      amountTotal: 35000,
     });
     await app.close();
   });
@@ -172,7 +193,9 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       productId: "prod_existing",
       defaultPriceId: "price_existing",
       currency: "usd",
-      unitAmount: 30000,
+      unitAmount: 35000,
+      taxCode: "txcd_99999999",
+      taxBehavior: "exclusive",
     });
     const app = await buildApp();
 
@@ -200,6 +223,8 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       defaultPriceId: "price_old",
       currency: "usd",
       unitAmount: 2000,
+      taxCode: "txcd_99999999",
+      taxBehavior: "exclusive",
     });
     const app = await buildApp();
 
@@ -222,7 +247,36 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       productId: "prod_node_123",
       defaultPriceId: "price_node_123",
       currency: "usd",
-      unitAmount: 30000,
+      unitAmount: 35000,
+      taxCode: "txcd_99999999",
+      taxBehavior: "exclusive",
+    });
+    await app.close();
+  });
+
+  it("recreates the Stripe catalog when the stored tax configuration is missing", async () => {
+    dbStore.set("paymentCatalog/nodeHardware", {
+      productId: "prod_old",
+      defaultPriceId: "price_old",
+      currency: "usd",
+      unitAmount: 35000,
+    });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/node-purchase/checkout-session",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.productsCreate).toHaveBeenCalledTimes(1);
+    expect(dbStore.get("paymentCatalog/nodeHardware")).toMatchObject({
+      productId: "prod_node_123",
+      defaultPriceId: "price_node_123",
+      currency: "usd",
+      unitAmount: 35000,
+      taxCode: "txcd_99999999",
+      taxBehavior: "exclusive",
     });
     await app.close();
   });
@@ -249,9 +303,31 @@ describe("POST /v1/payments/stripe/webhook", () => {
           },
           customer_email: "buyer@example.com",
           payment_intent: "pi_123",
+          automatic_tax: {
+            enabled: true,
+            status: "complete",
+          },
+          collected_information: {
+            shipping_details: {
+              name: "Buyer Example",
+              address: {
+                city: "Seattle",
+                country: "US",
+                line1: "123 Pike St",
+                line2: "Unit 4",
+                postal_code: "98101",
+                state: "WA",
+              },
+            },
+          },
+          total_details: {
+            amount_discount: 0,
+            amount_shipping: 0,
+            amount_tax: 3150,
+          },
           currency: "usd",
-          amount_subtotal: 30000,
-          amount_total: 30000,
+          amount_subtotal: 35000,
+          amount_total: 38150,
           url: null,
         },
       },
@@ -285,8 +361,24 @@ describe("POST /v1/payments/stripe/webhook", () => {
       customerEmail: "buyer@example.com",
       paymentIntentId: "pi_123",
       currency: "usd",
-      amountSubtotal: 30000,
-      amountTotal: 30000,
+      amountSubtotal: 35000,
+      amountTotal: 38150,
+      amountDiscount: 0,
+      amountShipping: 0,
+      amountTax: 3150,
+      automaticTaxEnabled: true,
+      automaticTaxStatus: "complete",
+      shippingDetails: {
+        name: "Buyer Example",
+        address: {
+          city: "Seattle",
+          country: "US",
+          line1: "123 Pike St",
+          line2: "Unit 4",
+          postalCode: "98101",
+          state: "WA",
+        },
+      },
     });
     await app.close();
   });


### PR DESCRIPTION
## Summary
- collect a US shipping address in Stripe Checkout for node hardware purchases
- raise the node price to 350 with shipping included and enable Stripe Tax with an exclusive physical-goods tax code
- persist shipping details and tax amounts from the completed checkout webhook, and update docs/tests/UI copy

## Testing
- pnpm --filter crowdpm-functions test -- nodePurchase
- pnpm --filter crowdpm-functions build
- pnpm build