### PR TITLE
Add node sensor product variants and pricing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -413,7 +413,7 @@ export default function App() {
               style={activeTab === "node" ? { fontWeight: 600 } : undefined}
               disabled={isLoading}
             >
-              Node
+              Products
             </DropdownMenu.Item>
             <DropdownMenu.Item
               onSelect={() => setTab("about")}

--- a/frontend/src/components/LegalDocumentDialog.tsx
+++ b/frontend/src/components/LegalDocumentDialog.tsx
@@ -158,8 +158,9 @@ function TermsOfService() {
       <Section title="3. Node Hardware Purchases">
         <P>
           CrowdPM node hardware is sold by {COMPANY_NAME}. Node purchases are one-time hardware
-          purchases processed through Stripe Checkout. The listed node price is $350 per node with
-          standard US shipping included; applicable sales tax is calculated during checkout from the
+          purchases processed through Stripe Checkout. The base node price is $350 with standard US
+          shipping included, and optional sensor add-ons increase the one-time hardware price for
+          the selected configuration. Applicable sales tax is calculated during checkout from the
           shipping address.
         </P>
         <P>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -135,13 +135,21 @@ export type CheckoutRedirectSession = {
   url: string;
 };
 
+export type NodePurchaseVariantId = "standard" | "co2" | "no2" | "co2_no2";
+
 export async function listDevices(): Promise<DeviceSummary[]> {
   return requestJson<DeviceSummary[]>("/v1/devices");
 }
 
-export async function createNodePurchaseCheckoutSession(): Promise<CheckoutRedirectSession> {
+export async function createNodePurchaseCheckoutSession(
+  variantId: NodePurchaseVariantId = "standard",
+): Promise<CheckoutRedirectSession> {
   return requestJson<CheckoutRedirectSession>("/v1/node-purchase/checkout-session", {
     method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ variantId }),
   });
 }
 

--- a/frontend/src/pages/NodePage.tsx
+++ b/frontend/src/pages/NodePage.tsx
@@ -27,6 +27,21 @@ type TableProps = {
   rows: ReactNode[][];
 };
 
+type NodeProductVariantId = "standard" | "co2" | "no2" | "co2_no2";
+
+type NodeProductVariant = {
+  id: NodeProductVariantId;
+  label: string;
+  summary: string;
+  addedHardware: string;
+  addOnAmountCents: number;
+  totalAmountCents: number;
+};
+
+const BASE_NODE_PRICE_CENTS = 35_000;
+const CO2_SENSOR_ADD_ON_CENTS = 2_899;
+const NO2_SENSOR_ADD_ON_CENTS = 2_695 + 699;
+
 const ZERO_2_W_URL = "https://www.amazon.com/Raspberry-Heatsink-Adapter-Quad-core-Bluetooth/dp/B0DRRDJKDV?crid=3VRASN6F43J3I&dib=eyJ2IjoiMSJ9.t-BTW30Tluhki6lWlHIi2rulYzLQMAGFk2OvRz-XBQTYgqnJ_G_aL00we8CvIVnKwG2Qc75itVV_M0bpyBUc5YG3r7ovACXMTrtlMTUUnZBffQIiEHNn3Yqk-Chei1tyWsoAB2tTea-NTY83Z_QJUq5-3JfgkUiz0PjutePcLmnkuMuu_IWzavyrhKUNrUjTEI8BgTUNhwVf1epqDu2ahFmxjLDI5xaFLi5SgdjHoeg.dYFNm35Nc1V43vvTuZ8pC5dQ-abvmafEYOYXJh8E5Ss&dib_tag=se&keywords=raspberry%2Bpi%2Bzero%2B2%2Bw&qid=1778398787&sprefix=Raspberry%2BPi%2BZero%2B2%2BW%2Caps%2C178&sr=8-2-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1&linkCode=ll2&tag=lipbalm01-20&linkId=35363b709757db3d01baa6b973c52a01&language=en_US&ref_=as_li_ss_tl";
 const PMS5003_URL = "https://www.amazon.com/BestParts-Digital-Particle-Concentration-PMS5003/dp/B0B1DQKV4N?crid=2CSK1VIYBL9LN&dib=eyJ2IjoiMSJ9.98U0BdlWh4vmYk-feCR0PmZpSTwOza-Io1F0J5aEYxt-Atifz_ulAtN2MSfswsFSwZAY5G94uyuiJwZQ1pJEgEFX1HBloSTDsFit2N07xKk13LTq4uwQ5LAGvFMMuUeWH2nLcVwe2SqFNb96Kn75VRFoIWku34vnGX3ryzbO4xgpcNSnNDH7QmqgRqu-KYCsnv1gNizUAnlnmoc22RpGTvxNFB4H45LOk2Hf_kqlcO8.l0Rt1mD9IbbwGvgp5ZFUzZgF46xGdPN76S6jbwz8CLE&dib_tag=se&keywords=Plantower+PMS5003&qid=1778398886&sprefix=plantower+pms5003%2Caps%2C225&sr=8-4&linkCode=ll2&tag=lipbalm01-20&linkId=7eb62de9f07d2cf0f66b47bb7349e0db&language=en_US&ref_=as_li_ss_tl";
 const DHT22_URL = "https://www.amazon.com/dp/B0DSW7D3S9?th=1&linkCode=ll2&tag=lipbalm01-20&linkId=8a2b4c580bdeb37c7affe8f834a72a28&language=en_US&ref_=as_li_ss_tl";
@@ -36,6 +51,53 @@ const USB_TO_TTL_URL = "https://www.amazon.com/dp/B0G61569JG?th=1&linkCode=ll2&t
 const OTG_ADAPTER_URL = "https://www.amazon.com/dp/B015GZLG8I?th=1&linkCode=ll2&tag=lipbalm01-20&linkId=d31fc458d54c90c0e3a7ef69edccad08&language=en_US&ref_=as_li_ss_tl";
 const LINE_CABLES_URL = "https://www.amazon.com/dp/B08YRGVYPV?th=1&linkCode=ll2&tag=lipbalm01-20&linkId=0e64e274f6524982c4806f74982744e0&language=en_US&ref_=as_li_ss_tl";
 const PISUGAR_3_PLUS_URL = "https://www.amazon.com/PiSugar-Plus-Pwnagotchi-Management-Raspberry/dp/B0FBK89B8H?crid=LFBH2KAF10OE&dib=eyJ2IjoiMSJ9.L0Ud_TUpDnpSJdO5W3nbRsP6KDdvl9mBzCTXI1Wgu8N8TErLSyNRjB761bzndZGqn8-A8kN77bnyCNm25h_AtH8fbGcUDaW2gupHScAfR8t7ylwXTTgwRxWWtJXzMZ6r4ew80IZaX6eRtLnMMl14zg.0HpvF_Oc66MzhahEEWzs9yCISfYWDvDd3YIgQQlW6BQ&dib_tag=se&keywords=PiSugar2+Plus+5000+mAh&qid=1778400315&s=electronics&sprefix=pisugar2+plus+5000+mah%2Celectronics%2C161&sr=1-3&linkCode=ll2&tag=lipbalm01-20&linkId=c7d788c8d0b545684e272d2ae0c677cf&language=en_US&ref_=as_li_ss_tl";
+const CO2_SENSOR_URL = "https://www.amazon.com/HiLetgo-Temperature-Humidity-Communication-Monitoring/dp/B0CDWXWCS5?psc=1&pd_rd_w=blPda&content-id=amzn1.sym.e7d77f83-4d42-48ed-825c-e0597e1533d7&pf_rd_p=e7d77f83-4d42-48ed-825c-e0597e1533d7&pf_rd_r=59515EY9GQNTR9T545T5&pd_rd_wg=8fbmW&pd_rd_r=74728aef-4573-4948-b457-68178961b213&sp_csd=d2lkZ2V0TmFtZT1zcF9kZXRhaWxfdGhlbWF0aWM%3D&linkCode=ll2&tag=lipbalm01-20&linkId=ea274a4ca23462d3503110f5d7ac5e4f&language=en_US&ref_=as_li_ss_tl";
+const NO2_SENSOR_URL = "https://www.amazon.com/dp/B0BG2YZP5L?&linkCode=ll2&tag=lipbalm01-20&linkId=6bbc3169ef4e30f4e28a1ea88660826b&language=en_US&ref_=as_li_ss_tl";
+const ADS1115_URL = "https://www.amazon.com/ADS1115-4-Channel-Converter-Arduino-Raspberry/dp/B0FLNDLX8K?crid=3RYX9FG87U6CM&dib=eyJ2IjoiMSJ9.vSXpQFCIOGW8Td7egqghItKea7rWhgp1u88Hzd4_30ya41b80qvopTqt3nuXewJ-SJaiqILg_eRk14OZIhExEVDLoudgGQxwK3jhWd3XiCOz7cdguU674-vANvudUPOfYFBAcCd16OGBGkvGHNFvB-b_Pboa5cdXyi5LdZc22Le5DO0pwdY0HJEkVrt37HJJeTtz0D8L421WubLPedN57g.BK5SdzZVxNfpMmMqtuSJL_oKs1QRxyNdLfNicsYlwZA&dib_tag=se&keywords=ADS1115&qid=1778541032&sprefix=ads1115%2Caps%2C416&xpid=wwbj2redDMdny&linkCode=ll2&tag=lipbalm01-20&linkId=ba8f1b74761bdb64217b8ea538d62d01&language=en_US&ref_=as_li_ss_tl";
+
+const NODE_PRODUCT_VARIANTS: NodeProductVariant[] = [
+  {
+    id: "standard",
+    label: "PM2.5 standard node",
+    summary: "Current shipped build with PMS5003, GPS, temperature/humidity, local storage, and battery management.",
+    addedHardware: "No additional gas sensor hardware",
+    addOnAmountCents: 0,
+    totalAmountCents: BASE_NODE_PRICE_CENTS,
+  },
+  {
+    id: "no2",
+    label: "PM2.5 + NO2 node",
+    summary: "Adds a MiCS-6814 NO2 / vehicle-exhaust module and an ADS1115 ADC for Pi-compatible readout.",
+    addedHardware: "MiCS-6814 NO2 module + ADS1115 ADC",
+    addOnAmountCents: NO2_SENSOR_ADD_ON_CENTS,
+    totalAmountCents: BASE_NODE_PRICE_CENTS + NO2_SENSOR_ADD_ON_CENTS,
+  },
+  {
+    id: "co2",
+    label: "PM2.5 + CO2 node",
+    summary: "Adds an SCD41 CO2 sensor that also reports temperature and humidity over I2C.",
+    addedHardware: "SCD41 CO2 sensor",
+    addOnAmountCents: CO2_SENSOR_ADD_ON_CENTS,
+    totalAmountCents: BASE_NODE_PRICE_CENTS + CO2_SENSOR_ADD_ON_CENTS,
+  },
+  {
+    id: "co2_no2",
+    label: "PM2.5 + CO2 + NO2 node",
+    summary: "Combines the CO2 add-on with the NO2 / car-exhaust add-on in one mobile node.",
+    addedHardware: "SCD41 CO2 sensor + MiCS-6814 NO2 module + ADS1115 ADC",
+    addOnAmountCents: CO2_SENSOR_ADD_ON_CENTS + NO2_SENSOR_ADD_ON_CENTS,
+    totalAmountCents: BASE_NODE_PRICE_CENTS + CO2_SENSOR_ADD_ON_CENTS + NO2_SENSOR_ADD_ON_CENTS,
+  },
+];
+
+const USD_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+});
+
+function formatUsd(cents: number): string {
+  return USD_FORMATTER.format(cents / 100);
+}
 
 function Section({ title, children }: SectionProps) {
   return (
@@ -207,6 +269,8 @@ export default function NodePage() {
   const [checkoutError, setCheckoutError] = useState("");
   const [checkoutNotice, setCheckoutNotice] = useState<CheckoutNotice>(readCheckoutNotice);
   const [openLegalDocument, setOpenLegalDocument] = useState<LegalDocumentId | null>(null);
+  const [selectedVariantId, setSelectedVariantId] = useState<NodeProductVariantId>("standard");
+  const selectedVariant = NODE_PRODUCT_VARIANTS.find(({ id }) => id === selectedVariantId) ?? NODE_PRODUCT_VARIANTS[0];
 
   useEffect(() => {
     setCheckoutNotice(readCheckoutNotice());
@@ -216,7 +280,7 @@ export default function NodePage() {
     setCheckoutError("");
     setIsStartingCheckout(true);
     try {
-      const session = await createNodePurchaseCheckoutSession();
+      const session = await createNodePurchaseCheckoutSession(selectedVariant.id);
       window.location.assign(session.url);
       return;
     }
@@ -242,31 +306,86 @@ export default function NodePage() {
         >
           <Box style={{ maxWidth: "46rem" }}>
             <Heading as="h1" size="5">
-              CrowdPM Node Hardware
+              Products - CrowdPM Node Hardware
             </Heading>
             <Text size="3" color="gray" mt="2" as="p">
               A CrowdPM node is a small air-quality computer that measures PM2.5,
               records where and when the measurement happened, stores the reading
               locally, and uploads the data to CrowdPM when internet is available.
+              Multiple product options are available: the current PM2.5 build, a
+              CO2 add-on build, a NO2 car-exhaust build, and a combined CO2 + NO2
+              build.
             </Text>
             <Text size="2" mt="3" as="p">
-              Price: $350 per node with US shipping included. Sales tax is calculated
+              Base price starts at {formatUsd(BASE_NODE_PRICE_CENTS)} per node with
+              US shipping included. The add-on sensor options below use the current
+              Amazon hardware prices listed on this page, and sales tax is calculated
               at checkout from the shipping address.
             </Text>
           </Box>
 
-          <Flex direction="column" gap="2" style={{ maxWidth: "19rem" }}>
+          <Flex direction="column" gap="2" style={{ maxWidth: "23rem", width: "100%" }}>
+            {NODE_PRODUCT_VARIANTS.map((variant) => {
+              const isSelected = variant.id === selectedVariant.id;
+              return (
+                <Card
+                  key={variant.id}
+                  style={{
+                    padding: 0,
+                    border: isSelected ? "1px solid var(--accent-8)" : "1px solid var(--gray-a5)",
+                    background: isSelected ? "var(--accent-a3)" : "var(--color-surface)",
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setSelectedVariantId(variant.id)}
+                    aria-pressed={isSelected}
+                    style={{
+                      all: "unset",
+                      boxSizing: "border-box",
+                      cursor: "pointer",
+                      display: "block",
+                      width: "100%",
+                      padding: "0.875rem",
+                    }}
+                  >
+                    <Flex align="start" justify="between" gap="3">
+                      <Box>
+                        <Text size="2" as="div" style={{ fontWeight: 600 }}>
+                          {variant.label}
+                        </Text>
+                        <Text size="1" color="gray" as="p" mt="1">
+                          {variant.summary}
+                        </Text>
+                      </Box>
+                      <Text size="2" as="span" style={{ fontWeight: 600, whiteSpace: "nowrap" }}>
+                        {formatUsd(variant.totalAmountCents)}
+                      </Text>
+                    </Flex>
+                  </button>
+                </Card>
+              );
+            })}
+
+            <Text size="2" as="p">
+              Selected price: {formatUsd(selectedVariant.totalAmountCents)}.
+              {" "}This option adds {formatUsd(selectedVariant.addOnAmountCents)} over the
+              {" "}{formatUsd(BASE_NODE_PRICE_CENTS)} base node.
+            </Text>
             <Button
               size="3"
               onClick={() => { void handlePurchaseNode(); }}
               disabled={isStartingCheckout}
             >
-              {isStartingCheckout ? "Opening Checkout..." : "Purchase Node - $350"}
+              {isStartingCheckout
+                ? "Opening Checkout..."
+                : `Purchase Selected Product - ${formatUsd(selectedVariant.totalAmountCents)}`}
             </Button>
             <Text size="1" color="gray" as="p">
               Sold by Denuo Web, LLC as a one-time hardware purchase. US shipping is
-              included, sales tax is calculated in Stripe Checkout, and node orders
-              are subject to the{" "}
+              included, sales tax is calculated in Stripe Checkout, and selected
+              sensor add-ons are reflected in the checkout price. Node orders are
+              subject to the{" "}
               <LegalDocumentLink documentId="terms" onOpen={setOpenLegalDocument}>
                 Terms
               </LegalDocumentLink>
@@ -308,12 +427,40 @@ export default function NodePage() {
 
       <Separator size="4" />
 
+      <Section title="Available Product Options">
+        <Text size="2" color="gray" as="p">
+          CrowdPM currently sells one standard PM2.5 node and three sensor-expanded
+          options. The add-on amounts below use the Amazon prices for the listed
+          sensor hardware and, where required, the extra interface board needed to
+          make the sensor compatible with the Raspberry Pi Zero 2 W.
+        </Text>
+
+        <InfoTable
+          headers={["Option", "Added hardware", "Added price", "Total price"]}
+          rows={NODE_PRODUCT_VARIANTS.map((variant) => [
+            variant.label,
+            variant.addedHardware,
+            variant.addOnAmountCents === 0 ? "Included in base build" : `+${formatUsd(variant.addOnAmountCents)}`,
+            formatUsd(variant.totalAmountCents),
+          ])}
+        />
+
+        <Callout.Root color="blue" variant="surface">
+          <Callout.Text>
+            For batches captured with extra gas sensors, the map can later add a
+            pollutant dropdown so viewers can switch between PM2.5, NO2, CO2,
+            and similar channels.
+          </Callout.Text>
+        </Callout.Root>
+      </Section>
+
       {/* ---- Recommended Prototype ---- */}
       <Section title="Recommended Prototype Hardware">
         <Text size="2" color="gray" as="p">
           This page focuses on the standard CrowdPM mobile node prototype: a
           Raspberry Pi Zero 2 W, PM2.5 sensor, GPS, temperature/humidity sensor,
-          local setup controls, and integrated battery management.
+          local setup controls, and integrated battery management. Optional build
+          variants add CO2 sensing, NO2 vehicle-exhaust sensing, or both.
         </Text>
         <Text size="1" color="gray" as="p">
           As an Amazon Associate I earn from qualifying purchases. Hardware part
@@ -335,6 +482,18 @@ export default function NodePage() {
             [
               <PartLink key="dht22" href={DHT22_URL}>DHT22</PartLink>,
               "Temperature and humidity sensor",
+            ],
+            [
+              <PartLink key="co2-sensor" href={CO2_SENSOR_URL}>HiLetgo SCD41 CO2 sensor</PartLink>,
+              "Optional CO2 add-on over I2C. Also reports temperature and humidity, so it can supplement the DHT22 in an expanded build.",
+            ],
+            [
+              <PartLink key="no2-sensor" href={NO2_SENSOR_URL}>MiCS-6814 NO2 / exhaust sensor module</PartLink>,
+              "Optional NO2-focused gas add-on sourced from an automobile-exhaust style air-quality module.",
+            ],
+            [
+              <PartLink key="ads1115" href={ADS1115_URL}>ADS1115 ADC</PartLink>,
+              "Required when using the MiCS-6814 add-on because the Pi Zero 2 W does not provide native analog input pins.",
             ],
             [
               <PartLink key="gps-featherwing" href={GPS_FEATHERWING_URL}>Adafruit Ultimate GPS FeatherWing</PartLink>,
@@ -487,6 +646,61 @@ DHT22:
               ["4.7 Ω", "4.7 ohms", "Incorrect; far too low"],
             ]}
           />
+        </Subsection>
+
+        <Subsection title="Optional CO2 Sensor (SCD41)">
+          <Text size="2" color="gray" as="p">
+            The SCD41 CO2 add-on is the cleanest extra sensor option for the Pi
+            Zero 2 W because it speaks I2C directly. Wire it to the Raspberry Pi
+            I2C bus and keep the module in free airflow, away from the PMS5003
+            exhaust and away from the Pi&apos;s warmest surfaces.
+          </Text>
+
+          <InfoTable
+            headers={["SCD41 Pin", "Raspberry Pi Connection", "Physical Pin"]}
+            rows={[
+              ["VIN / VCC", "3.3 V", "Pin 1"],
+              ["GND", "GND", "Pin 6 or 9"],
+              ["SDA", "GPIO2 / SDA1", "Pin 3"],
+              ["SCL", "GPIO3 / SCL1", "Pin 5"],
+            ]}
+          />
+        </Subsection>
+
+        <Subsection title="Optional NO2 Sensor (MiCS-6814 + ADS1115)">
+          <Text size="2" color="gray" as="p">
+            The Amazon MiCS-6814 boards expose analog gas channels, so the Pi
+            Zero 2 W needs an ADS1115 ADC in between. Use the oxidizing / NO2
+            output channel from the gas board and read it through an ADS1115
+            input. This is the extra hardware included in the NO2 product option.
+          </Text>
+
+          <InfoTable
+            headers={["ADS1115 Pin", "Raspberry Pi Connection", "Physical Pin"]}
+            rows={[
+              ["VDD", "3.3 V", "Pin 1"],
+              ["GND", "GND", "Pin 6 or 9"],
+              ["SDA", "GPIO2 / SDA1", "Pin 3"],
+              ["SCL", "GPIO3 / SCL1", "Pin 5"],
+              ["ADDR", "GND for default I2C address", "Pin 6 or 9"],
+            ]}
+          />
+
+          <InfoTable
+            headers={["MiCS-6814 Signal", "Connect To"]}
+            rows={[
+              ["VCC", "5 V, physical pin 2 or 4"],
+              ["GND", "Raspberry Pi GND"],
+              ["NO2 / OX analog output", "ADS1115 A0"],
+            ]}
+          />
+
+          <Text size="2" color="gray" as="p">
+            Board labels vary a little between Amazon sellers. Look for the
+            oxidizing output, often marked <InlineCode>OX</InlineCode>,
+            <InlineCode>NO2</InlineCode>, or a similar analog-output label, and
+            route that channel into the ADS1115.
+          </Text>
         </Subsection>
       </Section>
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -35,7 +35,7 @@ Important values:
 
 The code reads these values from `process.env`. In deployed Firebase Functions, `DEVICE_TOKEN_PRIVATE_KEY`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET` are expected to come from Secret Manager via each function's `secrets` binding, while the remaining runtime values can come from dotenv-backed env files.
 
-The node purchase flow now relies on Stripe Checkout shipping-address collection plus Stripe Tax. Configure Stripe Tax in the Stripe Dashboard so the physical-goods product can add US sales tax on top of the `$350` node price after the buyer enters a US shipping address.
+The node purchase flow now relies on Stripe Checkout shipping-address collection plus Stripe Tax. Configure Stripe Tax in the Stripe Dashboard so the physical-goods product can add US sales tax on top of the `$350` base node price after the buyer enters a US shipping address. Optional CO2 and NO2 hardware variants add their own pre-tax sensor surcharge before checkout.
 
 Stripe Checkout can still show `$0.00` tax for a valid US address when the Stripe account is not registered to collect tax in that jurisdiction. In Stripe's tax breakdown, that appears as `taxability_reason=not_collecting`. This is expected account configuration behavior, not a missing `automatic_tax` integration parameter.
 

--- a/functions/src/openapi.yaml
+++ b/functions/src/openapi.yaml
@@ -34,11 +34,19 @@ paths:
       description: >
         Creates a Stripe Checkout session for the one-time CrowdPM node hardware
         purchase. Checkout collects a US shipping address, applies Stripe Tax
-        based on that destination, and charges a $350 base price with shipping
-        included. The API lazily provisions the backing Stripe product + price
-        the first time this route is used, then reuses the stored identifiers on
-        later requests.
+        based on that destination, and charges the selected hardware variant.
+        The standard PM2.5 node starts at a $350 base price with shipping
+        included, while optional CO2 and NO2 sensor add-ons increase the final
+        pre-tax amount. The API lazily provisions the backing Stripe product +
+        price for each variant the first time that variant is requested, then
+        reuses the stored identifiers on later requests.
       security: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodePurchaseCheckoutRequest'
       responses:
         '200':
           description: Checkout session created.
@@ -46,6 +54,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckoutRedirectSession'
+        '400':
+          description: Invalid or unsupported hardware variant.
         '429':
           description: Rate limited.
         '500':
@@ -856,6 +866,18 @@ components:
           type: string
           format: uri
           description: Hosted Stripe Checkout URL to open in the browser.
+    NodePurchaseCheckoutRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        variantId:
+          type: string
+          enum:
+            - standard
+            - no2
+            - co2
+            - co2_no2
+          description: Selected CrowdPM hardware product variant.
     DeviceStatus:
       type: string
       enum:

--- a/functions/src/routes/nodePurchase.ts
+++ b/functions/src/routes/nodePurchase.ts
@@ -1,4 +1,5 @@
 import type { FastifyPluginAsync, FastifyRequest } from "fastify";
+import { z } from "zod";
 import { extractClientIp } from "../lib/http.js";
 import { httpError } from "../lib/httpError.js";
 import { rateLimitGuard } from "../lib/routeGuards.js";
@@ -7,6 +8,10 @@ import { createNodePurchaseCheckoutSession, handleStripeWebhook } from "../servi
 type RequestWithRawBody = {
   rawBody?: Buffer | string;
 };
+
+const nodeCheckoutBodySchema = z.object({
+  variantId: z.enum(["standard", "co2", "no2", "co2_no2"]).optional(),
+}).strict();
 
 function requestIp(req: FastifyRequest): string {
   return extractClientIp(req.headers) ?? req.ip ?? "unknown";
@@ -25,7 +30,15 @@ export const nodePurchaseRoutes: FastifyPluginAsync = async (app) => {
       rateLimitGuard((req) => `node-purchase:checkout:ip:${requestIp(req)}`, 30, 60_000),
       rateLimitGuard("node-purchase:checkout:global", 1_000, 60_000),
     ],
-  }, async () => createNodePurchaseCheckoutSession());
+  }, async (req) => {
+    const parsed = nodeCheckoutBodySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      throw httpError(400, "invalid_request", "invalid request", { details: parsed.error.flatten() });
+    }
+    return createNodePurchaseCheckoutSession({
+      variantId: parsed.data.variantId,
+    });
+  });
 
   app.post("/v1/payments/stripe/webhook", {
     preHandler: [

--- a/functions/src/services/nodePurchase.ts
+++ b/functions/src/services/nodePurchase.ts
@@ -4,17 +4,14 @@ import { httpError } from "../lib/httpError.js";
 import { getPublicAppBaseUrl, getStripeSecretKey, getStripeWebhookSecret } from "../lib/runtimeConfig.js";
 
 const CATALOG_COLLECTION = "paymentCatalog";
-const CATALOG_DOC_ID = "nodeHardware";
 const SESSION_COLLECTION = "nodePurchaseSessions";
-const NODE_HARDWARE_PRODUCT_NAME = "CrowdPM Node Hardware";
-const NODE_HARDWARE_CURRENCY = "usd";
-const NODE_HARDWARE_UNIT_AMOUNT = 35000;
 const NODE_HARDWARE_PRODUCT_TAX_CODE = "txcd_99999999";
 const NODE_HARDWARE_PRICE_TAX_BEHAVIOR: Stripe.Price.TaxBehavior = "exclusive";
 const NODE_HARDWARE_ALLOWED_SHIPPING_COUNTRIES: Array<"US"> = ["US"];
 const NODE_HARDWARE_CHECKOUT_SUBMIT_MESSAGE = "Price includes US shipping. Applicable sales tax is calculated at checkout.";
 const NODE_HARDWARE_SHIPPING_ADDRESS_MESSAGE = "We currently ship CrowdPM nodes only to addresses in the United States.";
 const STRIPE_API_VERSION = "2026-04-22.dahlia";
+const DEFAULT_NODE_HARDWARE_VARIANT_ID = "standard";
 
 type NodeHardwareCatalog = {
   productId: string;
@@ -28,6 +25,47 @@ type NodeHardwareCatalog = {
 export type NodePurchaseCheckoutSession = {
   sessionId: string;
   url: string;
+};
+
+export type NodePurchaseVariantId = "standard" | "co2" | "no2" | "co2_no2";
+
+type NodeHardwareVariantConfig = {
+  catalogDocId: string;
+  productName: string;
+  description: string;
+  unitAmount: number;
+  label: string;
+};
+
+const NODE_HARDWARE_VARIANTS: Record<NodePurchaseVariantId, NodeHardwareVariantConfig> = {
+  standard: {
+    catalogDocId: "nodeHardware",
+    productName: "CrowdPM Node Hardware",
+    description: "Node hardware purchase with US shipping included.",
+    unitAmount: 35_000,
+    label: "PM2.5 standard node",
+  },
+  no2: {
+    catalogDocId: "nodeHardwareNo2",
+    productName: "CrowdPM Node Hardware - PM2.5 + NO2",
+    description: "PM2.5 node with MiCS-6814 NO2 sensor and ADS1115 interface hardware, with US shipping included.",
+    unitAmount: 38_394,
+    label: "PM2.5 + NO2 node",
+  },
+  co2: {
+    catalogDocId: "nodeHardwareCo2",
+    productName: "CrowdPM Node Hardware - PM2.5 + CO2",
+    description: "PM2.5 node with SCD41 CO2 sensor hardware, with US shipping included.",
+    unitAmount: 37_899,
+    label: "PM2.5 + CO2 node",
+  },
+  co2_no2: {
+    catalogDocId: "nodeHardwareCo2No2",
+    productName: "CrowdPM Node Hardware - PM2.5 + CO2 + NO2",
+    description: "PM2.5 node with SCD41 CO2 sensor, MiCS-6814 NO2 sensor, and ADS1115 interface hardware, with US shipping included.",
+    unitAmount: 41_293,
+    label: "PM2.5 + CO2 + NO2 node",
+  },
 };
 
 let stripeClient: Stripe | null = null;
@@ -97,9 +135,9 @@ function readStoredCatalog(data: Record<string, unknown> | undefined): NodeHardw
   };
 }
 
-function isCurrentCatalog(catalog: NodeHardwareCatalog): boolean {
-  return catalog.currency === NODE_HARDWARE_CURRENCY
-    && catalog.unitAmount === NODE_HARDWARE_UNIT_AMOUNT
+function isCurrentCatalog(catalog: NodeHardwareCatalog, variant: NodeHardwareVariantConfig): boolean {
+  return catalog.currency === "usd"
+    && catalog.unitAmount === variant.unitAmount
     && catalog.taxCode === NODE_HARDWARE_PRODUCT_TAX_CODE
     && catalog.taxBehavior === NODE_HARDWARE_PRICE_TAX_BEHAVIOR;
 }
@@ -126,23 +164,24 @@ function normalizeStripeAddress(address: Stripe.Address | null | undefined): Rec
   };
 }
 
-async function ensureNodeHardwareCatalog(): Promise<NodeHardwareCatalog> {
-  const ref = db().collection(CATALOG_COLLECTION).doc(CATALOG_DOC_ID);
+async function ensureNodeHardwareCatalog(variantId: NodePurchaseVariantId): Promise<NodeHardwareCatalog> {
+  const variant = NODE_HARDWARE_VARIANTS[variantId];
+  const ref = db().collection(CATALOG_COLLECTION).doc(variant.catalogDocId);
   const snap = await ref.get();
   const stored = readStoredCatalog(snap.exists ? (snap.data() as Record<string, unknown>) : undefined);
-  if (stored && isCurrentCatalog(stored)) {
+  if (stored && isCurrentCatalog(stored, variant)) {
     return stored;
   }
 
   let product: Stripe.Product;
   try {
     product = await getStripeClient().products.create({
-      name: NODE_HARDWARE_PRODUCT_NAME,
-      description: "Node hardware purchase with US shipping included.",
+      name: variant.productName,
+      description: variant.description,
       tax_code: NODE_HARDWARE_PRODUCT_TAX_CODE,
       default_price_data: {
-        currency: NODE_HARDWARE_CURRENCY,
-        unit_amount: NODE_HARDWARE_UNIT_AMOUNT,
+        currency: "usd",
+        unit_amount: variant.unitAmount,
         tax_behavior: NODE_HARDWARE_PRICE_TAX_BEHAVIOR,
       },
     });
@@ -150,20 +189,20 @@ async function ensureNodeHardwareCatalog(): Promise<NodeHardwareCatalog> {
   catch (err) {
     const message = err instanceof Error && err.message.trim().length > 0
       ? err.message
-      : "Unable to create the Stripe node product.";
+      : `Unable to create the Stripe product for ${variant.productName}.`;
     throw httpError(502, "stripe_error", message);
   }
 
   const defaultPriceId = extractExpandableId(product.default_price as string | { id: string } | null | undefined);
   if (!defaultPriceId) {
-    throw httpError(502, "stripe_error", "Stripe did not return a default price for the node product.");
+    throw httpError(502, "stripe_error", `Stripe did not return a default price for ${variant.productName}.`);
   }
 
   const catalog: NodeHardwareCatalog = {
     productId: product.id,
     defaultPriceId,
-    currency: NODE_HARDWARE_CURRENCY,
-    unitAmount: NODE_HARDWARE_UNIT_AMOUNT,
+    currency: "usd",
+    unitAmount: variant.unitAmount,
     taxCode: NODE_HARDWARE_PRODUCT_TAX_CODE,
     taxBehavior: NODE_HARDWARE_PRICE_TAX_BEHAVIOR,
   };
@@ -176,9 +215,18 @@ async function ensureNodeHardwareCatalog(): Promise<NodeHardwareCatalog> {
   return catalog;
 }
 
-export async function createNodePurchaseCheckoutSession(): Promise<NodePurchaseCheckoutSession> {
-  const catalog = await ensureNodeHardwareCatalog();
+export async function createNodePurchaseCheckoutSession(args: {
+  variantId?: NodePurchaseVariantId;
+} = {}): Promise<NodePurchaseCheckoutSession> {
+  const variantId = args.variantId ?? DEFAULT_NODE_HARDWARE_VARIANT_ID;
+  const variant = NODE_HARDWARE_VARIANTS[variantId];
+  const catalog = await ensureNodeHardwareCatalog(variantId);
   const { successUrl, cancelUrl } = checkoutRedirectUrls();
+  const metadata = {
+    purchaseType: "node_hardware",
+    variantId,
+    variantLabel: variant.label,
+  } satisfies Record<string, string>;
 
   let session: Stripe.Checkout.Session;
   try {
@@ -205,6 +253,7 @@ export async function createNodePurchaseCheckoutSession(): Promise<NodePurchaseC
           message: NODE_HARDWARE_CHECKOUT_SUBMIT_MESSAGE,
         },
       },
+      metadata,
       success_url: successUrl,
       cancel_url: cancelUrl,
     });
@@ -223,6 +272,9 @@ export async function createNodePurchaseCheckoutSession(): Promise<NodePurchaseC
   await db().collection(SESSION_COLLECTION).doc(session.id).set({
     sessionId: session.id,
     status: "created",
+    purchaseType: "node_hardware",
+    variantId,
+    variantLabel: variant.label,
     productId: catalog.productId,
     priceId: catalog.defaultPriceId,
     mode: session.mode,
@@ -266,6 +318,9 @@ export async function handleStripeWebhook({ signature, rawBody }: StripeWebhookA
     await db().collection(SESSION_COLLECTION).doc(session.id).set({
       sessionId: session.id,
       status: "completed",
+      purchaseType: typeof session.metadata?.purchaseType === "string" ? session.metadata.purchaseType : "node_hardware",
+      variantId: typeof session.metadata?.variantId === "string" ? session.metadata.variantId : null,
+      variantLabel: typeof session.metadata?.variantLabel === "string" ? session.metadata.variantLabel : null,
       eventId: event.id,
       eventCreatedAt: new Date(event.created * 1000).toISOString(),
       completedAt: new Date().toISOString(),

--- a/functions/test/routes/nodePurchase.test.ts
+++ b/functions/test/routes/nodePurchase.test.ts
@@ -161,6 +161,11 @@ describe("POST /v1/node-purchase/checkout-session", () => {
           message: "Price includes US shipping. Applicable sales tax is calculated at checkout.",
         },
       },
+      metadata: {
+        purchaseType: "node_hardware",
+        variantId: "standard",
+        variantLabel: "PM2.5 standard node",
+      },
       success_url: "https://crowdpmplatform.web.app/node?checkout=success",
       cancel_url: "https://crowdpmplatform.web.app/node?checkout=cancelled",
     });
@@ -184,6 +189,79 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       automaticTaxEnabled: true,
       amountSubtotal: 35000,
       amountTotal: 35000,
+      purchaseType: "node_hardware",
+      variantId: "standard",
+      variantLabel: "PM2.5 standard node",
+    });
+    await app.close();
+  });
+
+  it("creates the CO2-expanded node variant at the matching Stripe price", async () => {
+    mocks.productsCreate.mockResolvedValueOnce({
+      id: "prod_node_co2_123",
+      default_price: "price_node_co2_123",
+    });
+    mocks.checkoutSessionsCreate.mockResolvedValueOnce({
+      id: "cs_node_co2_123",
+      url: "https://checkout.stripe.com/c/pay/cs_node_co2_123",
+      mode: "payment",
+      currency: "usd",
+      amount_subtotal: 37899,
+      amount_total: 37899,
+    });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/node-purchase/checkout-session",
+      payload: {
+        variantId: "co2",
+      },
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.productsCreate).toHaveBeenCalledWith({
+      name: "CrowdPM Node Hardware - PM2.5 + CO2",
+      description: "PM2.5 node with SCD41 CO2 sensor hardware, with US shipping included.",
+      tax_code: "txcd_99999999",
+      default_price_data: {
+        currency: "usd",
+        unit_amount: 37899,
+        tax_behavior: "exclusive",
+      },
+    });
+    expect(mocks.checkoutSessionsCreate).toHaveBeenCalledWith(expect.objectContaining({
+      line_items: [
+        {
+          price: "price_node_co2_123",
+          quantity: 1,
+        },
+      ],
+      metadata: {
+        purchaseType: "node_hardware",
+        variantId: "co2",
+        variantLabel: "PM2.5 + CO2 node",
+      },
+    }));
+    expect(dbStore.get("paymentCatalog/nodeHardwareCo2")).toMatchObject({
+      productId: "prod_node_co2_123",
+      defaultPriceId: "price_node_co2_123",
+      currency: "usd",
+      unitAmount: 37899,
+      taxCode: "txcd_99999999",
+      taxBehavior: "exclusive",
+    });
+    expect(dbStore.get("nodePurchaseSessions/cs_node_co2_123")).toMatchObject({
+      sessionId: "cs_node_co2_123",
+      purchaseType: "node_hardware",
+      unitAmount: 37899,
+      amountSubtotal: 37899,
+      amountTotal: 37899,
+      variantId: "co2",
+      variantLabel: "PM2.5 + CO2 node",
     });
     await app.close();
   });
@@ -280,6 +358,29 @@ describe("POST /v1/node-purchase/checkout-session", () => {
     });
     await app.close();
   });
+
+  it("rejects an unknown node purchase variant", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/node-purchase/checkout-session",
+      payload: {
+        variantId: "bogus",
+      },
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      error: "invalid_request",
+      message: "invalid request",
+    });
+    expect(mocks.checkoutSessionsCreate).not.toHaveBeenCalled();
+    await app.close();
+  });
 });
 
 describe("POST /v1/payments/stripe/webhook", () => {
@@ -295,6 +396,11 @@ describe("POST /v1/payments/stripe/webhook", () => {
       data: {
         object: {
           id: "cs_test_123",
+          metadata: {
+            purchaseType: "node_hardware",
+            variantId: "standard",
+            variantLabel: "PM2.5 standard node",
+          },
           mode: "payment",
           payment_status: "paid",
           customer: "cus_123",
@@ -363,6 +469,9 @@ describe("POST /v1/payments/stripe/webhook", () => {
       currency: "usd",
       amountSubtotal: 35000,
       amountTotal: 38150,
+      purchaseType: "node_hardware",
+      variantId: "standard",
+      variantLabel: "PM2.5 standard node",
       amountDiscount: 0,
       amountShipping: 0,
       amountTax: 3150,


### PR DESCRIPTION
## Summary
- rename the node menu entry to Products and update the node page hero copy for multiple hardware options
- add selectable PM2.5, CO2, NO2, and combined hardware variants with Amazon-backed sensor pricing and hookup notes
- extend node checkout to accept a validated hardware variant and charge the matching Stripe catalog price

## Testing
- pnpm --filter crowdpm-frontend build
- pnpm --filter crowdpm-functions build
- pnpm --filter crowdpm-functions exec vitest run test/routes/nodePurchase.test.ts
- pnpm lint