### PR TITLE
Handle stale batch selection on first map load

### DIFF
--- a/frontend/src/components/Map3D.tsx
+++ b/frontend/src/components/Map3D.tsx
@@ -517,6 +517,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
   const defaultCenterLat = defaultCenter?.lat;
   const defaultCenterLng = defaultCenter?.lng;
   const syncOverlayRef = useRef<((options?: { forceCenter?: boolean }) => void) | null>(null);
+  const hasRenderableData = data.length > 0;
 
   useEffect(() => { latestDataRef.current = data; }, [data]);
   useEffect(() => { selectedIndexRef.current = selectedIndex; }, [selectedIndex]);
@@ -673,6 +674,10 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
         map.addListener("heading_changed", markUserControl)
       ];
 
+      if (!currentSeries.length) {
+        return;
+      }
+
       type MapWithCapabilities = google.maps.Map & {
         getMapCapabilities?: () => { isWebGLOverlayViewAvailable?: boolean };
       };
@@ -733,7 +738,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       if (overlayRef.current === localOverlay) overlayRef.current = null;
       if (mapRef.current === localMap) mapRef.current = null;
     };
-  }, [interleaved, defaultCenterLat, defaultCenterLng]);
+  }, [defaultCenterLat, defaultCenterLng, hasRenderableData, interleaved]);
 
   return <div ref={divRef} style={{ width: "100%", height: "100%" }} />;
 });

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -653,6 +653,41 @@ export default function MapPage({
     userScopedSelectionKey,
   ]);
 
+  useEffect(() => {
+    if (isAuthLoading || !selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY) return;
+    if (measurementQuery.isFetching || measurementQuery.isLoading || !measurementQuery.isError) return;
+    if (!isTerminalBatchError(measurementQuery.error)) return;
+
+    setSelectedBatchKey("");
+    setIndexOverride(0);
+    safeLocalStorageRemove(
+      userScopedSelectionKey,
+      { context: "map:selected-batch:clear-terminal-error", userId: user?.uid }
+    );
+
+    const cached = getCachedBatch();
+    if (cached) {
+      const cachedKey = encodeBatchKey(cached.summary.deviceId, cached.summary.batchId);
+      if (cachedKey === selectedBatchKey) {
+        safeLocalStorageRemove(
+          userScopedCacheKey,
+          { context: "map:cache:clear-terminal-error", userId: user?.uid }
+        );
+      }
+    }
+  }, [
+    getCachedBatch,
+    isAuthLoading,
+    measurementQuery.error,
+    measurementQuery.isError,
+    measurementQuery.isFetching,
+    measurementQuery.isLoading,
+    selectedBatchKey,
+    user?.uid,
+    userScopedCacheKey,
+    userScopedSelectionKey,
+  ]);
+
   // // Reset override when data changes
   // useEffect(() => {
   //   setIndexOverride(null);


### PR DESCRIPTION
## Summary
- clear persisted selected-batch state when the detail endpoint returns a terminal missing/unauthorized error
- clear the cached local batch payload for that stale selection so the broken state does not rehydrate on the next load
- avoid attaching the deck.gl WebGL overlay until there are points to render, which prevents empty-state overlay initialization on first map load

## Verification
- `pnpm build`
- `pnpm lint`
