### PR TITLE
Fix map header dark theme and stacking

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -161,11 +161,11 @@ export default function App() {
   const isDarkTheme = activeTheme.appearance === "dark";
   const mapHeaderBackground = activeTab === "map"
     ? isDarkTheme
-      ? "linear-gradient(180deg, color-mix(in srgb, white 84%, transparent) 0%, color-mix(in srgb, white 72%, transparent) 58%, color-mix(in srgb, white 42%, transparent) 100%)"
+      ? "linear-gradient(180deg, color-mix(in srgb, var(--color-panel-solid) 96%, transparent) 0%, color-mix(in srgb, var(--color-panel-solid) 88%, transparent) 58%, color-mix(in srgb, var(--color-panel-solid) 60%, transparent) 100%)"
       : "linear-gradient(180deg, color-mix(in srgb, white 96%, transparent) 0%, color-mix(in srgb, white 88%, transparent) 58%, color-mix(in srgb, white 56%, transparent) 100%)"
     : "color-mix(in srgb, var(--color-panel-solid) 88%, transparent)";
-  const mapHeaderForegroundColor = activeTab === "map" && isDarkTheme ? "#111111" : "var(--gray-12)";
-  const airQualityNetworkColor = activeTab === "map" && isDarkTheme ? "#000000" : "var(--gray-11)";
+  const mapHeaderForegroundColor = "var(--gray-12)";
+  const airQualityNetworkColor = "var(--gray-11)";
 
   const openAuthDialog = (mode: AuthMode) => {
     setAuthMode(mode);

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1243,7 +1243,7 @@ export default function MapPage({
           position: "absolute",
           top: "var(--space-4)",
           right: "var(--space-4)",
-          zIndex: 3,
+          zIndex: 110,
           display: "flex",
           flexDirection: "column",
           gap: "var(--space-3)",


### PR DESCRIPTION
## Summary
- switch the map tab header to a dark theme-aware gradient when dark mode is active
- keep the map header text using theme tokens so it matches other pages in dark mode
- raise the floating map controls so the Measurement batch card renders above the fixed header

## Testing
- pnpm -C frontend build