### PR TITLE
Feat: Demo batch selector

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -127,7 +127,7 @@ function readThemeCheckoutSessionId(): string | null {
 }
 
 export default function App() {
-  const { user, isLoading, signOut, isModerator, isSuperAdmin } = useAuth();
+  const { user, isLoading, signOut, canAccessAdmin, canRunSmokeTests } = useAuth();
   const { settings } = useUserSettings();
   const userScopedKey = user?.uid ?? "anon";
   const initialDeepLinkedTab = typeof window !== "undefined"
@@ -150,13 +150,11 @@ export default function App() {
   const [pendingSmokeCleanup, setPendingSmokeCleanup] = useState<IngestSmokeTestCleanupResponse | null>(null);
 
   const isSignedIn = Boolean(user);
-  const canUseSmokeTests = Boolean(user) && isSuperAdmin;
-  const canUseAdmin = Boolean(user) && (isModerator || isSuperAdmin);
   const activeTab = !isSignedIn && tab !== "map" && tab !== "pairing-info" && tab !== "about" && tab !== "node"
     ? "map"
-    : (tab === "smoke" && (!user || !canUseSmokeTests)
+    : (tab === "smoke" && (!user || !canRunSmokeTests)
       ? "map"
-      : (tab === "admin" && !canUseAdmin ? "map" : tab));
+      : (tab === "admin" && !canAccessAdmin ? "map" : tab));
   const activeTheme = themeDraft ?? settings.theme;
   const isDarkTheme = activeTheme.appearance === "dark";
   const mapHeaderBackground = activeTab === "map"
@@ -213,8 +211,8 @@ export default function App() {
 
   const handleProtectedTabClick = (target: "dashboard" | "smoke" | "admin") => {
     if (user) {
-      if (target === "smoke" && !canUseSmokeTests) return;
-      if (target === "admin" && !canUseAdmin) return;
+      if (target === "smoke" && !canRunSmokeTests) return;
+      if (target === "admin" && !canAccessAdmin) return;
       setTab(target);
       return;
     }
@@ -501,7 +499,16 @@ export default function App() {
                 >
                   User Dashboard
                 </DropdownMenu.Item>
-                {canUseAdmin ? (
+                {canRunSmokeTests ? (
+                  <DropdownMenu.Item
+                    onSelect={() => handleProtectedTabClick("smoke")}
+                    style={activeTab === "smoke" ? { fontWeight: 600 } : undefined}
+                    disabled={isLoading}
+                  >
+                    Smoke Test Lab
+                  </DropdownMenu.Item>
+                ) : null}
+                {canAccessAdmin ? (
                   <DropdownMenu.Item
                     onSelect={() => handleProtectedTabClick("admin")}
                     style={activeTab === "admin" ? { fontWeight: 600 } : undefined}
@@ -611,17 +618,17 @@ export default function App() {
                     <UserDashboard
                       key={`dashboard:${userScopedKey}`}
                       onRequestActivation={openActivationModal}
-                      onOpenSmokeTest={canUseSmokeTests ? (() => handleProtectedTabClick("smoke")) : undefined}
+                      onOpenSmokeTest={canRunSmokeTests ? (() => handleProtectedTabClick("smoke")) : undefined}
                       onOpenThemeModal={openThemeModal}
                       refreshToken={dashboardRefreshToken}
                     />
-                  ) : activeTab === "smoke" && user && canUseSmokeTests ? (
+                  ) : activeTab === "smoke" && user && canRunSmokeTests ? (
                     <SmokeTestLab
                       key={`smoke:${userScopedKey}`}
                       onSmokeTestComplete={handleSmokeTestComplete}
                       onSmokeTestCleared={handleSmokeTestCleanup}
                     />
-                  ) : activeTab === "admin" && user && canUseAdmin ? (
+                  ) : activeTab === "admin" && user && canAccessAdmin ? (
                     <AdminModerationPage key={`admin:${userScopedKey}`} />
                   ) : activeTab === "pairing-info" ? (
                     <PairingInfoPage onOpenActivation={openActivationModal} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   BatchDetail,
   BatchSummary,
   BatchVisibility,
+  DemoBatchSetting,
   DeviceSummary,
   FirestoreTimestampLike,
   IngestBatchPayload,
@@ -120,6 +121,7 @@ export type {
   BatchDetail,
   BatchSummary,
   BatchVisibility,
+  DemoBatchSetting,
   DeviceSummary,
   FirestoreTimestampLike,
   MeasurementRecord,
@@ -232,6 +234,10 @@ export async function fetchPublicBatchDetail(deviceId: string, batchId: string):
   return requestJson<PublicBatchDetail>(`/v1/public/batches/${safeDevice}/${safeBatch}`);
 }
 
+export async function fetchDemoBatch(): Promise<PublicBatchSummary | null> {
+  return requestJson<PublicBatchSummary | null>("/v1/public/demo-batch");
+}
+
 export async function listAdminSubmissions(params?: {
   limit?: number;
   moderationState?: ModerationState;
@@ -250,6 +256,18 @@ export async function listAdminSubmissions(params?: {
   const suffix = qs.toString();
   const response = await requestJson<AdminSubmissionListResponse>(suffix ? `/v1/admin/submissions?${suffix}` : "/v1/admin/submissions");
   return Array.isArray(response.submissions) ? response.submissions : [];
+}
+
+export async function getAdminDemoBatch(): Promise<DemoBatchSetting> {
+  return requestJson<DemoBatchSetting>("/v1/admin/demo-batch");
+}
+
+export async function setAdminDemoBatch(deviceId: string, batchId: string): Promise<NonNullable<DemoBatchSetting>> {
+  return requestJson<NonNullable<DemoBatchSetting>>("/v1/admin/demo-batch", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ deviceId, batchId }),
+  });
 }
 
 export async function moderateAdminSubmission(

--- a/frontend/src/pages/AdminModerationPage.tsx
+++ b/frontend/src/pages/AdminModerationPage.tsx
@@ -13,9 +13,11 @@ import {
   Text,
 } from "@radix-ui/themes";
 import {
+  getAdminDemoBatch,
   listAdminSubmissions,
   listAdminUsers,
   moderateAdminSubmission,
+  setAdminDemoBatch,
   updateAdminUser,
   type AdminSubmissionSummary,
   type AdminUserSummary,
@@ -23,8 +25,11 @@ import {
   type ModerationState,
   type AdminRole,
 } from "../lib/api";
+import { decodeBatchKey, encodeBatchKey } from "../lib/batchKeys";
 import { useAuth } from "../providers/AuthProvider";
 import { clampPageIndex, getPaginationWindow, ResultCountControl } from "../components/PaginationControl";
+
+const NO_DEMO_BATCH_KEY = "__no_demo_batch__";
 
 function formatTimestamp(value: string | null): string {
   const ms = timestampToMillis(value);
@@ -36,6 +41,24 @@ function normalizeRoleLabel(role: AdminRole): string {
   return role === "super_admin" ? "Super Admin" : "Moderator";
 }
 
+function formatBatchOption(batch: AdminSubmissionSummary): string {
+  const device = batch.deviceName || batch.deviceId;
+  const count = batch.count ? ` (${batch.count})` : "";
+  return `${formatTimestamp(batch.processedAt)} - ${device}${count}`;
+}
+
+function mergeDemoBatchOptions(
+  batches: AdminSubmissionSummary[],
+  current: AdminSubmissionSummary | null,
+): AdminSubmissionSummary[] {
+  if (!current) return batches;
+  const key = encodeBatchKey(current.deviceId, current.batchId);
+  if (batches.some((batch) => encodeBatchKey(batch.deviceId, batch.batchId) === key)) {
+    return batches;
+  }
+  return [current, ...batches];
+}
+
 type SubmissionFilterState = "all" | ModerationState;
 type VisibilityFilterState = "all" | BatchVisibility;
 
@@ -43,15 +66,21 @@ export default function AdminModerationPage() {
   const { isSuperAdmin, canAccessAdmin } = useAuth();
 
   const [submissions, setSubmissions] = useState<AdminSubmissionSummary[]>([]);
+  const [demoBatches, setDemoBatches] = useState<AdminSubmissionSummary[]>([]);
   const [users, setUsers] = useState<AdminUserSummary[]>([]);
   const [usersPageToken, setUsersPageToken] = useState<string | null>(null);
 
   const [submissionsLoading, setSubmissionsLoading] = useState(false);
+  const [demoBatchLoading, setDemoBatchLoading] = useState(false);
+  const [demoBatchSaving, setDemoBatchSaving] = useState(false);
   const [usersLoading, setUsersLoading] = useState(false);
   const [actionBusyId, setActionBusyId] = useState<string | null>(null);
 
   const [submissionError, setSubmissionError] = useState<string | null>(null);
+  const [demoBatchError, setDemoBatchError] = useState<string | null>(null);
+  const [demoBatchMessage, setDemoBatchMessage] = useState<string | null>(null);
   const [userError, setUserError] = useState<string | null>(null);
+  const [demoBatchKey, setDemoBatchKey] = useState<string>(NO_DEMO_BATCH_KEY);
 
   const [moderationFilter, setModerationFilter] = useState<SubmissionFilterState>("all");
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilterState>("all");
@@ -81,6 +110,28 @@ export default function AdminModerationPage() {
     () => users.slice(userPagination.pageStart, userPagination.pageEnd),
     [userPagination.pageEnd, userPagination.pageStart, users],
   );
+
+  const refreshDemoBatchOptions = useCallback(async () => {
+    if (!canAccessAdmin) return;
+    setDemoBatchLoading(true);
+    setDemoBatchError(null);
+    try {
+      const [setting, batches] = await Promise.all([
+        getAdminDemoBatch(),
+        listAdminSubmissions({ moderationState: "approved", visibility: "public", limit: 200 }),
+      ]);
+      setDemoBatches(mergeDemoBatchOptions(batches, setting?.summary ?? null));
+      setDemoBatchKey(setting ? encodeBatchKey(setting.deviceId, setting.batchId) : NO_DEMO_BATCH_KEY);
+    }
+    catch (err) {
+      setDemoBatchError(err instanceof Error ? err.message : "Unable to load demo batch options.");
+      setDemoBatches([]);
+      setDemoBatchKey(NO_DEMO_BATCH_KEY);
+    }
+    finally {
+      setDemoBatchLoading(false);
+    }
+  }, [canAccessAdmin]);
 
   const refreshSubmissions = useCallback(async () => {
     if (!canAccessAdmin) return;
@@ -122,6 +173,11 @@ export default function AdminModerationPage() {
     if (!canAccessAdmin) return;
     void refreshSubmissions();
   }, [canAccessAdmin, refreshSubmissions]);
+
+  useEffect(() => {
+    if (!canAccessAdmin) return;
+    void refreshDemoBatchOptions();
+  }, [canAccessAdmin, refreshDemoBatchOptions]);
 
   useEffect(() => {
     if (!canManageUsers) return;
@@ -199,6 +255,27 @@ export default function AdminModerationPage() {
     }
   }, [canManageUsers, refreshUsers]);
 
+  const handleDemoBatchChange = useCallback(async (value: string) => {
+    if (value === NO_DEMO_BATCH_KEY) return;
+    const parsed = decodeBatchKey(value);
+    if (!parsed) return;
+
+    setDemoBatchSaving(true);
+    setDemoBatchError(null);
+    setDemoBatchMessage(null);
+    try {
+      const setting = await setAdminDemoBatch(parsed.deviceId, parsed.batchId);
+      setDemoBatchKey(encodeBatchKey(setting.deviceId, setting.batchId));
+      setDemoBatchMessage("Front page demo data updated.");
+    }
+    catch (err) {
+      setDemoBatchError(err instanceof Error ? err.message : "Unable to update demo batch.");
+    }
+    finally {
+      setDemoBatchSaving(false);
+    }
+  }, []);
+
   if (!canAccessAdmin) {
     return (
       <Card>
@@ -212,6 +289,45 @@ export default function AdminModerationPage() {
 
   return (
     <Flex direction="column" gap="5">
+      <Card>
+        <Flex direction="column" gap="3">
+          <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">
+            <Box>
+              <Heading as="h3" size="5">Front Page Demo Data</Heading>
+              <Text size="2" color="gray">Choose the approved public batch opened by See Demo Data.</Text>
+            </Box>
+            <Button onClick={() => { void refreshDemoBatchOptions(); }} disabled={demoBatchLoading || demoBatchSaving}>
+              {demoBatchLoading ? "Refreshing..." : "Refresh"}
+            </Button>
+          </Flex>
+          <Box maxWidth="520px">
+            <Text size="2" color="gray">Current demo batch</Text>
+            <Select.Root
+              value={demoBatchKey}
+              onValueChange={(value) => { void handleDemoBatchChange(value); }}
+              disabled={demoBatchLoading || demoBatchSaving || demoBatches.length === 0}
+            >
+              <Select.Trigger placeholder="Select demo batch" />
+              <Select.Content>
+                <Select.Item value={NO_DEMO_BATCH_KEY} disabled>
+                  {demoBatches.length ? "Select demo batch" : "No approved public batches"}
+                </Select.Item>
+                {demoBatches.map((batch) => {
+                  const key = encodeBatchKey(batch.deviceId, batch.batchId);
+                  return (
+                    <Select.Item key={key} value={key}>
+                      {formatBatchOption(batch)}
+                    </Select.Item>
+                  );
+                })}
+              </Select.Content>
+            </Select.Root>
+          </Box>
+          {demoBatchError ? <Text color="tomato">{demoBatchError}</Text> : null}
+          {demoBatchMessage ? <Text color="green">{demoBatchMessage}</Text> : null}
+        </Flex>
+      </Card>
+
       <Card>
         <Flex direction="column" gap="3">
           <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">

--- a/frontend/src/pages/AdminModerationPage.tsx
+++ b/frontend/src/pages/AdminModerationPage.tsx
@@ -40,7 +40,7 @@ type SubmissionFilterState = "all" | ModerationState;
 type VisibilityFilterState = "all" | BatchVisibility;
 
 export default function AdminModerationPage() {
-  const { user, isModerator, isSuperAdmin } = useAuth();
+  const { isSuperAdmin, canAccessAdmin } = useAuth();
 
   const [submissions, setSubmissions] = useState<AdminSubmissionSummary[]>([]);
   const [users, setUsers] = useState<AdminUserSummary[]>([]);
@@ -58,7 +58,7 @@ export default function AdminModerationPage() {
   const [submissionPageIndex, setSubmissionPageIndex] = useState(0);
   const [userPageIndex, setUserPageIndex] = useState(0);
 
-  const canAccess = Boolean(user) && isModerator;
+  const canManageUsers = canAccessAdmin && isSuperAdmin;
 
   const submissionParams = useMemo(() => ({
     moderationState: moderationFilter === "all" ? undefined : moderationFilter,
@@ -83,7 +83,7 @@ export default function AdminModerationPage() {
   );
 
   const refreshSubmissions = useCallback(async () => {
-    if (!canAccess) return;
+    if (!canAccessAdmin) return;
     setSubmissionsLoading(true);
     setSubmissionError(null);
     try {
@@ -97,10 +97,10 @@ export default function AdminModerationPage() {
     finally {
       setSubmissionsLoading(false);
     }
-  }, [canAccess, submissionParams]);
+  }, [canAccessAdmin, submissionParams]);
 
   const refreshUsers = useCallback(async (nextPageToken?: string | null) => {
-    if (!canAccess) return;
+    if (!canManageUsers) return;
     setUsersLoading(true);
     setUserError(null);
     try {
@@ -116,17 +116,17 @@ export default function AdminModerationPage() {
     finally {
       setUsersLoading(false);
     }
-  }, [canAccess]);
+  }, [canManageUsers]);
 
   useEffect(() => {
-    if (!canAccess) return;
+    if (!canAccessAdmin) return;
     void refreshSubmissions();
-  }, [canAccess, refreshSubmissions]);
+  }, [canAccessAdmin, refreshSubmissions]);
 
   useEffect(() => {
-    if (!canAccess) return;
+    if (!canManageUsers) return;
     void refreshUsers();
-  }, [canAccess, refreshUsers]);
+  }, [canManageUsers, refreshUsers]);
 
   useEffect(() => {
     const nextPageIndex = clampPageIndex(submissions.length, submissionPageIndex);
@@ -143,7 +143,7 @@ export default function AdminModerationPage() {
   }, [userPageIndex, users.length]);
 
   const handleModerationChange = useCallback(async (entry: AdminSubmissionSummary, moderationState: ModerationState) => {
-    if (!canAccess) return;
+    if (!canAccessAdmin) return;
     const reason = moderationState === "quarantined"
       ? window.prompt("Optional moderation reason", entry.moderationReason ?? "")
       : "";
@@ -162,10 +162,10 @@ export default function AdminModerationPage() {
     finally {
       setActionBusyId(null);
     }
-  }, [canAccess, refreshSubmissions]);
+  }, [canAccessAdmin, refreshSubmissions]);
 
   const handleToggleDisabled = useCallback(async (entry: AdminUserSummary) => {
-    if (!canAccess) return;
+    if (!canManageUsers) return;
     const nextDisabled = !entry.disabled;
     const reason = window.prompt("Optional moderation reason", "");
     setActionBusyId(`user:${entry.uid}:disabled`);
@@ -180,10 +180,10 @@ export default function AdminModerationPage() {
     finally {
       setActionBusyId(null);
     }
-  }, [canAccess, refreshUsers]);
+  }, [canManageUsers, refreshUsers]);
 
   const handleSetRoles = useCallback(async (entry: AdminUserSummary, roles: AdminRole[]) => {
-    if (!canAccess || !isSuperAdmin) return;
+    if (!canManageUsers) return;
     const reason = window.prompt("Optional role change reason", "");
     setActionBusyId(`user:${entry.uid}:roles`);
     setUserError(null);
@@ -197,9 +197,9 @@ export default function AdminModerationPage() {
     finally {
       setActionBusyId(null);
     }
-  }, [canAccess, isSuperAdmin, refreshUsers]);
+  }, [canManageUsers, refreshUsers]);
 
-  if (!canAccess) {
+  if (!canAccessAdmin) {
     return (
       <Card>
         <Flex direction="column" gap="2">
@@ -312,117 +312,115 @@ export default function AdminModerationPage() {
         </Flex>
       </Card>
 
-      <Card>
-        <Flex direction="column" gap="3">
-          <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">
-            <Heading as="h3" size="5">User moderation</Heading>
-            <ResultCountControl
-              itemLabelSingular="user"
-              itemLabelPlural="users"
-              pageStart={userPagination.pageStart}
-              pageEnd={userPagination.pageEnd}
-              totalCount={users.length}
-              onShowLess={() => setUserPageIndex((current) => clampPageIndex(users.length, current - 1))}
-              onShowMore={() => setUserPageIndex((current) => clampPageIndex(users.length, current + 1))}
-            />
-          </Flex>
-          <Flex gap="3" wrap="wrap" align="center">
-            <Button onClick={() => { void refreshUsers(); }} disabled={usersLoading}>
-              {usersLoading ? "Refreshing..." : "Refresh"}
-            </Button>
-            {usersPageToken ? (
-              <Button
-                variant="soft"
-                onClick={() => { void refreshUsers(usersPageToken); }}
-                disabled={usersLoading}
-              >
-                Next page
+      {canManageUsers ? (
+        <Card>
+          <Flex direction="column" gap="3">
+            <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">
+              <Heading as="h3" size="5">User moderation</Heading>
+              <ResultCountControl
+                itemLabelSingular="user"
+                itemLabelPlural="users"
+                pageStart={userPagination.pageStart}
+                pageEnd={userPagination.pageEnd}
+                totalCount={users.length}
+                onShowLess={() => setUserPageIndex((current) => clampPageIndex(users.length, current - 1))}
+                onShowMore={() => setUserPageIndex((current) => clampPageIndex(users.length, current + 1))}
+              />
+            </Flex>
+            <Flex gap="3" wrap="wrap" align="center">
+              <Button onClick={() => { void refreshUsers(); }} disabled={usersLoading}>
+                {usersLoading ? "Refreshing..." : "Refresh"}
               </Button>
+              {usersPageToken ? (
+                <Button
+                  variant="soft"
+                  onClick={() => { void refreshUsers(usersPageToken); }}
+                  disabled={usersLoading}
+                >
+                  Next page
+                </Button>
+              ) : null}
+            </Flex>
+            {userError ? <Text color="tomato">{userError}</Text> : null}
+            <Separator size="4" />
+            <Table.Root>
+              <Table.Header>
+                <Table.Row>
+                  <Table.ColumnHeaderCell>Email</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>UID</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Roles</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Status</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Action</Table.ColumnHeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {visibleUsers.map((entry) => {
+                  const busyDisabled = actionBusyId === `user:${entry.uid}:disabled`;
+                  const busyRoles = actionBusyId === `user:${entry.uid}:roles`;
+                  return (
+                    <Table.Row key={entry.uid}>
+                      <Table.Cell>{entry.email ?? "—"}</Table.Cell>
+                      <Table.Cell><Text style={{ fontFamily: "monospace" }}>{entry.uid}</Text></Table.Cell>
+                      <Table.Cell>
+                        <Flex gap="2" wrap="wrap">
+                          {entry.roles.length ? entry.roles.map((role) => (
+                            <Badge key={`${entry.uid}:${role}`} color={role === "super_admin" ? "orange" : "blue"}>
+                              {normalizeRoleLabel(role)}
+                            </Badge>
+                          )) : <Text color="gray">None</Text>}
+                        </Flex>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Badge color={entry.disabled ? "red" : "green"}>{entry.disabled ? "Disabled" : "Active"}</Badge>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Flex gap="2" wrap="wrap">
+                          <Button
+                            size="1"
+                            variant="soft"
+                            color={entry.disabled ? "green" : "tomato"}
+                            disabled={busyDisabled}
+                            onClick={() => { void handleToggleDisabled(entry); }}
+                          >
+                            {entry.disabled ? "Enable" : "Disable"}
+                          </Button>
+                          <Button
+                            size="1"
+                            variant="soft"
+                            disabled={busyRoles}
+                            onClick={() => { void handleSetRoles(entry, ["moderator"]); }}
+                          >
+                            Set Moderator
+                          </Button>
+                          <Button
+                            size="1"
+                            variant="soft"
+                            disabled={busyRoles}
+                            onClick={() => { void handleSetRoles(entry, ["super_admin"]); }}
+                          >
+                            Set Super Admin
+                          </Button>
+                          <Button
+                            size="1"
+                            variant="ghost"
+                            disabled={busyRoles}
+                            onClick={() => { void handleSetRoles(entry, []); }}
+                          >
+                            Clear Roles
+                          </Button>
+                        </Flex>
+                      </Table.Cell>
+                    </Table.Row>
+                  );
+                })}
+              </Table.Body>
+            </Table.Root>
+            {!users.length && !usersLoading ? (
+              <Text color="gray">No users returned from Firebase Auth.</Text>
             ) : null}
           </Flex>
-          {userError ? <Text color="tomato">{userError}</Text> : null}
-          <Separator size="4" />
-          <Table.Root>
-            <Table.Header>
-              <Table.Row>
-                <Table.ColumnHeaderCell>Email</Table.ColumnHeaderCell>
-                <Table.ColumnHeaderCell>UID</Table.ColumnHeaderCell>
-                <Table.ColumnHeaderCell>Roles</Table.ColumnHeaderCell>
-                <Table.ColumnHeaderCell>Status</Table.ColumnHeaderCell>
-                <Table.ColumnHeaderCell>Action</Table.ColumnHeaderCell>
-              </Table.Row>
-            </Table.Header>
-            <Table.Body>
-              {visibleUsers.map((entry) => {
-                const busyDisabled = actionBusyId === `user:${entry.uid}:disabled`;
-                const busyRoles = actionBusyId === `user:${entry.uid}:roles`;
-                return (
-                  <Table.Row key={entry.uid}>
-                    <Table.Cell>{entry.email ?? "—"}</Table.Cell>
-                    <Table.Cell><Text style={{ fontFamily: "monospace" }}>{entry.uid}</Text></Table.Cell>
-                    <Table.Cell>
-                      <Flex gap="2" wrap="wrap">
-                        {entry.roles.length ? entry.roles.map((role) => (
-                          <Badge key={`${entry.uid}:${role}`} color={role === "super_admin" ? "orange" : "blue"}>
-                            {normalizeRoleLabel(role)}
-                          </Badge>
-                        )) : <Text color="gray">None</Text>}
-                      </Flex>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Badge color={entry.disabled ? "red" : "green"}>{entry.disabled ? "Disabled" : "Active"}</Badge>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Flex gap="2" wrap="wrap">
-                        <Button
-                          size="1"
-                          variant="soft"
-                          color={entry.disabled ? "green" : "tomato"}
-                          disabled={busyDisabled}
-                          onClick={() => { void handleToggleDisabled(entry); }}
-                        >
-                          {entry.disabled ? "Enable" : "Disable"}
-                        </Button>
-                        {isSuperAdmin ? (
-                          <>
-                            <Button
-                              size="1"
-                              variant="soft"
-                              disabled={busyRoles}
-                              onClick={() => { void handleSetRoles(entry, ["moderator"]); }}
-                            >
-                              Set Moderator
-                            </Button>
-                            <Button
-                              size="1"
-                              variant="soft"
-                              disabled={busyRoles}
-                              onClick={() => { void handleSetRoles(entry, ["super_admin"]); }}
-                            >
-                              Set Super Admin
-                            </Button>
-                            <Button
-                              size="1"
-                              variant="ghost"
-                              disabled={busyRoles}
-                              onClick={() => { void handleSetRoles(entry, []); }}
-                            >
-                              Clear Roles
-                            </Button>
-                          </>
-                        ) : null}
-                      </Flex>
-                    </Table.Cell>
-                  </Table.Row>
-                );
-              })}
-            </Table.Body>
-          </Table.Root>
-          {!users.length && !usersLoading ? (
-            <Text color="gray">No users returned from Firebase Auth.</Text>
-          ) : null}
-        </Flex>
-      </Card>
+        </Card>
+      ) : null}
     </Flex>
   );
 }

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -4,6 +4,7 @@ import { timestampToIsoString, timestampToMillis } from "@crowdpm/types";
 import { Button, Dialog, Flex, Select, Switch, Text } from "@radix-ui/themes";
 import {
   fetchBatchDetail,
+  fetchDemoBatch,
   fetchPublicBatchDetail,
   listBatches,
   listPublicBatches,
@@ -294,6 +295,7 @@ export default function MapPage({
   onCleanupDetailConsumed,
 }: MapPageProps = {}) {
   const { user, isLoading: isAuthLoading } = useAuth();
+  const userId = user?.uid;
   const { settings } = useUserSettings();
   const queryClient = useQueryClient();
 
@@ -316,6 +318,7 @@ export default function MapPage({
 
   // Keep track of which batch is selected plus the position in the measurement timeline.
   const [selectedBatchKey, setSelectedBatchKey] = useState<string>("");
+  const [isDemoBatchLoading, setDemoBatchLoading] = useState(false);
   const [persistedMapZoom, setPersistedMapZoom] = useState<number | null>(null);
   const [zoomHydrationKey, setZoomHydrationKey] = useState<string | null>(null);
   const [isBatchBrowserOpen, setBatchBrowserOpen] = useState(false);
@@ -733,6 +736,31 @@ export default function MapPage({
       );
     }
   }, [isMapViewportActivated, user?.uid, userScopedSelectionKey]);
+
+  const handleDemoBatchSelect = useCallback(async () => {
+    setDemoBatchLoading(true);
+    try {
+      const demoBatch = await fetchDemoBatch();
+      if (!demoBatch) {
+        handleBatchSelect(SHOW_ALL_PUBLIC_24H_KEY);
+        return;
+      }
+
+      const key = encodeBatchKey(demoBatch.deviceId, demoBatch.batchId);
+      queryClient.setQueryData<BatchSummary[]>(BATCHES_QUERY_KEY(userId ?? null), (prev = []) => {
+        const filtered = prev.filter((batch) => encodeBatchKey(batch.deviceId, batch.batchId) !== key);
+        return sortBatchesByProcessedAtDesc([demoBatch, ...filtered]);
+      });
+      handleBatchSelect(key);
+    }
+    catch (err) {
+      logWarning("Unable to load demo batch", undefined, err);
+      handleBatchSelect(SHOW_ALL_PUBLIC_24H_KEY);
+    }
+    finally {
+      setDemoBatchLoading(false);
+    }
+  }, [handleBatchSelect, queryClient, userId]);
 
   const handleMapZoomChange = useCallback((zoom: number) => {
     const nextZoom = Math.min(Math.max(zoom, MIN_PERSISTED_MAP_ZOOM), MAX_PERSISTED_MAP_ZOOM);
@@ -1240,7 +1268,8 @@ export default function MapPage({
             <div style={{ display: "flex", gap: "var(--space-3)", justifyContent: "center", marginTop: "var(--space-4)", flexWrap: "wrap" }}>
               <button
                 type="button"
-                onClick={() => handleBatchSelect(SHOW_ALL_PUBLIC_24H_KEY)}
+                onClick={() => { void handleDemoBatchSelect(); }}
+                disabled={isDemoBatchLoading}
                 style={{
                   padding: "var(--space-2) var(--space-4)",
                   borderRadius: "var(--radius-3)",
@@ -1249,10 +1278,11 @@ export default function MapPage({
                   color: "var(--accent-contrast)",
                   fontWeight: 600,
                   fontSize: "var(--font-size-2)",
-                  cursor: "pointer",
+                  cursor: isDemoBatchLoading ? "wait" : "pointer",
+                  opacity: isDemoBatchLoading ? 0.8 : 1,
                 }}
               >
-                Browse public data
+                See Demo Data
               </button>
               <button
                 type="button"

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -406,7 +406,7 @@ export default function UserDashboard({ onRequestActivation, onOpenSmokeTest, on
           </Flex>
           {onOpenSmokeTest ? (
             <Text size="2" color="gray">
-              Super admins can also{" "}
+              Authorized test users can also{" "}
               <Link
                 href="#"
                 onClick={(event) => {

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -10,12 +10,16 @@ type AuthContextValue = {
   roles: AdminRole[];
   isModerator: boolean;
   isSuperAdmin: boolean;
+  canAccessAdmin: boolean;
+  canRunSmokeTests: boolean;
   signIn: (email: string, password: string) => Promise<UserCredential>;
   signUp: (email: string, password: string) => Promise<UserCredential>;
   signOut: () => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+const SMOKE_TESTER_EMAIL = "smoke-tester@crowdpm.dev";
+const PRODUCTION_HOST_SUFFIXES = [".web.app", ".firebaseapp.com"];
 
 async function loadFirebaseAuth() {
   const [{ auth }, firebaseAuth] = await Promise.all([
@@ -52,6 +56,16 @@ function extractRoles(tokenResult: IdTokenResult | null): AdminRole[] {
     out.add("super_admin");
   }
   return Array.from(out);
+}
+
+function isLocalEmulatorSmokeTester(user: User | null): boolean {
+  const emulatorHost = import.meta.env.VITE_FIREBASE_AUTH_EMULATOR_HOST?.trim();
+  const hostname = typeof window === "undefined" ? "" : window.location.hostname;
+  return (
+    Boolean(emulatorHost)
+    && !PRODUCTION_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix))
+    && user?.email?.trim().toLowerCase() === SMOKE_TESTER_EMAIL
+  );
 }
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -135,16 +149,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [clearCachesOnSignOut]);
 
   const value = useMemo<AuthContextValue>(
-    () => ({
-      user,
-      isLoading,
-      roles,
-      isModerator: roles.includes("moderator") || roles.includes("super_admin"),
-      isSuperAdmin: roles.includes("super_admin"),
-      signIn,
-      signUp,
-      signOut,
-    }),
+    () => {
+      const isSuperAdmin = roles.includes("super_admin");
+      const isModerator = roles.includes("moderator") || isSuperAdmin;
+      const isLocalSmokeTester = isLocalEmulatorSmokeTester(user);
+      return {
+        user,
+        isLoading,
+        roles,
+        isModerator,
+        isSuperAdmin,
+        canAccessAdmin: isModerator || isLocalSmokeTester,
+        canRunSmokeTests: isSuperAdmin || isLocalSmokeTester,
+        signIn,
+        signUp,
+        signOut,
+      };
+    },
     [user, isLoading, roles, signIn, signOut, signUp],
   );
 

--- a/functions/src/lib/rbac.ts
+++ b/functions/src/lib/rbac.ts
@@ -5,9 +5,21 @@ export type { AdminRole };
 
 export type Permission =
   | "users.manage"
+  | "smoke_tests.run"
   | "submissions.read_all"
   | "submissions.moderate"
   | "devices.moderate";
+
+const LOCAL_SMOKE_TESTER_EMAIL = "smoke-tester@crowdpm.dev";
+const MODERATOR_PERMISSIONS: Permission[] = [
+  "submissions.read_all",
+  "submissions.moderate",
+  "devices.moderate",
+];
+const LOCAL_SMOKE_TESTER_PERMISSIONS: Permission[] = [
+  "smoke_tests.run",
+  ...MODERATOR_PERMISSIONS,
+];
 
 function normalizeRole(value: unknown): AdminRole | null {
   if (typeof value !== "string") return null;
@@ -44,13 +56,24 @@ export function hasRole(user: DecodedIdToken, role: AdminRole): boolean {
   return rolesFromToken(user).includes(role);
 }
 
+function isEmulatorRuntime(): boolean {
+  return process.env.FUNCTIONS_EMULATOR === "true" || Boolean(process.env.FIREBASE_EMULATOR_HUB);
+}
+
+function isLocalSmokeTester(user: DecodedIdToken): boolean {
+  return (
+    isEmulatorRuntime()
+    && user.email?.trim().toLowerCase() === LOCAL_SMOKE_TESTER_EMAIL
+  );
+}
+
 export function hasPermission(user: DecodedIdToken, permission: Permission): boolean {
   const roles = rolesFromToken(user);
   if (roles.includes("super_admin")) return true;
 
-  if (roles.includes("moderator")) {
-    return ["submissions.read_all", "submissions.moderate", "devices.moderate"].includes(permission);
-  }
+  if (roles.includes("moderator")) return MODERATOR_PERMISSIONS.includes(permission);
+
+  if (isLocalSmokeTester(user)) return LOCAL_SMOKE_TESTER_PERMISSIONS.includes(permission);
 
   return false;
 }

--- a/functions/src/routes/adminSubmissions.ts
+++ b/functions/src/routes/adminSubmissions.ts
@@ -1,4 +1,4 @@
-import type { AdminSubmissionListResponse, AdminSubmissionSummary } from "@crowdpm/types";
+import type { AdminSubmissionListResponse, AdminSubmissionSummary, DemoBatchSetting } from "@crowdpm/types";
 import type { firestore } from "firebase-admin";
 import type { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
@@ -26,6 +26,12 @@ const updateBodySchema = z.object({
   moderationState: z.enum(["approved", "quarantined"] as const),
   reason: z.string().max(500).optional().nullable(),
 });
+const demoBatchBodySchema = z.object({
+  deviceId: z.string().trim().min(1),
+  batchId: z.string().trim().min(1),
+});
+const APP_SETTINGS_COLLECTION = "appSettings";
+const DEMO_BATCH_SETTINGS_DOC = "demoBatch";
 
 function normalizeReason(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -60,6 +66,22 @@ function serializeSubmission(doc: firestore.QueryDocumentSnapshot | firestore.Do
   };
 }
 
+async function loadApprovedPublicBatch(deviceId: string, batchId: string): Promise<AdminSubmissionSummary> {
+  const snap = await db().collection("batches").doc(batchId).get();
+  if (!snap.exists) {
+    throw httpError(404, "not_found", "Batch not found.");
+  }
+  const data = snap.data() ?? {};
+  if (
+    data.deviceId !== deviceId
+    || normalizeVisibility(data.visibility) !== "public"
+    || normalizeModerationState(data.moderationState) !== "approved"
+  ) {
+    throw httpError(400, "invalid_demo_batch", "Demo batch must be an approved public batch.");
+  }
+  return serializeSubmission(snap);
+}
+
 export const adminSubmissionsRoutes: FastifyPluginAsync = async (app) => {
   app.get("/v1/admin/submissions", {
     preHandler: [
@@ -87,6 +109,43 @@ export const adminSubmissionsRoutes: FastifyPluginAsync = async (app) => {
     return {
       submissions: snap.docs.map((doc) => serializeSubmission(doc)),
     };
+  });
+
+  app.get("/v1/admin/demo-batch", {
+    preHandler: [
+      requirePermissionGuard("submissions.read_all"),
+      rateLimitGuard((req) => `admin:demo-batch:get:${requestUserId(req)}`, 60, 60_000),
+      rateLimitGuard("admin:demo-batch:get:global", 1_000, 60_000),
+    ],
+  }, async (): Promise<DemoBatchSetting> => {
+    const snap = await db().collection(APP_SETTINGS_COLLECTION).doc(DEMO_BATCH_SETTINGS_DOC).get();
+    const deviceId = asNullableString(snap.get("deviceId"));
+    const batchId = asNullableString(snap.get("batchId"));
+    if (!deviceId || !batchId) return null;
+    const summary = await loadApprovedPublicBatch(deviceId, batchId).catch(() => null);
+    return summary ? { deviceId, batchId, summary } : null;
+  });
+
+  app.put<{ Body: unknown }>("/v1/admin/demo-batch", {
+    preHandler: [
+      requirePermissionGuard("submissions.moderate"),
+      rateLimitGuard((req) => `admin:demo-batch:put:${requestUserId(req)}`, 30, 60_000),
+      rateLimitGuard("admin:demo-batch:put:global", 500, 60_000),
+    ],
+  }, async (req): Promise<NonNullable<DemoBatchSetting>> => {
+    const parsed = demoBatchBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw httpError(400, "invalid_request", "invalid request", { details: parsed.error.flatten() });
+    }
+    const deviceId = parseDeviceId(parsed.data.deviceId, "deviceId");
+    const batchId = parsed.data.batchId;
+    const summary = await loadApprovedPublicBatch(deviceId, batchId);
+    await db().collection(APP_SETTINGS_COLLECTION).doc(DEMO_BATCH_SETTINGS_DOC).set({
+      deviceId,
+      batchId,
+      updatedAt: new Date(),
+    }, { merge: true });
+    return { deviceId, batchId, summary };
   });
 
   app.patch<{ Params: { deviceId: string; batchId: string } }>("/v1/admin/submissions/:deviceId/:batchId", {

--- a/functions/src/routes/publicBatches.ts
+++ b/functions/src/routes/publicBatches.ts
@@ -1,3 +1,4 @@
+import type { IncomingHttpHeaders } from "node:http";
 import type { BatchVisibility, PublicBatchDetail, PublicBatchSummary } from "@crowdpm/types";
 import type { firestore } from "firebase-admin";
 import type { FastifyPluginAsync } from "fastify";
@@ -11,6 +12,8 @@ import { rateLimitGuard, requestParam } from "../lib/routeGuards.js";
 import { decodeBatchPayload } from "../services/batchPayloads.js";
 
 const PUBLIC_BATCH_LIST_MAX_LIMIT = 500;
+const APP_SETTINGS_COLLECTION = "appSettings";
+const DEMO_BATCH_SETTINGS_DOC = "demoBatch";
 const listQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(PUBLIC_BATCH_LIST_MAX_LIMIT).optional(),
 });
@@ -52,7 +55,34 @@ function ensurePublicApproved(data: firestore.DocumentData | undefined): { visib
   return { visibility: "public", moderationState: "approved" };
 }
 
+async function loadPublicApprovedSummary(deviceId: string, batchId: string): Promise<PublicBatchSummary | null> {
+  const batchSnap = await db().collection("batches").doc(batchId).get();
+  if (!batchSnap.exists) return null;
+  const batchData = batchSnap.data() ?? {};
+  if (batchData.deviceId !== deviceId) return null;
+  try {
+    ensurePublicApproved(batchData);
+  }
+  catch {
+    return null;
+  }
+  return serializeSummary(batchSnap);
+}
+
 export const publicBatchesRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/v1/public/demo-batch", {
+    preHandler: [
+      rateLimitGuard((req) => `public:demo-batch:ip:${requestIp(req)}`, 120, 60_000),
+      rateLimitGuard("public:demo-batch:global", 2_000, 60_000),
+    ],
+  }, async (): Promise<PublicBatchSummary | null> => {
+    const snap = await db().collection(APP_SETTINGS_COLLECTION).doc(DEMO_BATCH_SETTINGS_DOC).get();
+    const deviceId = asString(snap.get("deviceId"));
+    const batchId = asString(snap.get("batchId"));
+    if (!deviceId || !batchId) return null;
+    return loadPublicApprovedSummary(deviceId, batchId);
+  });
+
   app.get("/v1/public/batches", {
     preHandler: [
       rateLimitGuard((req) => `public:batches:list:ip:${requestIp(req)}`, 120, 60_000),
@@ -124,4 +154,3 @@ export const publicBatchesRoutes: FastifyPluginAsync = async (app) => {
     };
   });
 };
-import type { IncomingHttpHeaders } from "node:http";

--- a/functions/src/services/ingestSmokeTestService.ts
+++ b/functions/src/services/ingestSmokeTestService.ts
@@ -8,7 +8,7 @@ import {
 } from "../lib/batchVisibility.js";
 import { app as getFirebaseApp, db as getDb } from "../lib/fire.js";
 import { normalizeVisibility } from "../lib/httpValidation.js";
-import { hasRole } from "../lib/rbac.js";
+import { hasPermission } from "../lib/rbac.js";
 import type { IngestService } from "./ingestService.js";
 import { prepareSmokeTestPlan, type SmokeTestBody, type SmokeTestPlan } from "./smokeTest.js";
 
@@ -45,7 +45,7 @@ type ResolvedDependencies = {
 export type SmokeTestServiceDependencies = Partial<ResolvedDependencies>;
 
 export function authorizeSmokeTestUser(user: DecodedIdToken): void {
-  if (hasRole(user, "super_admin")) return;
+  if (hasPermission(user, "smoke_tests.run")) return;
   throw new SmokeTestServiceError("forbidden", "Caller lacks permission to run smoke tests", 403);
 }
 

--- a/functions/test/routes/adminSubmissions.test.ts
+++ b/functions/test/routes/adminSubmissions.test.ts
@@ -15,6 +15,19 @@ type BatchRecord = {
 
 let batchRecords = new Map<string, BatchRecord>();
 
+async function withFunctionsEmulator<T>(enabled: boolean, fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.FUNCTIONS_EMULATOR;
+  if (enabled) process.env.FUNCTIONS_EMULATOR = "true";
+  else delete process.env.FUNCTIONS_EMULATOR;
+  try {
+    return await fn();
+  }
+  finally {
+    if (previous === undefined) delete process.env.FUNCTIONS_EMULATOR;
+    else process.env.FUNCTIONS_EMULATOR = previous;
+  }
+}
+
 function makeQuery() {
   const filters: Array<{ field: string; value: unknown }> = [];
   let limitValue: number | null = null;
@@ -71,7 +84,11 @@ const mockDb = {
     if (name !== "batches") throw new Error(`unexpected collection ${name}`);
     return {
       where: (...args: [string, string, unknown]) => makeQuery().where(...args),
-      orderBy: (...args: unknown[]) => makeQuery().orderBy(...args),
+      orderBy: (field: string, direction?: string) => {
+        void field;
+        void direction;
+        return makeQuery().orderBy();
+      },
       limit: (...args: [number]) => makeQuery().limit(...args),
       doc: (id: string) => makeDoc(id),
     };
@@ -128,6 +145,7 @@ beforeEach(() => {
     if (!auth) throw Object.assign(new Error("unauthorized"), { statusCode: 401 });
     if (auth === "Bearer mod") return { uid: "mod-1", roles: ["moderator"] };
     if (auth === "Bearer super") return { uid: "admin-1", roles: ["super_admin"] };
+    if (auth === "Bearer smoke") return { uid: "smoke-1", email: "smoke-tester@crowdpm.dev", roles: [] };
     return { uid: "user-1", roles: [] };
   });
   mocks.writeModerationAudit.mockResolvedValue(undefined);
@@ -182,6 +200,35 @@ describe("GET /v1/admin/submissions", () => {
       message: "You do not have permission to access this resource.",
     });
     await app.close();
+  });
+
+  it("allows the smoke tester to list submissions in the local emulator", async () => {
+    await withFunctionsEmulator(true, async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/v1/admin/submissions",
+        headers: { authorization: "Bearer smoke" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().submissions).toHaveLength(1);
+      await app.close();
+    });
+  });
+
+  it("denies the smoke tester outside the local emulator", async () => {
+    await withFunctionsEmulator(false, async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/v1/admin/submissions",
+        headers: { authorization: "Bearer smoke" },
+      });
+
+      expect(res.statusCode).toBe(403);
+      await app.close();
+    });
   });
 });
 

--- a/functions/test/routes/adminSubmissions.test.ts
+++ b/functions/test/routes/adminSubmissions.test.ts
@@ -14,6 +14,7 @@ type BatchRecord = {
 };
 
 let batchRecords = new Map<string, BatchRecord>();
+let appSettings = new Map<string, Record<string, unknown>>();
 
 async function withFunctionsEmulator<T>(enabled: boolean, fn: () => Promise<T>): Promise<T> {
   const previous = process.env.FUNCTIONS_EMULATOR;
@@ -79,8 +80,31 @@ function makeDoc(id: string) {
   };
 }
 
+function makeSettingsDoc(id: string) {
+  return {
+    get: async () => {
+      const record = appSettings.get(id);
+      return {
+        id,
+        exists: Boolean(record),
+        data: () => record ?? {},
+        get: (field: string) => record?.[field],
+      };
+    },
+    set: async (payload: Record<string, unknown>, options?: { merge?: boolean }) => {
+      const existing = appSettings.get(id);
+      appSettings.set(id, options?.merge ? { ...(existing ?? {}), ...payload } : { ...payload });
+    },
+  };
+}
+
 const mockDb = {
   collection: vi.fn((name: string) => {
+    if (name === "appSettings") {
+      return {
+        doc: (id: string) => makeSettingsDoc(id),
+      };
+    }
     if (name !== "batches") throw new Error(`unexpected collection ${name}`);
     return {
       where: (...args: [string, string, unknown]) => makeQuery().where(...args),
@@ -123,6 +147,9 @@ beforeEach(() => {
   mocks.requireUser.mockReset();
   mocks.writeModerationAudit.mockReset();
 
+  appSettings = new Map([
+    ["demoBatch", { deviceId: "device-1", batchId: "batch-1" }],
+  ]);
   batchRecords = new Map([
     [
       "batch-1",
@@ -153,6 +180,51 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+describe("GET /v1/admin/demo-batch", () => {
+  it("returns the configured approved public batch", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/admin/demo-batch",
+      headers: { authorization: "Bearer mod" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      deviceId: "device-1",
+      batchId: "batch-1",
+      summary: expect.objectContaining({
+        batchId: "batch-1",
+        deviceId: "device-1",
+        visibility: "public",
+        moderationState: "approved",
+      }),
+    });
+    await app.close();
+  });
+});
+
+describe("PUT /v1/admin/demo-batch", () => {
+  it("sets the demo batch when the batch is approved and public", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "PUT",
+      url: "/v1/admin/demo-batch",
+      headers: { authorization: "Bearer mod" },
+      payload: { deviceId: "device-1", batchId: "batch-1" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(appSettings.get("demoBatch")).toEqual(expect.objectContaining({
+      deviceId: "device-1",
+      batchId: "batch-1",
+    }));
+    await app.close();
+  });
 });
 
 describe("GET /v1/admin/submissions", () => {

--- a/functions/test/routes/adminUsers.test.ts
+++ b/functions/test/routes/adminUsers.test.ts
@@ -24,6 +24,19 @@ let users = new Map<string, UserRecord>();
 let revokedRefreshTokens = new Set<string>();
 let deviceOwnership = new Map<string, string[]>();
 
+async function withFunctionsEmulator<T>(enabled: boolean, fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.FUNCTIONS_EMULATOR;
+  if (enabled) process.env.FUNCTIONS_EMULATOR = "true";
+  else delete process.env.FUNCTIONS_EMULATOR;
+  try {
+    return await fn();
+  }
+  finally {
+    if (previous === undefined) delete process.env.FUNCTIONS_EMULATOR;
+    else process.env.FUNCTIONS_EMULATOR = previous;
+  }
+}
+
 function cloneUser(user: UserRecord): UserRecord {
   return JSON.parse(JSON.stringify(user));
 }
@@ -166,6 +179,7 @@ beforeEach(() => {
     if (!auth) throw Object.assign(new Error("unauthorized"), { statusCode: 401 });
     if (auth === "Bearer super") return { uid: "admin-1", roles: ["super_admin"], admin: true };
     if (auth === "Bearer mod") return { uid: "mod-1", roles: ["moderator"] };
+    if (auth === "Bearer smoke") return { uid: "smoke-1", email: "smoke-tester@crowdpm.dev", roles: [] };
     return { uid: "user-x", roles: [] };
   });
 
@@ -196,6 +210,24 @@ describe("GET /v1/admin/users", () => {
       disabled: false,
     }));
     await app.close();
+  });
+
+  it("denies the local smoke tester because user management remains super-admin only", async () => {
+    await withFunctionsEmulator(true, async () => {
+      const app = await buildApp();
+      const res = await app.inject({
+        method: "GET",
+        url: "/v1/admin/users",
+        headers: { authorization: "Bearer smoke" },
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.json()).toEqual({
+        error: "forbidden",
+        message: "You do not have permission to access this resource.",
+      });
+      await app.close();
+    });
   });
 });
 

--- a/functions/test/routes/publicBatches.test.ts
+++ b/functions/test/routes/publicBatches.test.ts
@@ -10,6 +10,7 @@ type BatchRecord = {
 };
 
 let batchRecords = new Map<string, BatchRecord>();
+let appSettings = new Map<string, Record<string, unknown>>();
 let storagePayloads = new Map<string, Buffer>();
 
 function gzipPayload(payload: unknown): Buffer {
@@ -50,6 +51,20 @@ function makeQuery() {
 
 const mockDb = {
   collection: vi.fn((name: string) => {
+    if (name === "appSettings") {
+      return {
+        doc: (id: string) => ({
+          get: async () => {
+            const record = appSettings.get(id);
+            return {
+              exists: Boolean(record),
+              data: () => record ?? {},
+              get: (field: string) => record?.[field],
+            };
+          },
+        }),
+      };
+    }
     if (name !== "batches") throw new Error(`unexpected collection ${name}`);
     return {
       where: (...args: [string, string, unknown]) => makeQuery().where(...args),
@@ -126,6 +141,9 @@ function seedBatch(id: string, overrides?: Record<string, unknown>) {
 
 beforeEach(() => {
   batchRecords = new Map();
+  appSettings = new Map([
+    ["demoBatch", { deviceId: "device-1", batchId: "batch-approved" }],
+  ]);
   storagePayloads = new Map();
   seedBatch("batch-approved");
   seedBatch("batch-private", { visibility: "private", processedAt: "2024-01-03T00:00:00.000Z" });
@@ -140,6 +158,34 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+});
+
+describe("GET /v1/public/demo-batch", () => {
+  it("returns the configured approved public batch", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/v1/public/demo-batch" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      batchId: "batch-approved",
+      deviceId: "device-1",
+      visibility: "public",
+      moderationState: "approved",
+    });
+    await app.close();
+  });
+
+  it("returns null when the configured batch is not public", async () => {
+    appSettings.set("demoBatch", { deviceId: "device-1", batchId: "batch-private" });
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/v1/public/demo-batch" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toBeNull();
+    await app.close();
+  });
 });
 
 describe("GET /v1/public/batches", () => {

--- a/functions/test/services/ingestSmokeTestService.test.ts
+++ b/functions/test/services/ingestSmokeTestService.test.ts
@@ -7,8 +7,21 @@ import {
   IngestSmokeTestService,
   SmokeTestServiceError,
 } from "../../src/services/ingestSmokeTestService.js";
-import type { IngestService } from "../../src/services/ingestService.js";
+import type { IngestRequest, IngestService } from "../../src/services/ingestService.js";
 import type { SmokeTestPlan } from "../../src/services/smokeTest.js";
+
+function withFunctionsEmulator<T>(enabled: boolean, fn: () => T): T {
+  const previous = process.env.FUNCTIONS_EMULATOR;
+  if (enabled) process.env.FUNCTIONS_EMULATOR = "true";
+  else delete process.env.FUNCTIONS_EMULATOR;
+  try {
+    return fn();
+  }
+  finally {
+    if (previous === undefined) delete process.env.FUNCTIONS_EMULATOR;
+    else process.env.FUNCTIONS_EMULATOR = previous;
+  }
+}
 
 function buildPlan(): SmokeTestPlan {
   return {
@@ -56,7 +69,10 @@ describe("IngestSmokeTestService", () => {
       storagePath: "ingest/v2/user-1/scoped-device-1/batch-1.json.gz",
       visibility: "public" as BatchVisibility,
     };
-    const ingestMock = vi.fn(async () => ingestResult);
+    const ingestMock = vi.fn(async (request: IngestRequest) => {
+      void request;
+      return ingestResult;
+    });
     const ingest = { ingest: ingestMock as unknown as IngestService["ingest"] };
 
     const service = new IngestSmokeTestService({
@@ -79,7 +95,7 @@ describe("IngestSmokeTestService", () => {
       deviceId: plan.primaryDeviceId,
       visibility: "public",
     }));
-    const ingestArgs = ingestMock.mock.calls[0]?.[0];
+    const ingestArgs = ingestMock.mock.calls[0][0];
     expect(JSON.parse(ingestArgs.rawBody)).toEqual(plan.payload);
 
     expect(writes[0]).toMatchObject({
@@ -149,10 +165,40 @@ describe("authorizeSmokeTestUser", () => {
     } as unknown as Parameters<typeof authorizeSmokeTestUser>[0])).toThrow(SmokeTestServiceError);
   });
 
-  it("rejects legacy smoke-test accounts without super-admin claims", () => {
+  it("allows the smoke tester in the local emulator", () => {
+    withFunctionsEmulator(true, () => {
+      expect(() => authorizeSmokeTestUser({
+        uid: "smoke-1",
+        email: "smoke-tester@crowdpm.dev",
+        roles: ["smoke-test"],
+      } as unknown as Parameters<typeof authorizeSmokeTestUser>[0])).not.toThrow();
+    });
+  });
+
+  it("rejects legacy smoke-test accounts outside the local emulator", () => {
+    withFunctionsEmulator(false, () => {
+      expect(() => authorizeSmokeTestUser({
+        uid: "smoke-1",
+        email: "smoke-tester@crowdpm.dev",
+        roles: ["smoke-test"],
+      } as unknown as Parameters<typeof authorizeSmokeTestUser>[0])).toThrow(SmokeTestServiceError);
+    });
+  });
+
+  it("rejects non-smoke users in the local emulator", () => {
+    withFunctionsEmulator(true, () => {
+      expect(() => authorizeSmokeTestUser({
+        uid: "user-1",
+        email: "user@example.com",
+        roles: [],
+      } as unknown as Parameters<typeof authorizeSmokeTestUser>[0])).toThrow(SmokeTestServiceError);
+    });
+  });
+
+  it("rejects legacy smoke-test accounts with the wrong email", () => {
     expect(() => authorizeSmokeTestUser({
       uid: "smoke-1",
-      email: "smoke-tester@crowdpm.dev",
+      email: "other@example.com",
       roles: ["smoke-test"],
     } as unknown as Parameters<typeof authorizeSmokeTestUser>[0])).toThrow(SmokeTestServiceError);
   });


### PR DESCRIPTION
## Summary

Added support for demo batch selection in the admin moderation page. Allows a batch to be selected that will connect to the See Demo Data button on the front page for signed out users.

Also local testing has been improved. The default smoke test account can now use the Smoke Test Lab again and has access to Submission Moderation and the batch select dropdown sections in the Admin page. These are only on dev and the smoke test account should not be able to access these on prod.

Implemented using ChatGPT's Codex agent.

## Checks

- [x] I have read CONTRIBUTING.md and this contribution is submitted under the applicable repository license terms.
- [x] If I am not already covered by a Denuo Web LLC contributor agreement, I agree to CLA.md for this contribution.
- [x] I have the right to submit this contribution, including any third-party materials identified in this pull request.
- [x] I ran the relevant lint, build, or test commands, or explained why they were not run.
