### PR TITLE
Fix node purchase card height on mobile

### DIFF
--- a/frontend/src/pages/NodePage.tsx
+++ b/frontend/src/pages/NodePage.tsx
@@ -424,7 +424,13 @@ export default function NodePage() {
             </Box>
           </Box>
 
-          <Card style={{ flex: "0 1 28rem", width: "100%" }}>
+          <Card
+            style={{
+              width: "100%",
+              maxWidth: "28rem",
+              minWidth: 0,
+            }}
+          >
             <Flex direction="column" gap="4">
               <Box>
                 <Text size="1" color="gray" as="div" style={{ textTransform: "uppercase", fontWeight: 600 }}>


### PR DESCRIPTION
## Summary
- remove the mobile height basis from the standard configuration card
- size that card by width only so it grows naturally with its content
- keep the checkout CTA and pricing copy inside the card on smaller viewports

## Verification
- pnpm --filter crowdpm-frontend build
- pnpm lint
- headless Chromium check at 390x640 confirmed the card `clientHeight` equals `scrollHeight` and the checkout button remains inside the card