### PR TITLE
Fix subscription usage reconciliation

### DIFF
--- a/functions/src/services/accountEntitlements.ts
+++ b/functions/src/services/accountEntitlements.ts
@@ -1,4 +1,11 @@
-import type { DocumentReference, Firestore } from "firebase-admin/firestore";
+import type {
+  AggregateQuerySnapshot,
+  DocumentReference,
+  Firestore,
+  Query,
+  QuerySnapshot,
+  Transaction,
+} from "firebase-admin/firestore";
 import type {
   BatchVisibility,
   SubscriptionBillingInterval,
@@ -15,7 +22,9 @@ import { db as getDb } from "../lib/fire.js";
 import { httpError } from "../lib/httpError.js";
 
 const ACCOUNT_ENTITLEMENTS_COLLECTION = "accountEntitlements";
+const BATCHES_COLLECTION = "batches";
 const COMPANY_CONTACT_EMAIL = "info@denuoweb.com";
+const DEVICES_COLLECTION = "devices";
 const ENTITLEMENT_SCHEMA_VERSION = 1;
 
 type PlanDefinition = {
@@ -78,6 +87,11 @@ type StoredCounterOverride = Partial<Pick<
 >> & {
   updatedAt: string;
 };
+
+type UsageCounts = Pick<
+  StoredEntitlementData,
+  "activeDeviceCount" | "storedBatchCount" | "storedPrivateBatchCount"
+>;
 
 export type UploadQuotaReservation = {
   monthKey: string;
@@ -258,6 +272,79 @@ function mergeLimits(base: SubscriptionLimits, overrides: Partial<SubscriptionLi
   };
 }
 
+function normalizeUpperStatus(value: unknown): string | null {
+  return typeof value === "string" ? value.trim().toUpperCase() : null;
+}
+
+function normalizeLowerStatus(value: unknown): string | null {
+  return typeof value === "string" ? value.trim().toLowerCase() : null;
+}
+
+function isDeviceActive(data: Record<string, unknown> | undefined): boolean {
+  const status = normalizeUpperStatus(data?.status);
+  const registryStatus = normalizeLowerStatus(data?.registryStatus);
+  return status !== "REVOKED"
+    && status !== "SUSPENDED"
+    && registryStatus !== "revoked"
+    && registryStatus !== "suspended";
+}
+
+function devicesQuery(targetDb: Firestore, userId: string): Query {
+  return targetDb.collection(DEVICES_COLLECTION).where("ownerUserIds", "array-contains", userId);
+}
+
+function storedBatchesQuery(targetDb: Firestore, userId: string): Query {
+  return targetDb.collection(BATCHES_COLLECTION).where("ownerUserIds", "array-contains", userId);
+}
+
+function storedPrivateBatchesQuery(targetDb: Firestore, userId: string): Query {
+  return storedBatchesQuery(targetDb, userId).where("visibility", "==", "private");
+}
+
+function countActiveDevices(snapshot: QuerySnapshot): number {
+  return snapshot.docs.reduce((total, doc) => {
+    const next = doc.data() as Record<string, unknown> | undefined;
+    return total + (isDeviceActive(next) ? 1 : 0);
+  }, 0);
+}
+
+function countAggregate(snapshot: AggregateQuerySnapshot<{ count: FirebaseFirestore.AggregateField<number> }>): number {
+  return snapshot.data().count;
+}
+
+async function loadUsageCounts(
+  userId: string,
+  targetDb: Firestore,
+): Promise<UsageCounts> {
+  const [ownedDevicesSnap, storedBatchCountSnap, storedPrivateBatchCountSnap] = await Promise.all([
+    devicesQuery(targetDb, userId).get(),
+    storedBatchesQuery(targetDb, userId).count().get(),
+    storedPrivateBatchesQuery(targetDb, userId).count().get(),
+  ]);
+  return {
+    activeDeviceCount: countActiveDevices(ownedDevicesSnap),
+    storedBatchCount: countAggregate(storedBatchCountSnap),
+    storedPrivateBatchCount: countAggregate(storedPrivateBatchCountSnap),
+  };
+}
+
+async function loadUsageCountsInTransaction(
+  userId: string,
+  targetDb: Firestore,
+  tx: Transaction,
+): Promise<UsageCounts> {
+  const [ownedDevicesSnap, storedBatchCountSnap, storedPrivateBatchCountSnap] = await Promise.all([
+    tx.get(devicesQuery(targetDb, userId)),
+    tx.get(storedBatchesQuery(targetDb, userId).count()),
+    tx.get(storedPrivateBatchesQuery(targetDb, userId).count()),
+  ]);
+  return {
+    activeDeviceCount: countActiveDevices(ownedDevicesSnap),
+    storedBatchCount: countAggregate(storedBatchCountSnap),
+    storedPrivateBatchCount: countAggregate(storedPrivateBatchCountSnap),
+  };
+}
+
 function readStoredEntitlementData(raw: Record<string, unknown> | undefined): StoredEntitlementData {
   return {
     planId: normalizePlanId(raw?.planId),
@@ -424,6 +511,7 @@ export function defaultBatchVisibilityForSubscription(summary: SubscriptionSumma
 export function buildSubscriptionSummary(
   raw: Record<string, unknown> | undefined,
   now: Date = new Date(),
+  usageCounts?: Partial<UsageCounts>,
 ): SubscriptionSummary {
   const stored = readStoredEntitlementData(raw);
   const effectivePlanId = effectivePlanIdFor(stored);
@@ -436,6 +524,9 @@ export function buildSubscriptionSummary(
   const monthlyPointsUsed = stored.currentUsageMonth === activeUsageMonth
     ? stored.currentMonthPointsUploaded
     : 0;
+  const activeDevices = usageCounts?.activeDeviceCount ?? stored.activeDeviceCount;
+  const storedBatchesTotal = usageCounts?.storedBatchCount ?? stored.storedBatchCount;
+  const storedPrivateBatches = usageCounts?.storedPrivateBatchCount ?? stored.storedPrivateBatchCount;
   return {
     planId: effectivePlanId,
     label: effectivePlan.label,
@@ -448,9 +539,9 @@ export function buildSubscriptionSummary(
     videoDownloadAccess: effectivePlan.videoDownloadAccess,
     limits,
     usage: {
-      activeDevices: stored.activeDeviceCount,
-      storedBatchesTotal: stored.storedBatchCount,
-      storedPrivateBatches: stored.storedPrivateBatchCount,
+      activeDevices,
+      storedBatchesTotal,
+      storedPrivateBatches,
       monthlyPointsUsed,
       monthlyPointsRemaining: Math.max(0, limits.monthlyPoints - monthlyPointsUsed),
       monthKey: activeUsageMonth,
@@ -463,8 +554,15 @@ export async function getSubscriptionSummary(
   userId: string,
   targetDb: Firestore = getDb(),
 ): Promise<SubscriptionSummary> {
-  const snap = await docRef(targetDb, userId).get();
-  return buildSubscriptionSummary(snap.exists ? (snap.data() as Record<string, unknown>) : undefined);
+  const [snap, usageCounts] = await Promise.all([
+    docRef(targetDb, userId).get(),
+    loadUsageCounts(userId, targetDb),
+  ]);
+  return buildSubscriptionSummary(
+    snap.exists ? (snap.data() as Record<string, unknown>) : undefined,
+    new Date(),
+    usageCounts,
+  );
 }
 
 export async function getStripeCustomerIdForUser(
@@ -512,7 +610,8 @@ export async function reserveUploadQuota(args: {
     const snap = await tx.get(ref);
     const raw = snap.exists ? (snap.data() as Record<string, unknown>) : undefined;
     const stored = readStoredEntitlementData(raw);
-    const summary = buildSubscriptionSummary(raw, now);
+    const usageCounts = await loadUsageCountsInTransaction(args.userId, targetDb, tx);
+    const summary = buildSubscriptionSummary(raw, now, usageCounts);
 
     if (args.pointCount > summary.limits.maxPointsPerBatch) {
       throw quotaExceeded(
@@ -576,7 +675,11 @@ export async function reserveUploadQuota(args: {
       monthKey: currentMonthKey,
       pointCount: args.pointCount,
       visibility: args.visibility,
-      subscription: buildSubscriptionSummary(applyCounterOverride(stored, override) as unknown as Record<string, unknown>, now),
+      subscription: buildSubscriptionSummary(applyCounterOverride(stored, override) as unknown as Record<string, unknown>, now, {
+        ...usageCounts,
+        storedBatchCount: override.storedBatchCount,
+        storedPrivateBatchCount: override.storedPrivateBatchCount,
+      }),
     };
   });
 }
@@ -630,7 +733,8 @@ export async function writeDeviceWithQuota(args: {
     const snap = await tx.get(ref);
     const raw = snap.exists ? (snap.data() as Record<string, unknown>) : undefined;
     const stored = readStoredEntitlementData(raw);
-    const summary = buildSubscriptionSummary(raw, now);
+    const usageCounts = await loadUsageCountsInTransaction(args.userId, targetDb, tx);
+    const summary = buildSubscriptionSummary(raw, now, usageCounts);
     if (summary.usage.activeDevices + 1 > summary.limits.maxActiveDevices) {
       throw quotaExceeded(
         summary,
@@ -664,13 +768,11 @@ export async function decrementActiveDeviceCount(args: {
   await targetDb.runTransaction(async (tx) => {
     const ref = docRef(targetDb, args.userId);
     const snap = await tx.get(ref);
-    if (!snap.exists) {
-      return;
-    }
-    const raw = snap.data() as Record<string, unknown>;
+    const raw = snap.exists ? (snap.data() as Record<string, unknown>) : undefined;
     const stored = readStoredEntitlementData(raw);
+    const usageCounts = await loadUsageCountsInTransaction(args.userId, targetDb, tx);
     const override: StoredCounterOverride = {
-      activeDeviceCount: Math.max(0, stored.activeDeviceCount - 1),
+      activeDeviceCount: usageCounts.activeDeviceCount,
       updatedAt: now.toISOString(),
     };
     tx.set(ref, baseCounterPayload(args.userId, now, stored, override), { merge: true });
@@ -689,16 +791,12 @@ export async function applyStoredBatchDeletion(args: {
   await targetDb.runTransaction(async (tx) => {
     const ref = docRef(targetDb, args.userId);
     const snap = await tx.get(ref);
-    if (!snap.exists) {
-      return;
-    }
-    const raw = snap.data() as Record<string, unknown>;
+    const raw = snap.exists ? (snap.data() as Record<string, unknown>) : undefined;
     const stored = readStoredEntitlementData(raw);
+    const usageCounts = await loadUsageCountsInTransaction(args.userId, targetDb, tx);
     const override: StoredCounterOverride = {
-      storedBatchCount: Math.max(0, stored.storedBatchCount - 1),
-      storedPrivateBatchCount: args.visibility === "private"
-        ? Math.max(0, stored.storedPrivateBatchCount - 1)
-        : stored.storedPrivateBatchCount,
+      storedBatchCount: usageCounts.storedBatchCount,
+      storedPrivateBatchCount: usageCounts.storedPrivateBatchCount,
       updatedAt: now.toISOString(),
     };
     tx.set(ref, baseCounterPayload(args.userId, now, stored, override), { merge: true });
@@ -724,7 +822,8 @@ export async function applyBatchVisibilityChange(args: {
     const snap = await tx.get(ref);
     const raw = snap.exists ? (snap.data() as Record<string, unknown>) : undefined;
     const stored = readStoredEntitlementData(raw);
-    const summary = buildSubscriptionSummary(raw, now);
+    const usageCounts = await loadUsageCountsInTransaction(args.userId, targetDb, tx);
+    const summary = buildSubscriptionSummary(raw, now, usageCounts);
 
     if (args.toVisibility === "private" && summary.limits.maxStoredPrivateBatches < 1) {
       throw quotaExceeded(

--- a/functions/test/routes/userSettings.test.ts
+++ b/functions/test/routes/userSettings.test.ts
@@ -75,6 +75,7 @@ function makeDocRef(path: string) {
       const data = dbStore.get(path);
       return {
         exists: Boolean(data),
+        data: () => data,
         get: (field: string) => data?.[field],
       };
     }),
@@ -86,9 +87,53 @@ function makeDocRef(path: string) {
   };
 }
 
+function matchesFilter(data: Record<string, unknown>, field: string, op: string, value: unknown): boolean {
+  const actual = data[field];
+  if (op === "array-contains") {
+    return Array.isArray(actual) && actual.includes(value);
+  }
+  if (op === "==") {
+    return actual === value;
+  }
+  throw new Error(`unsupported op ${op}`);
+}
+
+function queryDocs(collectionName: string, filters: Array<{ field: string; op: string; value: unknown }>) {
+  return Array.from(dbStore.entries())
+    .filter(([path]) => path.startsWith(`${collectionName}/`))
+    .map(([path, data]) => ({
+      id: path.slice(collectionName.length + 1),
+      data,
+    }))
+    .filter(({ data }) => filters.every((filter) => matchesFilter(data, filter.field, filter.op, filter.value)));
+}
+
+function makeQuery(collectionName: string, filters: Array<{ field: string; op: string; value: unknown }> = []) {
+  return {
+    where: (field: string, op: string, value: unknown) => makeQuery(collectionName, [...filters, { field, op, value }]),
+    get: async () => {
+      const docs = queryDocs(collectionName, filters).map(({ id, data }) => ({
+        id,
+        data: () => data,
+        get: (field: string) => data[field],
+      }));
+      return {
+        docs,
+        forEach: (callback: (doc: typeof docs[number]) => void) => docs.forEach(callback),
+      };
+    },
+    count: () => ({
+      get: async () => ({
+        data: () => ({ count: queryDocs(collectionName, filters).length }),
+      }),
+    }),
+  };
+}
+
 const mockDb = {
   collection: vi.fn((name: string) => ({
     doc: (id: string) => makeDocRef(`${name}/${id}`),
+    where: (field: string, op: string, value: unknown) => makeQuery(name, [{ field, op, value }]),
   })),
 };
 
@@ -156,6 +201,53 @@ describe("user settings routes", () => {
       themeSaveUnlocked: false,
       subscription: expectedFreeSubscription,
       subscriptionOffers: expectedOffers,
+    });
+    await app.close();
+  });
+
+  it("GET /v1/user/settings reconciles usage from live devices and batches", async () => {
+    const app = await buildApp();
+    dbStore.set("accountEntitlements/user-123", {
+      activeDeviceCount: 0,
+      storedBatchCount: 0,
+      storedPrivateBatchCount: 0,
+    });
+    dbStore.set("devices/device-1", {
+      ownerUserIds: ["user-123"],
+      status: "ACTIVE",
+      registryStatus: "active",
+    });
+    dbStore.set("devices/device-2", {
+      ownerUserIds: ["user-123"],
+      status: "ACTIVE",
+      registryStatus: "active",
+    });
+    dbStore.set("devices/device-revoked", {
+      ownerUserIds: ["user-123"],
+      status: "REVOKED",
+      registryStatus: "revoked",
+    });
+    dbStore.set("batches/batch-1", {
+      ownerUserIds: ["user-123"],
+      visibility: "public",
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/user/settings",
+      headers: { authorization: "Bearer ok" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      subscription: {
+        ...expectedFreeSubscription,
+        usage: {
+          activeDevices: 2,
+          storedBatchesTotal: 1,
+          storedPrivateBatches: 0,
+        },
+      },
     });
     await app.close();
   });

--- a/functions/test/services/accountEntitlements.test.ts
+++ b/functions/test/services/accountEntitlements.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSubscriptionSummary,
+  reserveUploadQuota,
+  writeDeviceWithQuota,
+} from "../../src/services/accountEntitlements.js";
+
+type CollectionName = "accountEntitlements" | "batches" | "devices";
+type QueryFilter = { field: string; op: string; value: unknown };
+type StoredDoc = Record<string, unknown>;
+
+function matchesFilter(data: StoredDoc, filter: QueryFilter): boolean {
+  const actual = data[filter.field];
+  if (filter.op === "array-contains") {
+    return Array.isArray(actual) && actual.includes(filter.value);
+  }
+  if (filter.op === "==") {
+    return actual === filter.value;
+  }
+  throw new Error(`unsupported filter ${filter.op}`);
+}
+
+function makeTestDb(seed?: Partial<Record<CollectionName, Array<[string, StoredDoc]>>>) {
+  const store: Record<CollectionName, Map<string, StoredDoc>> = {
+    accountEntitlements: new Map(seed?.accountEntitlements ?? []),
+    batches: new Map(seed?.batches ?? []),
+    devices: new Map(seed?.devices ?? []),
+  };
+
+  function queryEntries(collectionName: CollectionName, filters: QueryFilter[]) {
+    return Array.from(store[collectionName].entries())
+      .filter(([, data]) => filters.every((filter) => matchesFilter(data, filter)));
+  }
+
+  function makeSnapshot(id: string, data: StoredDoc | undefined) {
+    return {
+      id,
+      exists: Boolean(data),
+      data: () => data,
+      get: (field: string) => data?.[field],
+    };
+  }
+
+  function makeDocRef(collectionName: CollectionName, id: string) {
+    return {
+      get: async () => makeSnapshot(id, store[collectionName].get(id)),
+      set: async (payload: StoredDoc, options?: { merge?: boolean }) => {
+        const previous = store[collectionName].get(id) ?? {};
+        store[collectionName].set(id, options?.merge ? { ...previous, ...payload } : { ...payload });
+      },
+    };
+  }
+
+  function makeQuery(collectionName: CollectionName, filters: QueryFilter[] = []) {
+    return {
+      where: (field: string, op: string, value: unknown) => makeQuery(collectionName, [...filters, { field, op, value }]),
+      get: async () => {
+        const docs = queryEntries(collectionName, filters).map(([id, data]) => makeSnapshot(id, data));
+        return {
+          docs,
+          forEach: (callback: (doc: typeof docs[number]) => void) => docs.forEach(callback),
+        };
+      },
+      count: () => ({
+        get: async () => ({
+          data: () => ({ count: queryEntries(collectionName, filters).length }),
+        }),
+      }),
+    };
+  }
+
+  const db = {
+    collection: (name: string) => {
+      const collectionName = name as CollectionName;
+      return {
+        doc: (id: string) => makeDocRef(collectionName, id),
+        where: (field: string, op: string, value: unknown) => makeQuery(collectionName, [{ field, op, value }]),
+      };
+    },
+    runTransaction: async <T>(handler: (tx: {
+      get: (target: { get: () => Promise<unknown> }) => Promise<unknown>;
+      set: (target: { set: (payload: StoredDoc, options?: { merge?: boolean }) => Promise<void> }, payload: StoredDoc, options?: { merge?: boolean }) => Promise<void>;
+    }) => Promise<T>) => handler({
+      get: (target) => target.get(),
+      set: (target, payload, options) => target.set(payload, options),
+    }),
+  };
+
+  return { db, store };
+}
+
+describe("account entitlements", () => {
+  it("builds subscription usage from live devices and batches when stored counters are stale", async () => {
+    const { db } = makeTestDb({
+      accountEntitlements: [[
+        "user-1",
+        {
+          activeDeviceCount: 0,
+          storedBatchCount: 0,
+          storedPrivateBatchCount: 0,
+        },
+      ]],
+      devices: [
+        ["device-1", { ownerUserIds: ["user-1"], status: "ACTIVE", registryStatus: "active" }],
+        ["device-2", { ownerUserIds: ["user-1"], status: "ACTIVE", registryStatus: "active" }],
+        ["device-3", { ownerUserIds: ["user-1"], status: "SUSPENDED", registryStatus: "suspended" }],
+      ],
+      batches: [
+        ["batch-1", { ownerUserIds: ["user-1"], visibility: "public" }],
+        ["batch-2", { ownerUserIds: ["user-1"], visibility: "private" }],
+      ],
+    });
+
+    const summary = await getSubscriptionSummary("user-1", db as never);
+
+    expect(summary.usage).toMatchObject({
+      activeDevices: 2,
+      storedBatchesTotal: 2,
+      storedPrivateBatches: 1,
+    });
+  });
+
+  it("rejects uploads when actual stored batches already hit the plan limit", async () => {
+    const batches: Array<[string, StoredDoc]> = Array.from({ length: 100 }, (_, index) => [
+      `batch-${index + 1}`,
+      { ownerUserIds: ["user-1"], visibility: "public" },
+    ]);
+    const { db } = makeTestDb({
+      accountEntitlements: [[
+        "user-1",
+        {
+          storedBatchCount: 0,
+          storedPrivateBatchCount: 0,
+          currentUsageMonth: "2026-05",
+          currentMonthPointsUploaded: 0,
+        },
+      ]],
+      batches,
+    });
+
+    await expect(reserveUploadQuota({
+      userId: "user-1",
+      visibility: "public",
+      pointCount: 1,
+      targetDb: db as never,
+      now: new Date("2026-05-13T00:00:00.000Z"),
+    })).rejects.toMatchObject({
+      statusCode: 403,
+      code: "quota_exceeded",
+      message: "Stored batch limit reached for the current plan.",
+    });
+  });
+
+  it("rejects device registration when actual active devices already hit the plan limit", async () => {
+    const { db, store } = makeTestDb({
+      accountEntitlements: [[
+        "user-1",
+        {
+          activeDeviceCount: 0,
+          currentUsageMonth: "2026-05",
+          currentMonthPointsUploaded: 0,
+        },
+      ]],
+      devices: [
+        ["device-1", { ownerUserIds: ["user-1"], status: "ACTIVE", registryStatus: "active" }],
+        ["device-2", { ownerUserIds: ["user-1"], status: "ACTIVE", registryStatus: "active" }],
+      ],
+    });
+
+    await expect(writeDeviceWithQuota({
+      userId: "user-1",
+      deviceRef: db.collection("devices").doc("device-3") as never,
+      deviceData: {
+        ownerUserIds: ["user-1"],
+        status: "ACTIVE",
+        registryStatus: "active",
+      },
+      targetDb: db as never,
+      now: new Date("2026-05-13T00:00:00.000Z"),
+    })).rejects.toMatchObject({
+      statusCode: 403,
+      code: "quota_exceeded",
+      message: "Active device limit reached for the current plan.",
+    });
+    expect(store.devices.has("device-3")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- reconcile subscription device and batch usage from live Firestore data instead of relying on stale stored counters
- use reconciled usage during quota enforcement so limits match what the dashboard shows
- add regression coverage for stale counters in user settings and entitlement service tests

## Testing
- pnpm --filter crowdpm-functions build
- pnpm --filter crowdpm-functions exec vitest run