### PR TITLE
Refactor node hardware checkout options

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,6 +17,8 @@ import type {
   IngestPoint,
   MeasurementRecord,
   ModerationState,
+  NodePurchaseReceipt,
+  NodePurchaseVariantId,
   PublicBatchDetail,
   PublicBatchSummary,
   SmokeTestCleanupResponse,
@@ -122,6 +124,8 @@ export type {
   FirestoreTimestampLike,
   MeasurementRecord,
   ModerationState,
+  NodePurchaseReceipt,
+  NodePurchaseVariantId,
   PublicBatchDetail,
   PublicBatchSummary,
   UserSettings,
@@ -135,22 +139,25 @@ export type CheckoutRedirectSession = {
   url: string;
 };
 
-export type NodePurchaseVariantId = "standard" | "co2" | "no2" | "co2_no2";
-
 export async function listDevices(): Promise<DeviceSummary[]> {
   return requestJson<DeviceSummary[]>("/v1/devices");
 }
 
 export async function createNodePurchaseCheckoutSession(
   variantId: NodePurchaseVariantId = "standard",
+  quantity = 1,
 ): Promise<CheckoutRedirectSession> {
   return requestJson<CheckoutRedirectSession>("/v1/node-purchase/checkout-session", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ variantId }),
+    body: JSON.stringify({ variantId, quantity }),
   });
+}
+
+export async function listNodePurchaseReceipts(): Promise<NodePurchaseReceipt[]> {
+  return requestJson<NodePurchaseReceipt[]>("/v1/node-purchase/receipts");
 }
 
 export async function createThemeSaveCheckoutSession(): Promise<CheckoutRedirectSession> {

--- a/frontend/src/pages/NodePage.tsx
+++ b/frontend/src/pages/NodePage.tsx
@@ -4,8 +4,10 @@ import {
   Button,
   Callout,
   Card,
+  Checkbox,
   Flex,
   Heading,
+  Select,
   Separator,
   Tabs,
   Text,
@@ -42,8 +44,10 @@ type NodeProductVariant = {
 };
 
 const BASE_NODE_PRICE_CENTS = 35_000;
-const CO2_SENSOR_ADD_ON_CENTS = 2_899;
-const NO2_SENSOR_ADD_ON_CENTS = 2_695 + 699;
+const SENSOR_ADD_ON_PRICE_CENTS = 2_500;
+const CO2_SENSOR_ADD_ON_CENTS = SENSOR_ADD_ON_PRICE_CENTS;
+const NO2_SENSOR_ADD_ON_CENTS = SENSOR_ADD_ON_PRICE_CENTS;
+const NODE_QUANTITY_OPTIONS = Array.from({ length: 10 }, (_, index) => index + 1);
 
 const ZERO_2_W_URL = "https://www.amazon.com/Raspberry-Heatsink-Adapter-Quad-core-Bluetooth/dp/B0DRRDJKDV?crid=3VRASN6F43J3I&dib=eyJ2IjoiMSJ9.t-BTW30Tluhki6lWlHIi2rulYzLQMAGFk2OvRz-XBQTYgqnJ_G_aL00we8CvIVnKwG2Qc75itVV_M0bpyBUc5YG3r7ovACXMTrtlMTUUnZBffQIiEHNn3Yqk-Chei1tyWsoAB2tTea-NTY83Z_QJUq5-3JfgkUiz0PjutePcLmnkuMuu_IWzavyrhKUNrUjTEI8BgTUNhwVf1epqDu2ahFmxjLDI5xaFLi5SgdjHoeg.dYFNm35Nc1V43vvTuZ8pC5dQ-abvmafEYOYXJh8E5Ss&dib_tag=se&keywords=raspberry%2Bpi%2Bzero%2B2%2Bw&qid=1778398787&sprefix=Raspberry%2BPi%2BZero%2B2%2BW%2Caps%2C178&sr=8-2-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1&linkCode=ll2&tag=lipbalm01-20&linkId=35363b709757db3d01baa6b973c52a01&language=en_US&ref_=as_li_ss_tl";
 const PMS5003_URL = "https://www.amazon.com/BestParts-Digital-Particle-Concentration-PMS5003/dp/B0B1DQKV4N?crid=2CSK1VIYBL9LN&dib=eyJ2IjoiMSJ9.98U0BdlWh4vmYk-feCR0PmZpSTwOza-Io1F0J5aEYxt-Atifz_ulAtN2MSfswsFSwZAY5G94uyuiJwZQ1pJEgEFX1HBloSTDsFit2N07xKk13LTq4uwQ5LAGvFMMuUeWH2nLcVwe2SqFNb96Kn75VRFoIWku34vnGX3ryzbO4xgpcNSnNDH7QmqgRqu-KYCsnv1gNizUAnlnmoc22RpGTvxNFB4H45LOk2Hf_kqlcO8.l0Rt1mD9IbbwGvgp5ZFUzZgF46xGdPN76S6jbwz8CLE&dib_tag=se&keywords=Plantower+PMS5003&qid=1778398886&sprefix=plantower+pms5003%2Caps%2C225&sr=8-4&linkCode=ll2&tag=lipbalm01-20&linkId=7eb62de9f07d2cf0f66b47bb7349e0db&language=en_US&ref_=as_li_ss_tl";
@@ -93,6 +97,21 @@ const NODE_PRODUCT_VARIANTS: NodeProductVariant[] = [
   },
 ];
 
+const SENSOR_ADD_ONS = [
+  {
+    id: "co2",
+    label: "CO2 sensor",
+    description: "Adds SCD41 CO2 sensing for indoor and mobile air-quality context.",
+    amountCents: CO2_SENSOR_ADD_ON_CENTS,
+  },
+  {
+    id: "no2",
+    label: "NO2 sensor",
+    description: "Adds NO2-focused vehicle-exhaust sensing with the interface board included.",
+    amountCents: NO2_SENSOR_ADD_ON_CENTS,
+  },
+] as const;
+
 const USD_FORMATTER = new Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",
@@ -100,6 +119,13 @@ const USD_FORMATTER = new Intl.NumberFormat("en-US", {
 
 function formatUsd(cents: number): string {
   return USD_FORMATTER.format(cents / 100);
+}
+
+function nodeVariantIdForAddOns(includeCo2: boolean, includeNo2: boolean): NodeProductVariantId {
+  if (includeCo2 && includeNo2) return "co2_no2";
+  if (includeCo2) return "co2";
+  if (includeNo2) return "no2";
+  return "standard";
 }
 
 function Section({ title, children }: SectionProps) {
@@ -257,6 +283,79 @@ function InfoTable({ headers, rows }: TableProps) {
   );
 }
 
+function ProductGallery() {
+  const photos = ["Front", "Ports", "Mounted", "Kit"];
+  return (
+    <Flex direction="column" gap="3" style={{ minWidth: 0 }}>
+      <Box
+        style={{
+          aspectRatio: "4 / 3",
+          border: "1px solid var(--gray-a6)",
+          borderRadius: "8px",
+          background:
+            "linear-gradient(135deg, var(--gray-2), var(--gray-4) 58%, var(--accent-a3))",
+          display: "grid",
+          placeItems: "center",
+          overflow: "hidden",
+        }}
+      >
+        <Box
+          style={{
+            width: "48%",
+            maxWidth: "18rem",
+            aspectRatio: "1 / 1",
+            border: "1px solid var(--gray-a7)",
+            borderRadius: "8px",
+            background: "var(--color-panel-solid)",
+            boxShadow: "0 18px 45px var(--gray-a5)",
+            position: "relative",
+          }}
+        >
+          <Box
+            style={{
+              position: "absolute",
+              inset: "18%",
+              borderRadius: "6px",
+              border: "1px solid var(--gray-a6)",
+              background: "var(--gray-2)",
+            }}
+          />
+          <Box
+            style={{
+              position: "absolute",
+              right: "14%",
+              bottom: "14%",
+              width: "22%",
+              aspectRatio: "1 / 1",
+              borderRadius: "999px",
+              background: "var(--green-9)",
+            }}
+          />
+        </Box>
+      </Box>
+      <Flex gap="2" wrap="wrap">
+        {photos.map((label, index) => (
+          <Box
+            key={label}
+            style={{
+              flex: "1 1 5.5rem",
+              minWidth: "5.5rem",
+              aspectRatio: "1 / 1",
+              border: index === 0 ? "2px solid var(--accent-8)" : "1px solid var(--gray-a6)",
+              borderRadius: "8px",
+              background: "var(--gray-3)",
+              display: "grid",
+              placeItems: "center",
+            }}
+          >
+            <Text size="1" color="gray">{label}</Text>
+          </Box>
+        ))}
+      </Flex>
+    </Flex>
+  );
+}
+
 type CheckoutNotice = "success" | "cancelled" | null;
 
 function readCheckoutNotice(): CheckoutNotice {
@@ -272,8 +371,14 @@ export default function NodePage() {
   const [checkoutError, setCheckoutError] = useState("");
   const [checkoutNotice, setCheckoutNotice] = useState<CheckoutNotice>(readCheckoutNotice);
   const [openLegalDocument, setOpenLegalDocument] = useState<LegalDocumentId | null>(null);
-  const [selectedVariantId, setSelectedVariantId] = useState<NodeProductVariantId>("standard");
+  const [includeCo2, setIncludeCo2] = useState(false);
+  const [includeNo2, setIncludeNo2] = useState(false);
+  const [quantity, setQuantity] = useState(1);
+  const selectedVariantId = nodeVariantIdForAddOns(includeCo2, includeNo2);
   const selectedVariant = NODE_PRODUCT_VARIANTS.find(({ id }) => id === selectedVariantId) ?? NODE_PRODUCT_VARIANTS[0];
+  const unitAddOnAmountCents = (includeCo2 ? CO2_SENSOR_ADD_ON_CENTS : 0) + (includeNo2 ? NO2_SENSOR_ADD_ON_CENTS : 0);
+  const unitTotalAmountCents = BASE_NODE_PRICE_CENTS + unitAddOnAmountCents;
+  const orderSubtotalCents = unitTotalAmountCents * quantity;
 
   useEffect(() => {
     setCheckoutNotice(readCheckoutNotice());
@@ -283,7 +388,7 @@ export default function NodePage() {
     setCheckoutError("");
     setIsStartingCheckout(true);
     try {
-      const session = await createNodePurchaseCheckoutSession(selectedVariant.id);
+      const session = await createNodePurchaseCheckoutSession(selectedVariant.id, quantity);
       window.location.assign(session.url);
       return;
     }
@@ -299,15 +404,9 @@ export default function NodePage() {
   return (
     <>
       <Flex direction="column" gap="5">
-      {/* ---- Hero ---- */}
       <Box>
-        <Flex
-          justify="between"
-          align="start"
-          gap="4"
-          wrap="wrap"
-        >
-          <Box style={{ maxWidth: "46rem" }}>
+        <Flex direction={{ initial: "column", md: "row" }} align="start" gap="5">
+          <Box style={{ flex: "1 1 34rem", minWidth: 0 }}>
             <Heading as="h1" size="5">
               Products - CrowdPM Node Hardware
             </Heading>
@@ -315,109 +414,178 @@ export default function NodePage() {
               A CrowdPM node is a small air-quality computer that measures PM2.5,
               records where and when the measurement happened, stores the reading
               locally, and uploads the data to CrowdPM when internet is available.
-              Multiple product options are available: the current PM2.5 build, a
-              CO2 add-on build, a NO2 car-exhaust build, and a combined CO2 + NO2
-              build.
             </Text>
             <Text size="2" mt="3" as="p">
-              Base price starts at {formatUsd(BASE_NODE_PRICE_CENTS)} per node with
-              US shipping included. The add-on sensor options below use the current
-              Amazon hardware prices listed on this page, and sales tax is calculated
-              at checkout from the shipping address.
+              Start with the standard PM2.5 node, then add CO2, NO2, both sensors,
+              or neither. US shipping is included; sales tax is calculated at checkout.
             </Text>
+            <Box mt="4">
+              <ProductGallery />
+            </Box>
           </Box>
 
-          <Flex direction="column" gap="2" style={{ maxWidth: "23rem", width: "100%" }}>
-            {NODE_PRODUCT_VARIANTS.map((variant) => {
-              const isSelected = variant.id === selectedVariant.id;
-              return (
-                <Card
-                  key={variant.id}
-                  style={{
-                    padding: 0,
-                    border: isSelected ? "1px solid var(--accent-8)" : "1px solid var(--gray-a5)",
-                    background: isSelected ? "var(--accent-a3)" : "var(--color-surface)",
-                  }}
-                >
-                  <button
-                    type="button"
-                    onClick={() => setSelectedVariantId(variant.id)}
-                    aria-pressed={isSelected}
-                    style={{
-                      all: "unset",
-                      boxSizing: "border-box",
-                      cursor: "pointer",
-                      display: "block",
-                      width: "100%",
-                      padding: "0.875rem",
-                    }}
-                  >
-                    <Flex align="start" justify="between" gap="3">
-                      <Box>
-                        <Text size="2" as="div" style={{ fontWeight: 600 }}>
-                          {variant.label}
-                        </Text>
-                        <Text size="1" color="gray" as="p" mt="1">
-                          {variant.summary}
-                        </Text>
-                      </Box>
-                      <Text size="2" as="span" style={{ fontWeight: 600, whiteSpace: "nowrap" }}>
-                        {formatUsd(variant.totalAmountCents)}
-                      </Text>
-                    </Flex>
-                  </button>
-                </Card>
-              );
-            })}
+          <Card style={{ flex: "0 1 28rem", width: "100%" }}>
+            <Flex direction="column" gap="4">
+              <Box>
+                <Text size="1" color="gray" as="div" style={{ textTransform: "uppercase", fontWeight: 600 }}>
+                  Standard configuration
+                </Text>
+                <Heading as="h2" size="4" mt="1">
+                  CrowdPM Node
+                </Heading>
+                <Flex align="baseline" gap="2" mt="2" wrap="wrap">
+                  <Text as="div" size="6" weight="bold">
+                    {formatUsd(unitTotalAmountCents)}
+                  </Text>
+                  <Text size="2" color="gray">per device</Text>
+                </Flex>
+                <Text size="2" color="gray" as="p" mt="2">
+                  {selectedVariant.summary}
+                </Text>
+              </Box>
 
-            <Text size="2" as="p">
-              Selected price: {formatUsd(selectedVariant.totalAmountCents)}.
-              {" "}This option adds {formatUsd(selectedVariant.addOnAmountCents)} over the
-              {" "}{formatUsd(BASE_NODE_PRICE_CENTS)} base node.
-            </Text>
-            <Button
-              size="3"
-              onClick={() => { void handlePurchaseNode(); }}
-              disabled={isStartingCheckout}
-            >
-              {isStartingCheckout
-                ? "Opening Checkout..."
-                : `Purchase Selected Product - ${formatUsd(selectedVariant.totalAmountCents)}`}
-            </Button>
-            <Text size="1" color="gray" as="p">
-              Sold by Denuo Web LLC as a one-time hardware purchase. US shipping is
-              included, sales tax is calculated in Stripe Checkout, and selected
-              sensor add-ons are reflected in the checkout price. Node orders are
-              subject to the{" "}
-              <LegalDocumentLink documentId="terms" onOpen={setOpenLegalDocument}>
-                Terms
-              </LegalDocumentLink>
-              ,{" "}
-              <LegalDocumentLink documentId="license" onOpen={setOpenLegalDocument}>
-                License
-              </LegalDocumentLink>
-              , and{" "}
-              <LegalDocumentLink documentId="privacy" onOpen={setOpenLegalDocument}>
-                Privacy Policy
-              </LegalDocumentLink>
-              .
-            </Text>
-            <Text size="1" color="gray" as="p">
-              You are purchasing physical CrowdPM node hardware and any expressly
-              listed related services from Denuo Web LLC. CrowdPM Platform software
-              is open-source software maintained by Denuo Web LLC and contributors.
-              Purchase of hardware does not restrict your rights under the applicable
-              open-source software license or transfer ownership of Denuo Web LLC
-              trademarks, branding, hosted infrastructure, customer accounts, or
-              proprietary business materials.
-            </Text>
-          </Flex>
+              <Separator size="4" />
+
+              <Box>
+                <Text size="2" weight="bold" as="div" mb="2">
+                  Included
+                </Text>
+                <BulletList>
+                  <ListItem>PM2.5 sensing, GPS, temperature/humidity, local storage, and battery management.</ListItem>
+                  <ListItem>US shipping and first-time setup documentation.</ListItem>
+                </BulletList>
+              </Box>
+
+              <Box>
+                <Text size="2" weight="bold" as="div" mb="2">
+                  Add-ons
+                </Text>
+                <Flex direction="column" gap="2">
+                  {SENSOR_ADD_ONS.map((addOn) => {
+                    const checked = addOn.id === "co2" ? includeCo2 : includeNo2;
+                    const setChecked = addOn.id === "co2" ? setIncludeCo2 : setIncludeNo2;
+                    return (
+                      <Box
+                        key={addOn.id}
+                        asChild
+                        style={{
+                          border: checked ? "1px solid var(--accent-8)" : "1px solid var(--gray-a6)",
+                          borderRadius: "8px",
+                          background: checked ? "var(--accent-a3)" : "var(--color-surface)",
+                          cursor: "pointer",
+                          padding: "0.75rem",
+                        }}
+                      >
+                        <label>
+                          <Flex align="start" gap="3">
+                            <Checkbox
+                              checked={checked}
+                              onCheckedChange={(nextChecked) => setChecked(nextChecked === true)}
+                              mt="1"
+                            />
+                            <Flex justify="between" gap="3" style={{ flex: 1 }}>
+                              <Box>
+                                <Text size="2" weight="bold" as="div">{addOn.label}</Text>
+                                <Text size="1" color="gray" as="p" mt="1">{addOn.description}</Text>
+                              </Box>
+                              <Text size="2" weight="bold" style={{ whiteSpace: "nowrap" }}>
+                                +{formatUsd(addOn.amountCents)}
+                              </Text>
+                            </Flex>
+                          </Flex>
+                        </label>
+                      </Box>
+                    );
+                  })}
+                </Flex>
+              </Box>
+
+              <Flex align="center" justify="between" gap="3">
+                <Box>
+                  <Text size="2" weight="bold" as="div">
+                    Quantity
+                  </Text>
+                  <Text size="1" color="gray">Up to 10 devices per checkout</Text>
+                </Box>
+                <Box style={{ width: "7rem" }}>
+                  <Select.Root
+                    value={String(quantity)}
+                    onValueChange={(value) => setQuantity(Number(value))}
+                  >
+                    <Select.Trigger aria-label="Quantity" />
+                    <Select.Content>
+                      {NODE_QUANTITY_OPTIONS.map((option) => (
+                        <Select.Item key={option} value={String(option)}>
+                          {option}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Root>
+                </Box>
+              </Flex>
+
+              <Box
+                style={{
+                  borderTop: "1px solid var(--gray-a5)",
+                  paddingTop: "var(--space-3)",
+                }}
+              >
+                <Flex justify="between" gap="3">
+                  <Text size="2" color="gray">Base node</Text>
+                  <Text size="2">{formatUsd(BASE_NODE_PRICE_CENTS)}</Text>
+                </Flex>
+                <Flex justify="between" gap="3" mt="1">
+                  <Text size="2" color="gray">Selected add-ons</Text>
+                  <Text size="2">{unitAddOnAmountCents === 0 ? "$0.00" : `+${formatUsd(unitAddOnAmountCents)}`}</Text>
+                </Flex>
+                <Flex justify="between" gap="3" mt="1">
+                  <Text size="2" color="gray">Quantity</Text>
+                  <Text size="2">x {quantity}</Text>
+                </Flex>
+                <Separator size="4" my="3" />
+                <Flex justify="between" align="center" gap="3">
+                  <Text size="3" weight="bold">Subtotal</Text>
+                  <Text as="div" size="5" weight="bold">{formatUsd(orderSubtotalCents)}</Text>
+                </Flex>
+                <Text size="1" color="gray" as="p" mt="1">
+                  Sales tax is calculated in Stripe Checkout.
+                </Text>
+              </Box>
+
+              <Button
+                size="3"
+                onClick={() => { void handlePurchaseNode(); }}
+                disabled={isStartingCheckout}
+              >
+                {isStartingCheckout
+                  ? "Opening Checkout..."
+                  : `Checkout - ${formatUsd(orderSubtotalCents)}`}
+              </Button>
+
+              <Text size="1" color="gray" as="p">
+                Sold by Denuo Web LLC as a one-time hardware purchase. Orders are
+                subject to the{" "}
+                <LegalDocumentLink documentId="terms" onOpen={setOpenLegalDocument}>
+                  Terms
+                </LegalDocumentLink>
+                ,{" "}
+                <LegalDocumentLink documentId="license" onOpen={setOpenLegalDocument}>
+                  License
+                </LegalDocumentLink>
+                , and{" "}
+                <LegalDocumentLink documentId="privacy" onOpen={setOpenLegalDocument}>
+                  Privacy Policy
+                </LegalDocumentLink>
+                .
+              </Text>
+            </Flex>
+          </Card>
         </Flex>
 
         {checkoutNotice === "success" ? (
           <Callout.Root color="green" variant="surface" mt="4">
             <Callout.Text>
-              Checkout completed. Stripe will email the receipt for your node purchase.
+              Checkout completed. Stripe will email a receipt. Signed-in purchases also appear in the dashboard.
             </Callout.Text>
           </Callout.Root>
         ) : null}
@@ -439,22 +607,21 @@ export default function NodePage() {
 
       <Separator size="4" />
 
-      <Section title="Available Product Options">
+      <Section title="Configuration Options">
         <Text size="2" color="gray" as="p">
-          CrowdPM currently sells one standard PM2.5 node and three sensor-expanded
-          options. The add-on amounts below use the Amazon prices for the listed
-          sensor hardware and, where required, the extra interface board needed to
-          make the sensor compatible with the Raspberry Pi Zero 2 W.
+          Each order starts with the standard PM2.5 node. Add CO2, NO2, both
+          sensors, or neither; the selected configuration applies to every device
+          in the checkout quantity.
         </Text>
 
         <InfoTable
-          headers={["Option", "Added hardware", "Added price", "Total price"]}
-          rows={NODE_PRODUCT_VARIANTS.map((variant) => [
-            variant.label,
-            variant.addedHardware,
-            variant.addOnAmountCents === 0 ? "Included in base build" : `+${formatUsd(variant.addOnAmountCents)}`,
-            formatUsd(variant.totalAmountCents),
-          ])}
+          headers={["Configuration", "What it adds", "Price"]}
+          rows={[
+            ["Standard node", NODE_PRODUCT_VARIANTS[0].addedHardware, formatUsd(BASE_NODE_PRICE_CENTS)],
+            ["CO2 add-on", "SCD41 CO2 sensor", `+${formatUsd(CO2_SENSOR_ADD_ON_CENTS)}`],
+            ["NO2 add-on", "MiCS-6814 NO2 module + ADS1115 ADC", `+${formatUsd(NO2_SENSOR_ADD_ON_CENTS)}`],
+            ["Quantity", "1 to 10 devices per checkout", "Applied at checkout"],
+          ]}
         />
 
         <Callout.Root color="blue" variant="surface">
@@ -571,8 +738,8 @@ export default function NodePage() {
         <Text size="2" color="gray" as="p">
           This page focuses on the standard CrowdPM mobile node prototype: a
           Raspberry Pi Zero 2 W, PM2.5 sensor, GPS, temperature/humidity sensor,
-          local setup controls, and integrated battery management. Optional build
-          variants add CO2 sensing, NO2 vehicle-exhaust sensing, or both.
+          local setup controls, and integrated battery management. Optional
+          add-ons can include CO2 sensing, NO2 vehicle-exhaust sensing, or both.
         </Text>
         <Text size="1" color="gray" as="p">
           As an Amazon Associate I earn from qualifying purchases. Hardware part

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -7,11 +7,13 @@ import {
   deleteBatch,
   listBatches,
   listDevices,
+  listNodePurchaseReceipts,
   revokeDevice,
   updateBatchVisibility,
   type BatchSummary,
   type BatchVisibility,
   type DeviceSummary,
+  type NodePurchaseReceipt,
 } from "../lib/api";
 import { APP_ROUTES } from "../lib/appRoutes";
 import { logError } from "../lib/logger";
@@ -35,6 +37,30 @@ function describeStatus(status?: string | null): { label: string; tone: "green" 
   return { label: status ?? "Unknown", tone: "red" };
 }
 
+function formatReceiptMoney(cents: number | null, currency: string | null | undefined): string {
+  if (typeof cents !== "number" || !Number.isFinite(cents)) {
+    return "—";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: (currency ?? "usd").toUpperCase(),
+  }).format(cents / 100);
+}
+
+function formatReceiptDate(value: string | null): string {
+  if (!value) return "—";
+  const millis = Date.parse(value);
+  return Number.isNaN(millis) ? "—" : new Date(millis).toLocaleString();
+}
+
+function formatShippingLocation(receipt: NodePurchaseReceipt): string {
+  const address = receipt.shippingAddress;
+  const city = address?.city?.trim();
+  const state = address?.state?.trim();
+  if (city && state) return `${city}, ${state}`;
+  return city || state || "—";
+}
+
 export default function UserDashboard({ onRequestActivation, onOpenSmokeTest, onOpenThemeModal, refreshToken = 0 }: UserDashboardProps) {
   const { user } = useAuth();
   const { settings, isLoading: isSettingsLoading, isSaving: isSettingsSaving, error: settingsError, updateSettings } = useUserSettings();
@@ -53,6 +79,9 @@ export default function UserDashboard({ onRequestActivation, onOpenSmokeTest, on
   const [updatingBatchKey, setUpdatingBatchKey] = useState<string | null>(null);
   const [deletingBatchKey, setDeletingBatchKey] = useState<string | null>(null);
   const [batchPageIndex, setBatchPageIndex] = useState(0);
+  const [receipts, setReceipts] = useState<NodePurchaseReceipt[]>([]);
+  const [isLoadingReceipts, setIsLoadingReceipts] = useState(false);
+  const [receiptsError, setReceiptsError] = useState<string | null>(null);
   const [settingsMessage, setSettingsMessage] = useState<string | null>(null);
   const [settingsLocalError, setSettingsLocalError] = useState<string | null>(null);
   const activationUrl = useMemo(() => buildActivationLink(), []);
@@ -100,12 +129,35 @@ export default function UserDashboard({ onRequestActivation, onOpenSmokeTest, on
     }
   }, [user]);
 
+  const refreshReceipts = useCallback(async () => {
+    if (!user) {
+      setReceipts([]);
+      setReceiptsError(null);
+      return;
+    }
+    setIsLoadingReceipts(true);
+    setReceiptsError(null);
+    try {
+      const next = await listNodePurchaseReceipts();
+      setReceipts(next);
+    }
+    catch (err) {
+      setReceipts([]);
+      setReceiptsError(err instanceof Error ? err.message : "Unable to load hardware receipts");
+    }
+    finally {
+      setIsLoadingReceipts(false);
+    }
+  }, [user]);
+
   useEffect(() => {
     void refreshDevices();
     void refreshBatches();
-  }, [refreshBatches, refreshDevices, refreshToken]);
+    void refreshReceipts();
+  }, [refreshBatches, refreshDevices, refreshReceipts, refreshToken]);
 
   const ownedCount = useMemo(() => devices.length, [devices]);
+  const completedReceiptCount = useMemo(() => receipts.length, [receipts.length]);
   const activeCount = useMemo(
     () => devices.filter((device) => describeStatus(device.registryStatus ?? device.status).tone === "green").length,
     [devices],
@@ -381,14 +433,90 @@ export default function UserDashboard({ onRequestActivation, onOpenSmokeTest, on
               <Text size="2" color="gray">Active</Text>
               <Heading size="6">{activeCount}</Heading>
             </Flex>
+            <Flex direction="column" gap="1">
+              <Text size="2" color="gray">Hardware orders</Text>
+              <Heading size="6">{completedReceiptCount}</Heading>
+            </Flex>
           </Flex>
-          <Button variant="soft" onClick={refreshDevices} disabled={isLoadingDevices}>
-            <ReloadIcon /> {isLoadingDevices ? "Refreshing" : "Refresh"}
+          <Button
+            variant="soft"
+            onClick={() => { void Promise.all([refreshDevices(), refreshReceipts()]); }}
+            disabled={isLoadingDevices || isLoadingReceipts}
+          >
+            <ReloadIcon /> {isLoadingDevices || isLoadingReceipts ? "Refreshing" : "Refresh"}
           </Button>
         </Flex>
         {devicesError ? (
           <Text mt="3" color="tomato">{devicesError}</Text>
         ) : null}
+      </Card>
+
+      <Card>
+        <Flex direction="column" gap="3">
+          <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">
+            <Box>
+              <Heading as="h3" size="4">Hardware receipts</Heading>
+              <Text color="gray">Completed node purchases tied to this signed-in account.</Text>
+            </Box>
+            <Button variant="soft" onClick={refreshReceipts} disabled={isLoadingReceipts}>
+              <ReloadIcon /> {isLoadingReceipts ? "Refreshing" : "Refresh"}
+            </Button>
+          </Flex>
+          <Separator my="2" size="4" />
+          {receiptsError ? (
+            <Callout.Root color="tomato">
+              <Callout.Text>{receiptsError}</Callout.Text>
+            </Callout.Root>
+          ) : null}
+          {receipts.length === 0 ? (
+            <Text color="gray" style={{ fontStyle: "italic" }}>
+              {isLoadingReceipts ? "Loading receipts…" : "No completed hardware purchases for this account."}
+            </Text>
+          ) : (
+            <Table.Root>
+              <Table.Header>
+                <Table.Row>
+                  <Table.ColumnHeaderCell>Date</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Configuration</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Qty</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Total</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Ship to</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Payment</Table.ColumnHeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {receipts.map((receipt) => (
+                  <Table.Row key={receipt.sessionId}>
+                    <Table.Cell>
+                      <Flex direction="column" gap="1">
+                        <Text>{formatReceiptDate(receipt.completedAt)}</Text>
+                        <Text size="1" color="gray" style={{ fontFamily: "monospace" }}>
+                          {receipt.sessionId}
+                        </Text>
+                      </Flex>
+                    </Table.Cell>
+                    <Table.Cell>{receipt.variantLabel ?? "CrowdPM Node Hardware"}</Table.Cell>
+                    <Table.Cell>{receipt.quantity}</Table.Cell>
+                    <Table.Cell>
+                      <Flex direction="column" gap="1">
+                        <Text weight="medium">{formatReceiptMoney(receipt.amountTotal, receipt.currency)}</Text>
+                        <Text size="1" color="gray">
+                          Tax {formatReceiptMoney(receipt.amountTax, receipt.currency)}
+                        </Text>
+                      </Flex>
+                    </Table.Cell>
+                    <Table.Cell>{formatShippingLocation(receipt)}</Table.Cell>
+                    <Table.Cell>
+                      <Badge color={receipt.paymentStatus === "paid" ? "green" : "gray"} variant="soft">
+                        {receipt.paymentStatus ?? "completed"}
+                      </Badge>
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table.Root>
+          )}
+        </Flex>
       </Card>
 
       <Card id="user-settings">

--- a/functions/README.md
+++ b/functions/README.md
@@ -35,7 +35,7 @@ Important values:
 
 The code reads these values from `process.env`. In deployed Firebase Functions, `DEVICE_TOKEN_PRIVATE_KEY`, `STRIPE_SECRET_KEY`, and `STRIPE_WEBHOOK_SECRET` are expected to come from Secret Manager via each function's `secrets` binding, while the remaining runtime values can come from dotenv-backed env files.
 
-The node purchase flow now relies on Stripe Checkout shipping-address collection plus Stripe Tax. Configure Stripe Tax in the Stripe Dashboard so the physical-goods product can add US sales tax on top of the `$350` base node price after the buyer enters a US shipping address. Optional CO2 and NO2 hardware variants add their own pre-tax sensor surcharge before checkout.
+The node purchase flow now relies on Stripe Checkout shipping-address collection plus Stripe Tax. Configure Stripe Tax in the Stripe Dashboard so the physical-goods product can add US sales tax on top of the `$350` base node price after the buyer enters a US shipping address. Optional CO2 and NO2 add-ons are `$25` each before tax.
 
 Stripe Checkout can still show `$0.00` tax for a valid US address when the Stripe account is not registered to collect tax in that jurisdiction. In Stripe's tax breakdown, that appears as `taxability_reason=not_collecting`. This is expected account configuration behavior, not a missing `automatic_tax` integration parameter.
 

--- a/functions/src/lib/routeGuards.ts
+++ b/functions/src/lib/routeGuards.ts
@@ -40,6 +40,18 @@ export function requireUserGuard(options?: RequireUserOptions): preHandlerHookHa
   };
 }
 
+export function optionalUserGuard(options?: RequireUserOptions): preHandlerHookHandler {
+  return async (req) => {
+    const rawAuthorization = req.headers.authorization;
+    const authorization = Array.isArray(rawAuthorization) ? rawAuthorization[0] ?? "" : rawAuthorization ?? "";
+    if (!authorization.startsWith("Bearer ") || authorization.slice(7).trim().length === 0) {
+      return;
+    }
+    const user = await requireUser(req, options);
+    (req as GuardedRequest).user = user;
+  };
+}
+
 export function requirePermissionGuard(permission: Permission): preHandlerHookHandler {
   return async (req) => {
     const user = await requireUser(req);
@@ -56,6 +68,10 @@ export function getRequestUser(req: FastifyRequest): DecodedIdToken {
     throw httpError(401, "unauthorized", "Authentication required");
   }
   return user;
+}
+
+export function getOptionalRequestUser(req: FastifyRequest): DecodedIdToken | null {
+  return (req as GuardedRequest).user ?? null;
 }
 
 export function requestUserId(req: FastifyRequest): string {

--- a/functions/src/openapi.yaml
+++ b/functions/src/openapi.yaml
@@ -36,13 +36,12 @@ paths:
         purchase. Checkout collects a US shipping address, applies Stripe Tax
         based on that destination, and charges the selected hardware variant.
         The standard PM2.5 node starts at a $350 base price with shipping
-        included, while optional CO2 and NO2 sensor add-ons increase the final
-        pre-tax amount. The purchase covers physical node hardware and expressly
-        listed related services; it does not transfer proprietary rights in
-        CrowdPM Platform software or restrict rights under applicable open-source
-        licenses. The API lazily provisions the backing Stripe product + price
-        for each variant the first time that variant is requested, then reuses
-        the stored identifiers on later requests.
+        included, while optional CO2 and NO2 sensor add-ons are $25 each before
+        tax. The selected quantity can be 1 through 10 devices. If a valid
+        bearer token is supplied, the completed hardware receipt is tied to that
+        account. The API lazily provisions the backing Stripe product + price for
+        each variant the first time that variant is requested, then reuses the
+        stored identifiers on later requests.
       security: []
       requestBody:
         required: false
@@ -65,6 +64,26 @@ paths:
           description: Stripe or application configuration is missing.
         '502':
           description: Stripe returned an upstream error.
+  /v1/node-purchase/receipts:
+    get:
+      operationId: listNodePurchaseReceipts
+      summary: List signed-in user's node hardware receipts
+      description: Returns completed CrowdPM node hardware purchase receipts tied to the signed-in account.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Completed node hardware receipts.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NodePurchaseReceipt'
+        '401':
+          description: Missing or invalid bearer token.
+        '429':
+          description: Rate limited.
   /v1/theme-purchase/checkout-session:
     post:
       operationId: createThemeSaveCheckoutSession
@@ -914,6 +933,86 @@ components:
             - co2
             - co2_no2
           description: Selected CrowdPM hardware product variant.
+        quantity:
+          type: integer
+          minimum: 1
+          maximum: 10
+          default: 1
+          description: Number of devices to purchase in this checkout.
+    NodePurchaseReceipt:
+      type: object
+      required:
+        - sessionId
+        - purchaseType
+        - status
+        - quantity
+        - currency
+      properties:
+        sessionId:
+          type: string
+          description: Stripe Checkout session identifier.
+        purchaseType:
+          type: string
+          enum: [node_hardware]
+        status:
+          type: string
+          enum: [completed]
+        paymentStatus:
+          type: string
+          nullable: true
+        variantId:
+          type: string
+          nullable: true
+          enum:
+            - standard
+            - no2
+            - co2
+            - co2_no2
+        variantLabel:
+          type: string
+          nullable: true
+        quantity:
+          type: integer
+          minimum: 1
+          maximum: 10
+        currency:
+          type: string
+          example: usd
+        unitAmount:
+          type: integer
+          nullable: true
+          description: Per-device pre-tax price in the smallest currency unit.
+        amountSubtotal:
+          type: integer
+          nullable: true
+        amountTax:
+          type: integer
+          nullable: true
+        amountShipping:
+          type: integer
+          nullable: true
+        amountDiscount:
+          type: integer
+          nullable: true
+        amountTotal:
+          type: integer
+          nullable: true
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+        customerEmail:
+          type: string
+          nullable: true
+        shippingName:
+          type: string
+          nullable: true
+        shippingAddress:
+          type: object
+          nullable: true
+          additionalProperties:
+            type: string
+            nullable: true
     DeviceStatus:
       type: string
       enum:

--- a/functions/src/routes/nodePurchase.ts
+++ b/functions/src/routes/nodePurchase.ts
@@ -2,12 +2,20 @@ import type { FastifyPluginAsync, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { extractClientIp } from "../lib/http.js";
 import { httpError } from "../lib/httpError.js";
-import { getRequestUser, rateLimitGuard, requestUserId, requireUserGuard } from "../lib/routeGuards.js";
+import {
+  getOptionalRequestUser,
+  getRequestUser,
+  optionalUserGuard,
+  rateLimitGuard,
+  requestUserId,
+  requireUserGuard,
+} from "../lib/routeGuards.js";
 import {
   confirmThemeSaveCheckoutSession,
   createNodePurchaseCheckoutSession,
   createThemeSaveCheckoutSession,
   handleStripeWebhook,
+  listNodePurchaseReceipts,
 } from "../services/nodePurchase.js";
 
 type RequestWithRawBody = {
@@ -16,6 +24,7 @@ type RequestWithRawBody = {
 
 const nodeCheckoutBodySchema = z.object({
   variantId: z.enum(["standard", "co2", "no2", "co2_no2"]).optional(),
+  quantity: z.number().int().min(1).max(10).optional(),
 }).strict();
 
 const confirmThemeCheckoutBodySchema = z.object({
@@ -36,6 +45,7 @@ function rawBodyAsString(req: FastifyRequest): string {
 export const nodePurchaseRoutes: FastifyPluginAsync = async (app) => {
   app.post("/v1/node-purchase/checkout-session", {
     preHandler: [
+      optionalUserGuard(),
       rateLimitGuard((req) => `node-purchase:checkout:ip:${requestIp(req)}`, 30, 60_000),
       rateLimitGuard("node-purchase:checkout:global", 1_000, 60_000),
     ],
@@ -44,10 +54,24 @@ export const nodePurchaseRoutes: FastifyPluginAsync = async (app) => {
     if (!parsed.success) {
       throw httpError(400, "invalid_request", "invalid request", { details: parsed.error.flatten() });
     }
+    const user = getOptionalRequestUser(req);
     return createNodePurchaseCheckoutSession({
       variantId: parsed.data.variantId,
+      quantity: parsed.data.quantity,
+      userId: user?.uid,
+      customerEmail: user?.email ?? null,
     });
   });
+
+  app.get("/v1/node-purchase/receipts", {
+    preHandler: [
+      requireUserGuard(),
+      rateLimitGuard((req) => `node-purchase:receipts:user:${requestUserId(req)}`, 60, 60_000),
+      rateLimitGuard("node-purchase:receipts:global", 2_000, 60_000),
+    ],
+  }, async (req) => listNodePurchaseReceipts({
+    userId: requestUserId(req),
+  }));
 
   app.post("/v1/theme-purchase/checkout-session", {
     preHandler: [

--- a/functions/src/services/nodePurchase.ts
+++ b/functions/src/services/nodePurchase.ts
@@ -13,6 +13,8 @@ const NODE_HARDWARE_CHECKOUT_SUBMIT_MESSAGE = "You are purchasing physical Crowd
 const NODE_HARDWARE_SHIPPING_ADDRESS_MESSAGE = "We currently ship CrowdPM nodes only to addresses in the United States.";
 const THEME_SAVE_UNLOCK_CHECKOUT_SUBMIT_MESSAGE = "One-time digital expansion purchase that permanently unlocks theme preference saving for the purchasing account. Applicable sales tax is calculated at checkout.";
 const DEFAULT_NODE_HARDWARE_VARIANT_ID = "standard";
+const DEFAULT_NODE_HARDWARE_QUANTITY = 1;
+const MAX_NODE_HARDWARE_QUANTITY = 10;
 
 type PaymentCatalog = {
   productId: string;
@@ -50,6 +52,27 @@ export type NodePurchaseCheckoutSession = {
 };
 
 export type NodePurchaseVariantId = "standard" | "co2" | "no2" | "co2_no2";
+
+export type NodePurchaseReceipt = {
+  sessionId: string;
+  purchaseType: "node_hardware";
+  status: "completed";
+  paymentStatus: string | null;
+  variantId: NodePurchaseVariantId | null;
+  variantLabel: string | null;
+  quantity: number;
+  currency: string;
+  unitAmount: number | null;
+  amountSubtotal: number | null;
+  amountTax: number | null;
+  amountShipping: number | null;
+  amountDiscount: number | null;
+  amountTotal: number | null;
+  completedAt: string | null;
+  customerEmail: string | null;
+  shippingName: string | null;
+  shippingAddress: Record<string, string | null> | null;
+};
 
 type NodeHardwareVariantConfig = Pick<CheckoutProductConfig, "catalogDocId" | "productName" | "description" | "unitAmount"> & {
   label: string;
@@ -91,21 +114,21 @@ const NODE_HARDWARE_VARIANTS: Record<NodePurchaseVariantId, NodeHardwareVariantC
     label: "PM2.5 + NO2 node",
     productName: "CrowdPM Node Hardware - PM2.5 + NO2",
     description: "PM2.5 node with MiCS-6814 NO2 sensor and ADS1115 interface hardware, with US shipping included.",
-    unitAmount: 38_394,
+    unitAmount: 37_500,
   },
   co2: {
     catalogDocId: "nodeHardwareCo2",
     label: "PM2.5 + CO2 node",
     productName: "CrowdPM Node Hardware - PM2.5 + CO2",
     description: "PM2.5 node with SCD41 CO2 sensor hardware, with US shipping included.",
-    unitAmount: 37_899,
+    unitAmount: 37_500,
   },
   co2_no2: {
     catalogDocId: "nodeHardwareCo2No2",
     label: "PM2.5 + CO2 + NO2 node",
     productName: "CrowdPM Node Hardware - PM2.5 + CO2 + NO2",
     description: "PM2.5 node with SCD41 CO2 sensor, MiCS-6814 NO2 sensor, and ADS1115 interface hardware, with US shipping included.",
-    unitAmount: 41_293,
+    unitAmount: 40_000,
   },
 };
 
@@ -163,6 +186,18 @@ function readNodeVariantId(value: unknown): NodePurchaseVariantId | null {
     return value;
   }
   return null;
+}
+
+function readFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function readNodeQuantity(value: unknown): number | null {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_NODE_HARDWARE_QUANTITY) {
+    return null;
+  }
+  return parsed;
 }
 
 function extractExpandableId(value: string | { id: string } | null | undefined): string | null {
@@ -305,6 +340,7 @@ async function ensureCatalog(config: CheckoutProductConfig): Promise<PaymentCata
 type CreateCheckoutSessionOptions = {
   customerEmail?: string | null;
   userId?: string;
+  quantity?: number;
   metadata?: Record<string, string>;
   sessionData?: Record<string, unknown>;
 };
@@ -315,6 +351,7 @@ async function createCheckoutSession(
 ): Promise<NodePurchaseCheckoutSession> {
   const catalog = await ensureCatalog(config);
   const { successUrl, cancelUrl } = checkoutRedirectUrls(config);
+  const quantity = options.quantity ?? DEFAULT_NODE_HARDWARE_QUANTITY;
   const metadata: Record<string, string> = {
     purchaseType: config.purchaseType,
   };
@@ -329,7 +366,7 @@ async function createCheckoutSession(
     line_items: [
       {
         price: catalog.defaultPriceId,
-        quantity: 1,
+        quantity,
       },
     ],
     mode: "payment",
@@ -377,6 +414,7 @@ async function createCheckoutSession(
     checkoutUrl: session.url,
     currency: session.currency ?? catalog.currency,
     unitAmount: catalog.unitAmount,
+    quantity,
     automaticTaxEnabled: true,
     amountSubtotal: session.amount_subtotal ?? null,
     amountTotal: session.amount_total ?? null,
@@ -401,17 +439,26 @@ async function ensureThemeSaveLocked(userId: string): Promise<void> {
 
 export async function createNodePurchaseCheckoutSession(args: {
   variantId?: NodePurchaseVariantId;
+  quantity?: number;
+  userId?: string;
+  customerEmail?: string | null;
 } = {}): Promise<NodePurchaseCheckoutSession> {
   const variantId = args.variantId ?? DEFAULT_NODE_HARDWARE_VARIANT_ID;
+  const quantity = args.quantity ?? DEFAULT_NODE_HARDWARE_QUANTITY;
   const variant = NODE_HARDWARE_VARIANTS[variantId];
   return createCheckoutSession(nodeHardwareConfigForVariant(variantId), {
+    userId: args.userId,
+    customerEmail: args.customerEmail,
+    quantity,
     metadata: {
       variantId,
       variantLabel: variant.label,
+      quantity: String(quantity),
     },
     sessionData: {
       variantId,
       variantLabel: variant.label,
+      quantity,
     },
   });
 }
@@ -469,6 +516,19 @@ async function resolvePurchase(session: Stripe.Checkout.Session): Promise<Resolv
 }
 
 function resolveThemeUnlockUserId(
+  session: Stripe.Checkout.Session,
+  storedSession: Record<string, unknown> | null,
+): string | null {
+  const metadataUserId = readNonEmptyString(session.metadata?.userId);
+  if (metadataUserId) return metadataUserId;
+
+  const clientReferenceId = readNonEmptyString(session.client_reference_id);
+  if (clientReferenceId) return clientReferenceId;
+
+  return readNonEmptyString(storedSession?.userId);
+}
+
+function resolveNodePurchaseUserId(
   session: Stripe.Checkout.Session,
   storedSession: Record<string, unknown> | null,
 ): string | null {
@@ -541,14 +601,80 @@ async function recordCompletedSession(
 
   const variantId = readNodeVariantId(session.metadata?.variantId) ?? readNodeVariantId(storedSession?.variantId);
   const variantLabel = readNonEmptyString(session.metadata?.variantLabel) ?? readNonEmptyString(storedSession?.variantLabel);
+  const quantity = readNodeQuantity(session.metadata?.quantity)
+    ?? readNodeQuantity(storedSession?.quantity)
+    ?? DEFAULT_NODE_HARDWARE_QUANTITY;
+  const userId = resolveNodePurchaseUserId(session, storedSession);
   if (variantId) {
     payload.variantId = variantId;
   }
   if (variantLabel) {
     payload.variantLabel = variantLabel;
   }
+  payload.quantity = quantity;
+  if (userId) {
+    payload.userId = userId;
+  }
 
   await db().collection(config.sessionCollection).doc(session.id).set(payload, { merge: true });
+}
+
+function receiptFromSession(data: Record<string, unknown>): NodePurchaseReceipt | null {
+  if (data.purchaseType !== NODE_HARDWARE_BASE_CONFIG.purchaseType || data.status !== "completed") {
+    return null;
+  }
+  const sessionId = readNonEmptyString(data.sessionId);
+  if (!sessionId) {
+    return null;
+  }
+  const shippingDetails = typeof data.shippingDetails === "object" && data.shippingDetails !== null
+    ? data.shippingDetails as Record<string, unknown>
+    : null;
+  const address = typeof shippingDetails?.address === "object" && shippingDetails.address !== null
+    ? shippingDetails.address as Record<string, string | null>
+    : null;
+
+  return {
+    sessionId,
+    purchaseType: "node_hardware",
+    status: "completed",
+    paymentStatus: readNonEmptyString(data.paymentStatus),
+    variantId: readNodeVariantId(data.variantId),
+    variantLabel: readNonEmptyString(data.variantLabel),
+    quantity: readNodeQuantity(data.quantity) ?? DEFAULT_NODE_HARDWARE_QUANTITY,
+    currency: readNonEmptyString(data.currency) ?? "usd",
+    unitAmount: readFiniteNumber(data.unitAmount),
+    amountSubtotal: readFiniteNumber(data.amountSubtotal),
+    amountTax: readFiniteNumber(data.amountTax),
+    amountShipping: readFiniteNumber(data.amountShipping),
+    amountDiscount: readFiniteNumber(data.amountDiscount),
+    amountTotal: readFiniteNumber(data.amountTotal),
+    completedAt: readNonEmptyString(data.completedAt),
+    customerEmail: readNonEmptyString(data.customerEmail),
+    shippingName: readNonEmptyString(shippingDetails?.name),
+    shippingAddress: address,
+  };
+}
+
+export async function listNodePurchaseReceipts(args: {
+  userId: string;
+  limit?: number;
+}): Promise<NodePurchaseReceipt[]> {
+  const limit = Math.min(Math.max(Math.floor(args.limit ?? 20), 1), 50);
+  const snap = await db()
+    .collection(NODE_HARDWARE_BASE_CONFIG.sessionCollection)
+    .where("userId", "==", args.userId)
+    .limit(50)
+    .get();
+  return snap.docs
+    .map((doc) => receiptFromSession(doc.data() as Record<string, unknown>))
+    .filter((receipt): receipt is NodePurchaseReceipt => Boolean(receipt))
+    .sort((a, b) => {
+      const timeA = a.completedAt ? Date.parse(a.completedAt) : 0;
+      const timeB = b.completedAt ? Date.parse(b.completedAt) : 0;
+      return timeB - timeA;
+    })
+    .slice(0, limit);
 }
 
 async function retrieveCheckoutSession(sessionId: string): Promise<Stripe.Checkout.Session> {

--- a/functions/test/routes/nodePurchase.test.ts
+++ b/functions/test/routes/nodePurchase.test.ts
@@ -33,9 +33,36 @@ function makeDocRef(path: string) {
   };
 }
 
+function makeQueryRef(
+  collectionName: string,
+  filters: Array<{ field: string; value: unknown }> = [],
+  queryLimit = Number.POSITIVE_INFINITY,
+) {
+  return {
+    where: vi.fn((field: string, op: string, value: unknown) => {
+      if (op !== "==") throw new Error(`unsupported op ${op}`);
+      return makeQueryRef(collectionName, [...filters, { field, value }], queryLimit);
+    }),
+    limit: vi.fn((limit: number) => makeQueryRef(collectionName, filters, limit)),
+    get: vi.fn(async () => {
+      const prefix = `${collectionName}/`;
+      const docs = Array.from(dbStore.entries())
+        .filter(([path, data]) => path.startsWith(prefix)
+          && filters.every((filter) => data[filter.field] === filter.value))
+        .slice(0, queryLimit)
+        .map(([path, data]) => ({
+          id: path.slice(prefix.length),
+          data: () => ({ ...data }),
+        }));
+      return { docs };
+    }),
+  };
+}
+
 const mockDb = {
   collection: vi.fn((name: string) => ({
     doc: (id: string) => makeDocRef(`${name}/${id}`),
+    where: (field: string, op: string, value: unknown) => makeQueryRef(name).where(field, op, value),
   })),
 };
 
@@ -181,6 +208,7 @@ describe("POST /v1/node-purchase/checkout-session", () => {
         purchaseType: "node_hardware",
         variantId: "standard",
         variantLabel: "PM2.5 standard node",
+        quantity: "1",
       },
       success_url: "https://crowdpmplatform.web.app/node?checkout=success",
       cancel_url: "https://crowdpmplatform.web.app/node?checkout=cancelled",
@@ -202,6 +230,7 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       checkoutUrl: "https://checkout.stripe.com/c/pay/cs_test_123",
       currency: "usd",
       unitAmount: 35000,
+      quantity: 1,
       automaticTaxEnabled: true,
       amountSubtotal: 35000,
       amountTotal: 35000,
@@ -222,8 +251,8 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       url: "https://checkout.stripe.com/c/pay/cs_node_co2_123",
       mode: "payment",
       currency: "usd",
-      amount_subtotal: 37899,
-      amount_total: 37899,
+      amount_subtotal: 37500,
+      amount_total: 37500,
     });
     const app = await buildApp();
 
@@ -245,7 +274,7 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       tax_code: "txcd_99999999",
       default_price_data: {
         currency: "usd",
-        unit_amount: 37899,
+        unit_amount: 37500,
         tax_behavior: "exclusive",
       },
     });
@@ -260,24 +289,85 @@ describe("POST /v1/node-purchase/checkout-session", () => {
         purchaseType: "node_hardware",
         variantId: "co2",
         variantLabel: "PM2.5 + CO2 node",
+        quantity: "1",
       },
     }));
     expect(dbStore.get("paymentCatalog/nodeHardwareCo2")).toMatchObject({
       productId: "prod_node_co2_123",
       defaultPriceId: "price_node_co2_123",
       currency: "usd",
-      unitAmount: 37899,
+      unitAmount: 37500,
       taxCode: "txcd_99999999",
       taxBehavior: "exclusive",
     });
     expect(dbStore.get("nodePurchaseSessions/cs_node_co2_123")).toMatchObject({
       sessionId: "cs_node_co2_123",
       purchaseType: "node_hardware",
-      unitAmount: 37899,
-      amountSubtotal: 37899,
-      amountTotal: 37899,
+      unitAmount: 37500,
+      quantity: 1,
+      amountSubtotal: 37500,
+      amountTotal: 37500,
       variantId: "co2",
       variantLabel: "PM2.5 + CO2 node",
+    });
+    await app.close();
+  });
+
+  it("attaches signed-in buyer metadata and checkout quantity to node purchases", async () => {
+    mocks.productsCreate.mockResolvedValueOnce({
+      id: "prod_node_no2_123",
+      default_price: "price_node_no2_123",
+    });
+    mocks.checkoutSessionsCreate.mockResolvedValueOnce({
+      id: "cs_node_no2_qty_123",
+      url: "https://checkout.stripe.com/c/pay/cs_node_no2_qty_123",
+      mode: "payment",
+      currency: "usd",
+      amount_subtotal: 75_000,
+      amount_total: 75_000,
+    });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/node-purchase/checkout-session",
+      payload: {
+        variantId: "no2",
+        quantity: 2,
+      },
+      headers: {
+        authorization: "Bearer ok",
+        "content-type": "application/json",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.checkoutSessionsCreate).toHaveBeenCalledWith(expect.objectContaining({
+      line_items: [
+        {
+          price: "price_node_no2_123",
+          quantity: 2,
+        },
+      ],
+      customer_email: "buyer@example.com",
+      client_reference_id: "user-123",
+      metadata: {
+        purchaseType: "node_hardware",
+        userId: "user-123",
+        variantId: "no2",
+        variantLabel: "PM2.5 + NO2 node",
+        quantity: "2",
+      },
+    }));
+    expect(dbStore.get("nodePurchaseSessions/cs_node_no2_qty_123")).toMatchObject({
+      userId: "user-123",
+      customerEmail: "buyer@example.com",
+      variantId: "no2",
+      variantLabel: "PM2.5 + NO2 node",
+      unitAmount: 37_500,
+      quantity: 2,
+      amountSubtotal: 75_000,
+      amountTotal: 75_000,
     });
     await app.close();
   });
@@ -395,6 +485,126 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       message: "invalid request",
     });
     expect(mocks.checkoutSessionsCreate).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("rejects a node checkout quantity above ten", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/node-purchase/checkout-session",
+      payload: {
+        variantId: "standard",
+        quantity: 11,
+      },
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({
+      error: "invalid_request",
+      message: "invalid request",
+    });
+    expect(mocks.checkoutSessionsCreate).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("lists completed hardware receipts for the signed-in buyer", async () => {
+    dbStore.set("nodePurchaseSessions/cs_old", {
+      sessionId: "cs_old",
+      status: "completed",
+      purchaseType: "node_hardware",
+      userId: "user-123",
+      paymentStatus: "paid",
+      variantId: "standard",
+      variantLabel: "PM2.5 standard node",
+      quantity: 1,
+      currency: "usd",
+      unitAmount: 35_000,
+      amountSubtotal: 35_000,
+      amountTax: 3_150,
+      amountShipping: 0,
+      amountDiscount: 0,
+      amountTotal: 38_150,
+      completedAt: "2026-01-01T00:00:00.000Z",
+      customerEmail: "buyer@example.com",
+      shippingDetails: {
+        name: "Buyer Example",
+        address: {
+          city: "Seattle",
+          country: "US",
+          line1: "123 Pike St",
+          line2: null,
+          postalCode: "98101",
+          state: "WA",
+        },
+      },
+    });
+    dbStore.set("nodePurchaseSessions/cs_new", {
+      sessionId: "cs_new",
+      status: "completed",
+      purchaseType: "node_hardware",
+      userId: "user-123",
+      paymentStatus: "paid",
+      variantId: "co2_no2",
+      variantLabel: "PM2.5 + CO2 + NO2 node",
+      quantity: 3,
+      currency: "usd",
+      unitAmount: 40_000,
+      amountSubtotal: 120_000,
+      amountTax: 10_800,
+      amountShipping: 0,
+      amountDiscount: 0,
+      amountTotal: 130_800,
+      completedAt: "2026-02-01T00:00:00.000Z",
+      customerEmail: "buyer@example.com",
+    });
+    dbStore.set("nodePurchaseSessions/cs_pending", {
+      sessionId: "cs_pending",
+      status: "created",
+      purchaseType: "node_hardware",
+      userId: "user-123",
+    });
+    dbStore.set("nodePurchaseSessions/cs_other", {
+      sessionId: "cs_other",
+      status: "completed",
+      purchaseType: "node_hardware",
+      userId: "user-456",
+    });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/node-purchase/receipts",
+      headers: {
+        authorization: "Bearer ok",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([
+      expect.objectContaining({
+        sessionId: "cs_new",
+        status: "completed",
+        variantId: "co2_no2",
+        quantity: 3,
+        amountTotal: 130_800,
+      }),
+      expect.objectContaining({
+        sessionId: "cs_old",
+        status: "completed",
+        variantId: "standard",
+        quantity: 1,
+        amountTotal: 38_150,
+        shippingAddress: expect.objectContaining({
+          city: "Seattle",
+          state: "WA",
+        }),
+      }),
+    ]);
     await app.close();
   });
 
@@ -746,6 +956,7 @@ describe("POST /v1/payments/stripe/webhook", () => {
       purchaseType: "node_hardware",
       variantId: "standard",
       variantLabel: "PM2.5 standard node",
+      quantity: 1,
       amountDiscount: 0,
       amountShipping: 0,
       amountTax: 3150,

--- a/shared-types/src/index.ts
+++ b/shared-types/src/index.ts
@@ -15,6 +15,29 @@ export type DeviceSummary = {
   lastSeenAt: string | null;
 } & Record<string, unknown>;
 
+export type NodePurchaseVariantId = "standard" | "co2" | "no2" | "co2_no2";
+
+export type NodePurchaseReceipt = {
+  sessionId: string;
+  purchaseType: "node_hardware";
+  status: "completed";
+  paymentStatus: string | null;
+  variantId: NodePurchaseVariantId | null;
+  variantLabel: string | null;
+  quantity: number;
+  currency: string;
+  unitAmount: number | null;
+  amountSubtotal: number | null;
+  amountTax: number | null;
+  amountShipping: number | null;
+  amountDiscount: number | null;
+  amountTotal: number | null;
+  completedAt: string | null;
+  customerEmail: string | null;
+  shippingName: string | null;
+  shippingAddress: Record<string, string | null> | null;
+};
+
 export type FirestoreTimestampLike = {
   toDate(): Date;
   toMillis(): number;


### PR DESCRIPTION
## Summary
- Rework the node hardware product area around a standard node, CO2/NO2 add-on checkboxes, quantity selection, and future photo slots
- Add quantity-aware Stripe checkout with optional signed-in user attribution for node purchases
- Add signed-in hardware receipt retrieval and dashboard display

## Verification
- pnpm --filter crowdpm-functions test -- nodePurchase
- pnpm --filter crowdpm-functions build
- pnpm --filter crowdpm-frontend build
- pnpm lint