### PR TITLE
fix(frontend): sync Google Maps basemap with theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -576,7 +576,7 @@ export default function App() {
             }}
           >
             <Suspense fallback={tabPanelFallback}>
-              <MapPage key={`map:${userScopedKey}`} />
+              <MapPage key={`map:${userScopedKey}`} mapAppearance={activeTheme.appearance} />
             </Suspense>
           </Box>
         ) : (

--- a/frontend/src/components/Map3D.tsx
+++ b/frontend/src/components/Map3D.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from "react";
+import type { UserThemeAppearance } from "@crowdpm/types";
 import { GoogleMapsOverlay } from "@deck.gl/google-maps";
 import { PathLayer } from "@deck.gl/layers";
 import { SimpleMeshLayer } from "@deck.gl/mesh-layers";
@@ -40,8 +41,16 @@ export type Map3DHandle = {
   waitForVisualReady: () => Promise<void>;
 };
 
+type MapCameraState = {
+  center: { lat: number; lng: number };
+  zoom?: number;
+  tilt?: number;
+  heading?: number;
+};
+
 type Map3DProps = {
   data: MeasurementPoint[];
+  appearance: UserThemeAppearance;
   selectedIndex: number;
   onSelectIndex?: (index: number) => void;
   onSelectPoint?: (point: MeasurementPoint) => void;
@@ -101,6 +110,20 @@ function waitForMapIdle(map: google.maps.Map | null, timeoutMs: number): Promise
     const listener = map.addListener("idle", finish);
     const timeoutId = window.setTimeout(finish, timeoutMs);
   });
+}
+
+function readMapCameraState(map: google.maps.Map | null): MapCameraState | null {
+  if (!map) return null;
+
+  const center = map.getCenter();
+  if (!center) return null;
+
+  return {
+    center: { lat: center.lat(), lng: center.lng() },
+    zoom: map.getZoom() ?? undefined,
+    tilt: map.getTilt() ?? undefined,
+    heading: map.getHeading() ?? undefined,
+  };
 }
 
 function ensureRange(min: number, max: number): [number, number] {
@@ -536,6 +559,7 @@ async function createCaptureSession(
 
 const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
   data,
+  appearance,
   selectedIndex,
   onSelectIndex,
   onSelectPoint,
@@ -559,6 +583,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
   const showAllModeRef = useRef(showAllMode);
   const playbackPathModeRef = useRef(playbackPathMode);
   const sphereGeometryRef = useRef<SphereGeometry | null>(null);
+  const cameraStateRef = useRef<MapCameraState | null>(null);
   const hasUserControlRef = useRef(typeof defaultZoom === "number");
   const initialDefaultZoomRef = useRef(defaultZoom);
   const dataSignatureRef = useRef(signature(data));
@@ -691,17 +716,23 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
         : FALLBACK_CENTER;
       const initialDefaultZoom = initialDefaultZoomRef.current;
       const resolvedZoom = initialDefaultZoom ?? FALLBACK_ZOOM;
-      const center = firstPoint ? { lat: firstPoint.lat, lng: firstPoint.lon } : resolvedCenter;
-      const initialZoom = firstPoint ? (initialDefaultZoom ?? 15) : resolvedZoom;
-      const initialTilt = firstPoint ? 67.5 : 0;
+      const defaultCenter = firstPoint ? { lat: firstPoint.lat, lng: firstPoint.lon } : resolvedCenter;
+      const defaultInitialZoom = firstPoint ? (initialDefaultZoom ?? 15) : resolvedZoom;
+      const defaultInitialTilt = firstPoint ? 67.5 : 0;
+      const savedCamera = cameraStateRef.current;
+      const center = savedCamera?.center ?? defaultCenter;
+      const initialZoom = savedCamera?.zoom ?? defaultInitialZoom;
+      const initialTilt = savedCamera?.tilt ?? defaultInitialTilt;
+      const initialHeading = savedCamera?.heading ?? 0;
 
       const MapCtor = mapsLib.Map as typeof google.maps.Map;
       const map = new MapCtor(element, {
         mapId,
+        colorScheme: appearance === "dark" ? "DARK" : "LIGHT",
         center,
         zoom: initialZoom,
         tilt: initialTilt,
-        heading: 0,
+        heading: initialHeading,
         gestureHandling: "greedy",
         disableDefaultUI: true,
         keyboardShortcuts: true,
@@ -768,7 +799,12 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       }
 
       if (currentSeries.length && typeof map.moveCamera === "function") {
-        map.moveCamera({ tilt: 67.5, heading: 0, zoom: initialDefaultZoom ?? 18 });
+        map.moveCamera({
+          center,
+          tilt: savedCamera?.tilt ?? 67.5,
+          heading: initialHeading,
+          zoom: savedCamera?.zoom ?? initialDefaultZoom ?? 18,
+        });
       }
       overlayRef.current = overlay;
       syncOverlayRef.current?.();
@@ -776,6 +812,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
 
     return () => {
       cancelled = true;
+      cameraStateRef.current = readMapCameraState(localMap ?? mapRef.current);
       const overlay = overlayRef.current;
       if (overlay) {
         disposeGoogleMapsOverlayExternalFramebuffer(overlay);
@@ -789,7 +826,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       if (overlayRef.current === localOverlay) overlayRef.current = null;
       if (mapRef.current === localMap) mapRef.current = null;
     };
-  }, [defaultCenterLat, defaultCenterLng, hasRenderableData, interleaved]);
+  }, [appearance, defaultCenterLat, defaultCenterLng, hasRenderableData, interleaved]);
 
   return <div ref={divRef} style={{ width: "100%", height: "100%" }} />;
 });

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,6 +1,6 @@
 import { lazy, startTransition, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { timestampToMillis, type IngestPoint } from "@crowdpm/types";
+import { timestampToMillis, type IngestPoint, type UserThemeAppearance } from "@crowdpm/types";
 import { Button, Dialog, Flex, Select, Switch, Text } from "@radix-ui/themes";
 import {
   fetchBatchDetail,
@@ -72,6 +72,10 @@ type MapMeasurementRecord = MeasurementRecord & {
 };
 
 type StoredTimelineIndexes = Record<string, number>;
+
+type MapPageProps = {
+  mapAppearance: UserThemeAppearance;
+};
 
 function formatBatchLabel(batch: BatchSummary) {
   const timeMs = timestampToMillis(batch.processedAt);
@@ -224,7 +228,7 @@ function getStoredTimelineIndex(storageKey: string, batchKey: string, maxIndex: 
   return Math.min(Math.max(Math.round(index), 0), maxIndex);
 }
 
-export default function MapPage() {
+export default function MapPage({ mapAppearance }: MapPageProps) {
   const { user, isLoading: isAuthLoading } = useAuth();
   const userId = user?.uid;
   const { settings } = useUserSettings();
@@ -984,6 +988,7 @@ export default function MapPage() {
           <Map3D
             ref={map3DRef}
             data={data}
+            appearance={mapAppearance}
             selectedIndex={selectedIndex}
             onSelectIndex={effectiveShowAllMode ? undefined : handleTimelineIndexChange}
             onSelectPoint={handleMapPointSelect}


### PR DESCRIPTION
## Summary
- pass the selected app appearance into the map page and 3D map
- initialize Google Maps with the matching light or dark color scheme
- preserve the current camera when the map is recreated for theme changes

## Testing
- pnpm --filter crowdpm-frontend build