### PR TITLE
Fix theme save unlock confirmation flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,12 @@ import { PROJECT_LINKS, PROJECT_RESOURCE_LINKS } from "./lib/projectLinks";
 import { logWarning } from "./lib/logger";
 import { useAuth } from "./providers/AuthProvider";
 import { useUserSettings } from "./providers/UserSettingsProvider";
-import { createThemeSaveCheckoutSession, type IngestSmokeTestCleanupResponse, type IngestSmokeTestResponse } from "./lib/api";
+import {
+  confirmThemeSaveCheckoutSession,
+  createThemeSaveCheckoutSession,
+  type IngestSmokeTestCleanupResponse,
+  type IngestSmokeTestResponse,
+} from "./lib/api";
 import {
   Theme,
   Box,
@@ -111,7 +116,14 @@ function clearThemeCheckoutNoticeFromUrl() {
   if (typeof window === "undefined") return;
   const nextUrl = new URL(window.location.href);
   nextUrl.searchParams.delete("themeCheckout");
+  nextUrl.searchParams.delete("themeCheckoutSessionId");
   window.history.replaceState({}, "", `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`);
+}
+
+function readThemeCheckoutSessionId(): string | null {
+  if (typeof window === "undefined") return null;
+  const sessionId = new URLSearchParams(window.location.search).get("themeCheckoutSessionId");
+  return typeof sessionId === "string" && sessionId.trim().length > 0 ? sessionId : null;
 }
 
 export default function App() {
@@ -122,6 +134,7 @@ export default function App() {
     ? getDeepLinkedAppTab(window.location.pathname)
     : null;
   const initialThemeCheckoutNotice = readThemeCheckoutNotice();
+  const initialThemeCheckoutSessionId = readThemeCheckoutSessionId();
   const [tab, setTab] = useState<AppTab>(initialDeepLinkedTab ?? "map");
   const [authMode, setAuthMode] = useState<AuthMode>("login");
   const [isAuthDialogOpen, setAuthDialogOpen] = useState(false);
@@ -130,6 +143,7 @@ export default function App() {
   const [isTeamModalOpen, setTeamModalOpen] = useState(false);
   const [isThemeModalOpen, setThemeModalOpen] = useState(Boolean(initialThemeCheckoutNotice));
   const [themeCheckoutNotice, setThemeCheckoutNotice] = useState<ThemeCheckoutNotice>(initialThemeCheckoutNotice);
+  const [themeCheckoutSessionId, setThemeCheckoutSessionId] = useState<string | null>(initialThemeCheckoutSessionId);
   const [themeDraft, setThemeDraft] = useState<UserThemeSettings | null>(null);
   const [dashboardRefreshToken, setDashboardRefreshToken] = useState(0);
   const [pendingSmokeResult, setPendingSmokeResult] = useState<IngestSmokeTestResponse | null>(null);
@@ -161,11 +175,12 @@ export default function App() {
   const closeThemeModal = useCallback(() => {
     setThemeModalOpen(false);
     setThemeDraft(null);
-    if (themeCheckoutNotice) {
+    if (themeCheckoutNotice || themeCheckoutSessionId) {
       setThemeCheckoutNotice(null);
+      setThemeCheckoutSessionId(null);
       clearThemeCheckoutNoticeFromUrl();
     }
-  }, [themeCheckoutNotice]);
+  }, [themeCheckoutNotice, themeCheckoutSessionId]);
 
   const handleThemeModalOpenChange = useCallback((next: boolean) => {
     if (next) {
@@ -346,6 +361,7 @@ export default function App() {
         open={isThemeModalOpen}
         onOpenChange={handleThemeModalOpenChange}
         checkoutNotice={themeCheckoutNotice}
+        checkoutSessionId={themeCheckoutSessionId}
         theme={activeTheme}
         onThemeChange={setThemeDraft}
         onThemeSaved={() => setThemeDraft(null)}
@@ -659,6 +675,7 @@ type ThemePreferencesModalProps = {
   open: boolean;
   onOpenChange: (next: boolean) => void;
   checkoutNotice: ThemeCheckoutNotice;
+  checkoutSessionId: string | null;
   theme: UserThemeSettings;
   onThemeChange: (next: UserThemeSettings) => void;
   onThemeSaved: () => void;
@@ -668,6 +685,7 @@ function ThemePreferencesModal({
   open,
   onOpenChange,
   checkoutNotice,
+  checkoutSessionId,
   theme,
   onThemeChange,
   onThemeSaved,
@@ -677,8 +695,9 @@ function ThemePreferencesModal({
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isStartingCheckout, setIsStartingCheckout] = useState(false);
+  const [isConfirmingCheckout, setIsConfirmingCheckout] = useState(false);
   const [openLegalDocument, setOpenLegalDocument] = useState<LegalDocumentId | null>(null);
-  const controlsDisabled = isLoading || isSaving || isStartingCheckout;
+  const controlsDisabled = isLoading || isSaving || isStartingCheckout || isConfirmingCheckout;
   const hasUnsavedChanges = JSON.stringify(theme) !== JSON.stringify(settings.theme);
   const saveDisabled = controlsDisabled || !user || !settings.themeSaveUnlocked || !hasUnsavedChanges;
   const unlockDisabled = controlsDisabled || !user || settings.themeSaveUnlocked;
@@ -700,11 +719,37 @@ function ThemePreferencesModal({
   }, [checkoutNotice, open, settings.themeSaveUnlocked]);
 
   useEffect(() => {
-    if (!open || checkoutNotice !== "success" || !user) return;
-    void refresh().catch((err) => {
-      setError(err instanceof Error ? err.message : "Unable to refresh theme entitlements.");
-    });
-  }, [checkoutNotice, open, refresh, user]);
+    if (!open || checkoutNotice !== "success" || !user) {
+      setIsConfirmingCheckout(false);
+      return;
+    }
+    let isCancelled = false;
+    setIsConfirmingCheckout(true);
+    void (async () => {
+      try {
+        if (checkoutSessionId) {
+          await confirmThemeSaveCheckoutSession(checkoutSessionId);
+        }
+        await refresh();
+      }
+      catch (err) {
+        if (isCancelled) return;
+        if (err instanceof Error && err.message === "theme_save_pending") {
+          setError("Theme purchase is still processing. Please try again in a moment.");
+          return;
+        }
+        setError(err instanceof Error ? err.message : "Unable to refresh theme entitlements.");
+      }
+      finally {
+        if (!isCancelled) {
+          setIsConfirmingCheckout(false);
+        }
+      }
+    })();
+    return () => {
+      isCancelled = true;
+    };
+  }, [checkoutNotice, checkoutSessionId, open, refresh, user]);
 
   const handleSave = async () => {
     if (!user) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -67,10 +67,10 @@ async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
     if (errorBody) {
       try {
         const parsed = JSON.parse(errorBody) as { error?: unknown; message?: unknown };
-        const parsedMessage = typeof parsed.error === "string"
-          ? parsed.error
-          : typeof parsed.message === "string"
-            ? parsed.message
+        const parsedMessage = typeof parsed.message === "string"
+          ? parsed.message
+          : typeof parsed.error === "string"
+            ? parsed.error
             : null;
         if (parsedMessage) {
           throw new Error(parsedMessage);
@@ -156,6 +156,20 @@ export async function createNodePurchaseCheckoutSession(
 export async function createThemeSaveCheckoutSession(): Promise<CheckoutRedirectSession> {
   return requestJson<CheckoutRedirectSession>("/v1/theme-purchase/checkout-session", {
     method: "POST",
+  });
+}
+
+export async function confirmThemeSaveCheckoutSession(sessionId: string): Promise<{
+  confirmed: true;
+  sessionId: string;
+  unlockGranted: true;
+}> {
+  return requestJson("/v1/theme-purchase/confirm", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ sessionId }),
   });
 }
 

--- a/functions/src/routes/nodePurchase.ts
+++ b/functions/src/routes/nodePurchase.ts
@@ -3,7 +3,12 @@ import { z } from "zod";
 import { extractClientIp } from "../lib/http.js";
 import { httpError } from "../lib/httpError.js";
 import { getRequestUser, rateLimitGuard, requestUserId, requireUserGuard } from "../lib/routeGuards.js";
-import { createNodePurchaseCheckoutSession, createThemeSaveCheckoutSession, handleStripeWebhook } from "../services/nodePurchase.js";
+import {
+  confirmThemeSaveCheckoutSession,
+  createNodePurchaseCheckoutSession,
+  createThemeSaveCheckoutSession,
+  handleStripeWebhook,
+} from "../services/nodePurchase.js";
 
 type RequestWithRawBody = {
   rawBody?: Buffer | string;
@@ -11,6 +16,10 @@ type RequestWithRawBody = {
 
 const nodeCheckoutBodySchema = z.object({
   variantId: z.enum(["standard", "co2", "no2", "co2_no2"]).optional(),
+}).strict();
+
+const confirmThemeCheckoutBodySchema = z.object({
+  sessionId: z.string().trim().min(1),
 }).strict();
 
 function requestIp(req: FastifyRequest): string {
@@ -51,6 +60,24 @@ export const nodePurchaseRoutes: FastifyPluginAsync = async (app) => {
     userId: requestUserId(req),
     customerEmail: getRequestUser(req).email ?? null,
   }));
+
+  app.post("/v1/theme-purchase/confirm", {
+    preHandler: [
+      requireUserGuard(),
+      rateLimitGuard((req) => `theme-purchase:confirm:user:${requestUserId(req)}`, 20, 60_000),
+      rateLimitGuard((req) => `theme-purchase:confirm:ip:${requestIp(req)}`, 40, 60_000),
+      rateLimitGuard("theme-purchase:confirm:global", 1_000, 60_000),
+    ],
+  }, async (req) => {
+    const parsed = confirmThemeCheckoutBodySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      throw httpError(400, "invalid_request", "invalid request", { details: parsed.error.flatten() });
+    }
+    return confirmThemeSaveCheckoutSession({
+      sessionId: parsed.data.sessionId,
+      userId: requestUserId(req),
+    });
+  });
 
   app.post("/v1/payments/stripe/webhook", {
     preHandler: [

--- a/functions/src/services/nodePurchase.ts
+++ b/functions/src/services/nodePurchase.ts
@@ -228,9 +228,13 @@ function isCurrentCatalog(catalog: PaymentCatalog, config: CheckoutProductConfig
 
 function checkoutRedirectUrls(config: CheckoutProductConfig): { successUrl: string; cancelUrl: string } {
   const baseUrl = normalizeBaseUrl(getPublicAppBaseUrl());
+  const successUrl = `${baseUrl}${config.successPath}?${config.successQueryParam}${config.purchaseType === THEME_SAVE_UNLOCK_CONFIG.purchaseType
+    ? "&themeCheckoutSessionId={CHECKOUT_SESSION_ID}"
+    : ""}`;
+  const cancelUrl = `${baseUrl}${config.successPath}?${config.cancelQueryParam}`;
   return {
-    successUrl: `${baseUrl}${config.successPath}?${config.successQueryParam}`,
-    cancelUrl: `${baseUrl}${config.successPath}?${config.cancelQueryParam}`,
+    successUrl,
+    cancelUrl,
   };
 }
 
@@ -420,6 +424,12 @@ export async function createThemeSaveCheckoutSession(args: {
   return createCheckoutSession(THEME_SAVE_UNLOCK_CONFIG, args);
 }
 
+export type ConfirmThemeSaveCheckoutSessionResult = {
+  confirmed: true;
+  sessionId: string;
+  unlockGranted: true;
+};
+
 type StripeWebhookArgs = {
   signature: string;
   rawBody: string;
@@ -432,12 +442,13 @@ type ResolvedPurchase = {
 
 async function resolvePurchase(session: Stripe.Checkout.Session): Promise<ResolvedPurchase> {
   const metadataPurchaseType = readNonEmptyString(session.metadata?.purchaseType);
+  const themeSnap = await db().collection(THEME_SAVE_UNLOCK_CONFIG.sessionCollection).doc(session.id).get();
+  const themeStoredSession = themeSnap.exists ? (themeSnap.data() as Record<string, unknown>) : null;
 
-  if (metadataPurchaseType === THEME_SAVE_UNLOCK_CONFIG.purchaseType) {
-    const snap = await db().collection(THEME_SAVE_UNLOCK_CONFIG.sessionCollection).doc(session.id).get();
+  if (metadataPurchaseType === THEME_SAVE_UNLOCK_CONFIG.purchaseType || themeSnap.exists) {
     return {
       config: THEME_SAVE_UNLOCK_CONFIG,
-      storedSession: snap.exists ? (snap.data() as Record<string, unknown>) : null,
+      storedSession: themeStoredSession,
     };
   }
 
@@ -454,11 +465,7 @@ async function resolvePurchase(session: Stripe.Checkout.Session): Promise<Resolv
     };
   }
 
-  const themeSnap = await db().collection(THEME_SAVE_UNLOCK_CONFIG.sessionCollection).doc(session.id).get();
-  return {
-    config: THEME_SAVE_UNLOCK_CONFIG,
-    storedSession: themeSnap.exists ? (themeSnap.data() as Record<string, unknown>) : null,
-  };
+  throw httpError(404, "purchase_session_not_found", "Checkout session is not recognized.");
 }
 
 function resolveThemeUnlockUserId(
@@ -474,11 +481,15 @@ function resolveThemeUnlockUserId(
   return readNonEmptyString(storedSession?.userId);
 }
 
+function isThemeCheckoutSessionCompleted(session: Stripe.Checkout.Session): boolean {
+  return session.mode === "payment" && session.payment_status === "paid";
+}
+
 async function recordCompletedSession(
   config: CheckoutProductConfig,
   storedSession: Record<string, unknown> | null,
   session: Stripe.Checkout.Session,
-  event: Stripe.Event,
+  event?: Stripe.Event,
 ): Promise<void> {
   const shippingDetails = session.collected_information?.shipping_details ?? null;
   const completedAt = new Date().toISOString();
@@ -486,8 +497,6 @@ async function recordCompletedSession(
     sessionId: session.id,
     status: "completed",
     purchaseType: config.purchaseType,
-    eventId: event.id,
-    eventCreatedAt: new Date(event.created * 1000).toISOString(),
     completedAt,
     mode: session.mode,
     paymentStatus: session.payment_status ?? null,
@@ -510,6 +519,10 @@ async function recordCompletedSession(
       }
       : null,
   };
+  if (event) {
+    payload.eventId = event.id;
+    payload.eventCreatedAt = new Date(event.created * 1000).toISOString();
+  }
 
   if (config.purchaseType === THEME_SAVE_UNLOCK_CONFIG.purchaseType) {
     const userId = resolveThemeUnlockUserId(session, storedSession);
@@ -536,6 +549,50 @@ async function recordCompletedSession(
   }
 
   await db().collection(config.sessionCollection).doc(session.id).set(payload, { merge: true });
+}
+
+async function retrieveCheckoutSession(sessionId: string): Promise<Stripe.Checkout.Session> {
+  try {
+    return await getStripeClient().checkout.sessions.retrieve(sessionId);
+  }
+  catch (err) {
+    const message = err instanceof Error && err.message.trim().length > 0
+      ? err.message
+      : "Unable to retrieve the Stripe Checkout session.";
+    throw httpError(502, "stripe_error", message);
+  }
+}
+
+export async function confirmThemeSaveCheckoutSession(args: {
+  sessionId: string;
+  userId: string;
+}): Promise<ConfirmThemeSaveCheckoutSessionResult> {
+  const sessionId = readNonEmptyString(args.sessionId);
+  if (!sessionId) {
+    throw httpError(400, "invalid_request", "sessionId is required.");
+  }
+
+  const session = await retrieveCheckoutSession(sessionId);
+  const { config, storedSession } = await resolvePurchase(session);
+  if (config.purchaseType !== THEME_SAVE_UNLOCK_CONFIG.purchaseType) {
+    throw httpError(400, "invalid_request", "Checkout session is not a theme save unlock purchase.");
+  }
+
+  const sessionUserId = resolveThemeUnlockUserId(session, storedSession);
+  if (!sessionUserId || sessionUserId !== args.userId) {
+    throw httpError(403, "theme_save_forbidden", "This theme save checkout does not belong to the signed-in account.");
+  }
+
+  if (!isThemeCheckoutSessionCompleted(session)) {
+    throw httpError(409, "theme_save_pending", "Theme purchase is still processing. Please try again in a moment.");
+  }
+
+  await recordCompletedSession(config, storedSession, session);
+  return {
+    confirmed: true,
+    sessionId,
+    unlockGranted: true,
+  };
 }
 
 export async function handleStripeWebhook({ signature, rawBody }: StripeWebhookArgs): Promise<{ received: true }> {

--- a/functions/test/routes/nodePurchase.test.ts
+++ b/functions/test/routes/nodePurchase.test.ts
@@ -7,6 +7,7 @@ import { withRateLimitsEnabled } from "../helpers/rateLimitEnv.js";
 const mocks = vi.hoisted(() => ({
   productsCreate: vi.fn(),
   checkoutSessionsCreate: vi.fn(),
+  checkoutSessionsRetrieve: vi.fn(),
   constructEvent: vi.fn(),
   rateLimitOrThrow: vi.fn(),
   requireUser: vi.fn(),
@@ -60,6 +61,7 @@ vi.mock("stripe", () => ({
     checkout = {
       sessions: {
         create: mocks.checkoutSessionsCreate,
+        retrieve: mocks.checkoutSessionsRetrieve,
       },
     };
 
@@ -91,6 +93,7 @@ beforeEach(() => {
 
   mocks.productsCreate.mockReset();
   mocks.checkoutSessionsCreate.mockReset();
+  mocks.checkoutSessionsRetrieve.mockReset();
   mocks.constructEvent.mockReset();
   mocks.rateLimitOrThrow.mockReset();
   mocks.requireUser.mockReset();
@@ -460,7 +463,7 @@ describe("POST /v1/theme-purchase/checkout-session", () => {
         purchaseType: "theme_save_unlock",
         userId: "user-123",
       },
-      success_url: "https://crowdpmplatform.web.app/?themeCheckout=success",
+      success_url: "https://crowdpmplatform.web.app/?themeCheckout=success&themeCheckoutSessionId={CHECKOUT_SESSION_ID}",
       cancel_url: "https://crowdpmplatform.web.app/?themeCheckout=cancelled",
     });
     expect(dbStore.get("paymentCatalog/themeSaveUnlock")).toMatchObject({
@@ -526,6 +529,130 @@ describe("POST /v1/theme-purchase/checkout-session", () => {
       message: "Theme saving is already unlocked for this account.",
     });
     expect(mocks.checkoutSessionsCreate).not.toHaveBeenCalled();
+    await app.close();
+  });
+});
+
+describe("POST /v1/theme-purchase/confirm", () => {
+  it("finalizes a paid theme checkout session for the signed-in account", async () => {
+    dbStore.set("themeSavePurchaseSessions/cs_theme_123", {
+      sessionId: "cs_theme_123",
+      status: "created",
+      userId: "user-123",
+      purchaseType: "theme_save_unlock",
+    });
+    mocks.checkoutSessionsRetrieve.mockResolvedValue({
+      id: "cs_theme_123",
+      mode: "payment",
+      payment_status: "paid",
+      customer: "cus_theme_123",
+      customer_details: {
+        email: "buyer@example.com",
+      },
+      customer_email: "buyer@example.com",
+      payment_intent: "pi_theme_123",
+      automatic_tax: {
+        enabled: true,
+        status: "complete",
+      },
+      metadata: {
+        purchaseType: "theme_save_unlock",
+        userId: "user-123",
+      },
+      client_reference_id: "user-123",
+      total_details: {
+        amount_discount: 0,
+        amount_shipping: 0,
+        amount_tax: 27,
+      },
+      currency: "usd",
+      amount_subtotal: 300,
+      amount_total: 327,
+      url: null,
+    });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/theme-purchase/confirm",
+      payload: {
+        sessionId: "cs_theme_123",
+      },
+      headers: {
+        authorization: "Bearer ok",
+        "content-type": "application/json",
+        "x-forwarded-for": "203.0.113.6",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      confirmed: true,
+      sessionId: "cs_theme_123",
+      unlockGranted: true,
+    });
+    expect(mocks.checkoutSessionsRetrieve).toHaveBeenCalledWith("cs_theme_123");
+    expect(dbStore.get("themeSavePurchaseSessions/cs_theme_123")).toMatchObject({
+      sessionId: "cs_theme_123",
+      status: "completed",
+      purchaseType: "theme_save_unlock",
+      paymentStatus: "paid",
+      userId: "user-123",
+      unlockGranted: true,
+    });
+    expect(dbStore.get("userSettings/user-123")).toMatchObject({
+      themeSaveUnlocked: true,
+      themeSaveUnlockedBySessionId: "cs_theme_123",
+    });
+    await app.close();
+  });
+
+  it("rejects confirming another account's theme checkout session", async () => {
+    dbStore.set("themeSavePurchaseSessions/cs_theme_456", {
+      sessionId: "cs_theme_456",
+      status: "created",
+      userId: "other-user",
+      purchaseType: "theme_save_unlock",
+    });
+    mocks.checkoutSessionsRetrieve.mockResolvedValue({
+      id: "cs_theme_456",
+      mode: "payment",
+      payment_status: "paid",
+      metadata: {
+        purchaseType: "theme_save_unlock",
+        userId: "other-user",
+      },
+      client_reference_id: "other-user",
+      total_details: {
+        amount_discount: 0,
+        amount_shipping: 0,
+        amount_tax: 27,
+      },
+      currency: "usd",
+      amount_subtotal: 300,
+      amount_total: 327,
+      url: null,
+    });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/theme-purchase/confirm",
+      payload: {
+        sessionId: "cs_theme_456",
+      },
+      headers: {
+        authorization: "Bearer ok",
+        "content-type": "application/json",
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toEqual({
+      error: "theme_save_forbidden",
+      message: "This theme save checkout does not belong to the signed-in account.",
+    });
+    expect(dbStore.get("userSettings/user-123")).toBeUndefined();
     await app.close();
   });
 });


### PR DESCRIPTION
## Summary
- include the Stripe checkout session id in the theme unlock success redirect
- add an authenticated theme purchase confirmation endpoint that finalizes the unlock directly from Stripe when the webhook is delayed or missed
- confirm the session from the frontend before refreshing user settings, and prefer readable API error messages

## Testing
- pnpm --filter crowdpm-functions exec vitest run test/routes/nodePurchase.test.ts
- pnpm --filter crowdpm-functions build
- pnpm --filter crowdpm-frontend build