### PR TITLE
Restrict smoke tests to super admins

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -92,9 +92,10 @@ The Functions emulator seeds `smoke-tester@crowdpm.dev` with password `crowdpm-d
 Use the web app first:
 
 1. Open `http://localhost:5173`.
-2. Sign in with the local smoke-test user.
-3. Open the Smoke Test Lab.
-4. Run a smoke test and confirm a batch appears on the map and in the dashboard.
+2. Grant `smoke-tester@crowdpm.dev` the `super_admin` role for local use if needed: `pnpm --filter crowdpm-functions admin:grant-role -- --email smoke-tester@crowdpm.dev --roles super_admin`
+3. Sign in with that super-admin account.
+4. Open the Smoke Test Lab from the User Dashboard.
+5. Run a smoke test and confirm a batch appears on the map and in the dashboard.
 
 Use the device emulator when testing pairing or DPoP behavior:
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -14,6 +14,3 @@ VITE_FIREBASE_APP_ID=1:1234567890:web:local1234567890
 # Optional: point Firebase Auth SDK at the local emulator when running `pnpm dev`.
 # Comment out to hit a hosted Firebase project instead.
 VITE_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
-
-VITE_SMOKE_TEST_USER_EMAIL=smoke-tester@crowdpm.dev
-# VITE_SMOKE_TEST_USER_EMAILS=smoke-tester@crowdpm.dev,other-user@example.com

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,11 +34,6 @@ Local-only value:
 
 - `VITE_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099`
 
-Optional smoke-test values:
-
-- `VITE_SMOKE_TEST_USER_EMAIL`
-- `VITE_SMOKE_TEST_USER_EMAILS`
-
 Vite reads environment variables at startup, so restart the dev server after changing `.env.local`.
 
 ## Structure

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,13 +22,6 @@ import {
 } from "@radix-ui/themes";
 import { GitHubLogoIcon, HamburgerMenuIcon, LinkedInLogoIcon } from "@radix-ui/react-icons";
 
-const rawSmokeTestEmails = import.meta.env.VITE_SMOKE_TEST_USER_EMAILS
-  ?? import.meta.env.VITE_SMOKE_TEST_USER_EMAIL
-  ?? "smoke-tester@crowdpm.dev";
-const SMOKE_TEST_EMAILS = parseSmokeTestEmails(
-  typeof rawSmokeTestEmails === "string" ? rawSmokeTestEmails : String(rawSmokeTestEmails)
-);
-
 const TEAM_MEMBERS: Array<{
   name: string;
   role: string;
@@ -122,11 +115,7 @@ export default function App() {
   const [pendingSmokeCleanup, setPendingSmokeCleanup] = useState<IngestSmokeTestCleanupResponse | null>(null);
 
   const isSignedIn = Boolean(user);
-  const isSmokeTestAccount = (() => {
-    const email = user?.email;
-    return typeof email === "string" && email.length > 0 && isSmokeTestEmail(email);
-  })();
-  const canUseSmokeTests = Boolean(user) && (isSmokeTestAccount || isSuperAdmin);
+  const canUseSmokeTests = Boolean(user) && isSuperAdmin;
   const canUseAdmin = Boolean(user) && (isModerator || isSuperAdmin);
   const activeTab = !isSignedIn && tab !== "map" && tab !== "pairing-info" && tab !== "about" && tab !== "node"
     ? "map"
@@ -442,15 +431,6 @@ export default function App() {
                 >
                   User Dashboard
                 </DropdownMenu.Item>
-                {canUseSmokeTests ? (
-                  <DropdownMenu.Item
-                    onSelect={() => handleProtectedTabClick("smoke")}
-                    style={activeTab === "smoke" ? { fontWeight: 600 } : undefined}
-                    disabled={isLoading}
-                  >
-                    Smoke Test
-                  </DropdownMenu.Item>
-                ) : null}
                 {canUseAdmin ? (
                   <DropdownMenu.Item
                     onSelect={() => handleProtectedTabClick("admin")}
@@ -527,6 +507,7 @@ export default function App() {
                     <UserDashboard
                       key={`dashboard:${userScopedKey}`}
                       onRequestActivation={openActivationModal}
+                      onOpenSmokeTest={canUseSmokeTests ? (() => handleProtectedTabClick("smoke")) : undefined}
                       onOpenThemeModal={openThemeModal}
                       refreshToken={dashboardRefreshToken}
                     />
@@ -554,8 +535,7 @@ export default function App() {
                     >
                       <Heading size="5">Sign in to access CrowdPM</Heading>
                       <Text size="2" color="gray" style={{ maxWidth: 360 }}>
-                        Log in to explore the CrowdPM map, run smoke tests, review batches, and access the coordination
-                        resources.
+                        Log in to explore the CrowdPM map, review batches, and access the coordination resources.
                       </Text>
                     </Flex>
                   )}
@@ -578,17 +558,6 @@ export default function App() {
       </Suspense>
     </Theme>
   );
-}
-
-function parseSmokeTestEmails(raw: string): string[] {
-  return raw.split(",")
-    .map((value) => value.trim().toLowerCase())
-    .filter((value) => value.length > 0);
-}
-
-function isSmokeTestEmail(email: string): boolean {
-  const normalized = email.trim().toLowerCase();
-  return normalized.length > 0 && SMOKE_TEST_EMAILS.includes(normalized);
 }
 
 type ActivationModalProps = {

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Badge, Box, Button, Callout, Card, Flex, Heading, SegmentedControl, Select, Separator, Switch, Table, Text, TextField } from "@radix-ui/themes";
+import { Badge, Box, Button, Callout, Card, Flex, Heading, Link, SegmentedControl, Select, Separator, Switch, Table, Text, TextField } from "@radix-ui/themes";
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { timestampToMillis } from "@crowdpm/types";
 import { InternalNewTabAnchor } from "../components/InternalLink";
@@ -22,6 +22,7 @@ import { clampPageIndex, getPaginationWindow, ResultCountControl } from "../comp
 
 type UserDashboardProps = {
   onRequestActivation: () => void;
+  onOpenSmokeTest?: () => void;
   onOpenThemeModal: () => void;
   refreshToken?: number;
 };
@@ -34,7 +35,7 @@ function describeStatus(status?: string | null): { label: string; tone: "green" 
   return { label: status ?? "Unknown", tone: "red" };
 }
 
-export default function UserDashboard({ onRequestActivation, onOpenThemeModal, refreshToken = 0 }: UserDashboardProps) {
+export default function UserDashboard({ onRequestActivation, onOpenSmokeTest, onOpenThemeModal, refreshToken = 0 }: UserDashboardProps) {
   const { user } = useAuth();
   const { settings, isLoading: isSettingsLoading, isSaving: isSettingsSaving, error: settingsError, updateSettings } = useUserSettings();
   const [devices, setDevices] = useState<DeviceSummary[]>([]);
@@ -351,6 +352,21 @@ export default function UserDashboard({ onRequestActivation, onOpenThemeModal, r
               <InternalNewTabAnchor href={APP_ROUTES.pairingGuide}>How does pairing work?</InternalNewTabAnchor>
             </Button>
           </Flex>
+          {onOpenSmokeTest ? (
+            <Text size="2" color="gray">
+              Super admins can also{" "}
+              <Link
+                href="#"
+                onClick={(event) => {
+                  event.preventDefault();
+                  onOpenSmokeTest();
+                }}
+              >
+                open the Smoke Test Lab
+              </Link>
+              {" "}from here.
+            </Text>
+          ) : null}
         </Flex>
       </Card>
 

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -11,5 +11,3 @@ STRIPE_WEBHOOK_SECRET=whsec_replace_with_stripe_webhook_secret
 DEV_AUTH_USER_EMAIL=smoke-tester@crowdpm.dev
 DEV_AUTH_USER_PASSWORD=crowdpm-dev
 DEV_AUTH_USER_DISPLAY_NAME=CrowdPM Smoke Tester
-SMOKE_TEST_USER_EMAIL=smoke-tester@crowdpm.dev
-SMOKE_TEST_USER_EMAILS=smoke-tester@crowdpm.dev

--- a/functions/README.md
+++ b/functions/README.md
@@ -32,7 +32,6 @@ Important values:
 - `STRIPE_SECRET_KEY`: Stripe secret key for creating the node hardware Checkout session.
 - `STRIPE_WEBHOOK_SECRET`: Stripe webhook signing secret for `checkout.session.completed`.
 - `DEV_AUTH_USER_EMAIL`, `DEV_AUTH_USER_PASSWORD`, `DEV_AUTH_USER_DISPLAY_NAME`: local Auth emulator seed user.
-- `SMOKE_TEST_USER_EMAILS`: optional comma-separated allowlist for smoke-test routes.
 
 The code reads these values from `process.env`. In deployed Firebase Functions, `DEVICE_TOKEN_PRIVATE_KEY`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET` are expected to come from Secret Manager via each function's `secrets` binding, while the remaining runtime values can come from dotenv-backed env files.
 

--- a/functions/src/services/ingestSmokeTestService.ts
+++ b/functions/src/services/ingestSmokeTestService.ts
@@ -45,46 +45,12 @@ type ResolvedDependencies = {
 export type SmokeTestServiceDependencies = Partial<ResolvedDependencies>;
 
 export function authorizeSmokeTestUser(user: DecodedIdToken): void {
-  if (isSmokeTestEmail(user)) return;
   if (hasRole(user, "super_admin")) return;
-  const roles = extractRoles(user);
-  const allowedRoles = new Set(["smoke-test", "smoke_test", "smoketester"]);
-  const hasAllowedRole = roles.some((role) => allowedRoles.has(role.toLowerCase()));
-  if (hasAllowedRole) return;
   throw new SmokeTestServiceError("forbidden", "Caller lacks permission to run smoke tests", 403);
 }
 
 function defaultAuthorizeSmokeTest(user: DecodedIdToken): void {
   authorizeSmokeTestUser(user);
-}
-
-const SMOKE_TEST_EMAILS = normalizeEmails(
-  process.env.SMOKE_TEST_USER_EMAILS
-  ?? process.env.SMOKE_TEST_USER_EMAIL
-  ?? process.env.DEV_AUTH_USER_EMAIL
-  ?? "smoke-tester@crowdpm.dev"
-);
-
-function normalizeEmails(raw: string): Set<string> {
-  return new Set(
-    raw.split(",")
-      .map((value) => value.trim().toLowerCase())
-      .filter((value) => value.length > 0)
-  );
-}
-
-function isSmokeTestEmail(user: DecodedIdToken): boolean {
-  const email = (user as { email?: unknown }).email;
-  if (typeof email !== "string") return false;
-  return SMOKE_TEST_EMAILS.has(email.trim().toLowerCase());
-}
-
-function extractRoles(user: DecodedIdToken): string[] {
-  const rawRoles = (user as { roles?: unknown }).roles;
-  if (!Array.isArray(rawRoles)) return [];
-  return rawRoles
-    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
-    .map((value) => value.trim());
 }
 
 export class IngestSmokeTestService {

--- a/functions/test/routes/admin.test.ts
+++ b/functions/test/routes/admin.test.ts
@@ -187,7 +187,7 @@ describe("POST /v1/admin/ingest-smoke-test", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/admin/ingest-smoke-test",
-      headers: { authorization: "Bearer smoke" },
+      headers: { authorization: "Bearer admin" },
       payload: { payload: { points: [] } },
     });
 
@@ -223,7 +223,7 @@ describe("POST /v1/admin/ingest-smoke-test", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/admin/ingest-smoke-test",
-      headers: { authorization: "Bearer smoke" },
+      headers: { authorization: "Bearer admin" },
       payload: { payload: { points: [] } },
     });
 

--- a/functions/test/services/ingestSmokeTestService.test.ts
+++ b/functions/test/services/ingestSmokeTestService.test.ts
@@ -142,10 +142,18 @@ describe("authorizeSmokeTestUser", () => {
     } as unknown as Parameters<typeof authorizeSmokeTestUser>[0])).not.toThrow();
   });
 
-  it("rejects users without smoke-test or super-admin privileges", () => {
+  it("rejects users without super-admin privileges", () => {
     expect(() => authorizeSmokeTestUser({
       uid: "user-1",
       roles: ["moderator"],
+    } as unknown as Parameters<typeof authorizeSmokeTestUser>[0])).toThrow(SmokeTestServiceError);
+  });
+
+  it("rejects legacy smoke-test accounts without super-admin claims", () => {
+    expect(() => authorizeSmokeTestUser({
+      uid: "smoke-1",
+      email: "smoke-tester@crowdpm.dev",
+      roles: ["smoke-test"],
     } as unknown as Parameters<typeof authorizeSmokeTestUser>[0])).toThrow(SmokeTestServiceError);
   });
 });


### PR DESCRIPTION
## Summary
- restrict smoke test access to super admins in the frontend and backend
- move the Smoke Test entry out of the hamburger menu into the User Dashboard Add a device card
- remove obsolete smoke-test allowlist env/docs references and update local smoke-test instructions

## Testing
- pnpm lint
- pnpm --filter crowdpm-frontend build
- pnpm --filter crowdpm-functions build
- pnpm --filter crowdpm-functions test -- --run test/services/ingestSmokeTestService.test.ts test/routes/admin.test.ts