### PR TITLE
fix(frontend): restore batch selection and visible markers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ CrowdPM documentation is organized by audience and environment. Avoid copying th
 | `deployment.md` | Maintainers | Deployed Firebase release checklist and rollback process. |
 | `hardware-builder.md` | Hardware builders | Device pairing, DPoP, access tokens, ingest payload contract. |
 | `openapi-swagger-ui.md` | API users | View `functions/src/openapi.yaml` in Swagger UI locally. |
+| `test-plan.txt` | Capstone team | Sprint test scope, methods, ownership, and Kanban evidence. |
 | `INSTALL-openjdk25-linux.md` | Linux contributors | JDK 25 setup notes for Firebase emulators. |
 | `INSTALL-openjdk25-mac.md` | macOS contributors | JDK 25 setup notes for Firebase emulators. |
 

--- a/docs/test-plan.txt
+++ b/docs/test-plan.txt
@@ -1,0 +1,40 @@
+Test Plan
+CrowdPM Platform: Fullstack PM2.5 Mapping
+Jaron Rosenau, Jack Armstrong, Skylar Soon, Mark Sparhawk
+CS462 Spring 2026
+Oregon State University
+
+Project Links
+Task Board - Asana: https://app.asana.com/1/941689499454829/project/1211814553979599/board
+Project Wiki - GitHub Wiki: https://github.com/Denuo-Web/CrowdPMPlatform/wiki
+Repository - GitHub Repo: https://github.com/Denuo-Web/CrowdPMPlatform/
+Website - CrowdPM Platform: https://crowdpmplatform.web.app/
+
+Testing Scope and Needs
+This sprint focuses on the highest-risk CrowdPM features: map/public pages, sign in and sign out, device activation and pairing, the user dashboard, admin moderation, node purchase, and the ingest pipeline.
+
+- Public map and data visibility: public batches should appear, while private and quarantined data stays hidden.
+- Authentication and access: protected routes should only work for the correct users.
+- Device flow: pairing, authorization, registration, and access-token steps should work end to end.
+- Dashboard and batch management: users should be able to view devices and batches, change visibility, and delete their own data.
+- Admin moderation: moderator-only actions and quarantine controls should stay protected.
+- Node purchase: product selection and Stripe checkout should use the correct options and pricing.
+- Ingest pipeline: uploads should be accepted, stored, processed, and shown in the correct visibility state.
+
+Testing Methods
+We are using white-box testing and black-box testing for this sprint. We are not using TDD.
+
+- White-box testing: Vitest backend tests for auth checks, role checks, pairing errors, Stripe validation, and ingest logic.
+- Black-box testing: end-to-end checks for device onboarding, map visibility behavior, dashboard flows, and frontend smoke tests.
+
+Team Assignments
+The Kanban board includes testing tasks for the areas above and assigns them as follows:
+
+- Mark: device end-to-end ingest flow from pair to visibility
+- Skylar: frontend smoke and regression testing
+- Jaron: node purchase and Stripe testing
+- Jack: role, access, and moderation testing
+
+Evidence
+Asana board link: https://app.asana.com/1/941689499454829/project/1211814553979599/board
+Screenshot: add the current board screenshot showing testing tasks assigned to team members.

--- a/frontend/src/components/Map3D.tsx
+++ b/frontend/src/components/Map3D.tsx
@@ -154,6 +154,13 @@ function signature(series: MeasurementPoint[]) {
   ].join(":");
 }
 
+function markerRadiusMeters(precision: number | null): number {
+  if (typeof precision !== "number" || !Number.isFinite(precision)) {
+    return 10;
+  }
+  return Math.max(5, precision / 2);
+}
+
 function createLayers(
   series: MeasurementPoint[],
   selectedIndex: number,
@@ -184,7 +191,7 @@ function createLayers(
         return [...base, 200] as [number, number, number, number];
       },
       getScale: (d) => {
-        const radiusMeters = Math.max(0.5, (d.precision ?? 20) / 2);
+        const radiusMeters = markerRadiusMeters(d.precision ?? null);
         return [radiusMeters, radiusMeters, radiusMeters];
       },
       pickable: true,
@@ -228,7 +235,7 @@ function createLayers(
       return [...base, 220] as [number, number, number, number];
     },
     getScale: (d) => {
-      const radiusMeters = Math.max(0.5, (d.precision ?? 20) / 2);
+      const radiusMeters = markerRadiusMeters(d.precision ?? null);
       return [radiusMeters, radiusMeters, radiusMeters];
     },
     pickable: true,

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -55,6 +55,7 @@ const MAP_EMPTY_STATE_DESCRIPTION = "Explore public sensor data below, or pair y
 
 // React Query cache keys. Keeping them as helpers avoids typos across the file.
 const BATCHES_QUERY_KEY = (uid: string | null | undefined) => ["batches", uid ?? "guest"] as const;
+const EXPANDED_BATCHES_QUERY_KEY = (uid: string | null | undefined) => ["batchesExpanded", uid ?? "guest", EXPANDED_BATCH_FETCH_LIMIT] as const;
 const BATCH_DETAIL_QUERY_KEY = (uid: string, batchKey: string) => ["batchDetail", uid, batchKey] as const;
 const Map3D = lazy(() => import("../components/Map3D"));
 const TERMINAL_BATCH_ERROR_MESSAGES = ["unauthorized", "authentication required", "not_found", "batch not found"] as const;
@@ -230,7 +231,6 @@ function getStoredTimelineIndex(storageKey: string, batchKey: string, maxIndex: 
 
 export default function MapPage({ mapAppearance }: MapPageProps) {
   const { user, isLoading: isAuthLoading } = useAuth();
-  const userId = user?.uid;
   const { settings } = useUserSettings();
   const queryClient = useQueryClient();
 
@@ -301,7 +301,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     [batchesQuery.data]
   );
   const batchBrowserQuery = useQuery<VisibleBatchSummary[]>({
-    queryKey: ["batchesExpanded", user?.uid ?? "guest", EXPANDED_BATCH_FETCH_LIMIT],
+    queryKey: EXPANDED_BATCHES_QUERY_KEY(user?.uid ?? null),
     queryFn: () => loadBatchSummaries(EXPANDED_BATCH_FETCH_LIMIT, EXPANDED_BATCH_FETCH_LIMIT),
     enabled: isBatchBrowserOpen && !isAuthLoading,
     placeholderData: () => visibleBatches,
@@ -642,6 +642,18 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     }
   }, [isMapViewportActivated, user?.uid, userScopedSelectionKey]);
 
+  const upsertBatchSummary = useCallback((summary: VisibleBatchSummary) => {
+    const mergeSummaries = (prev: VisibleBatchSummary[] = []) => {
+      const filtered = prev.filter((batch) => (
+        batch.batchId !== summary.batchId || batch.deviceId !== summary.deviceId
+      ));
+      return sortBatchesByProcessedAtDesc([summary, ...filtered]);
+    };
+
+    queryClient.setQueryData<VisibleBatchSummary[]>(BATCHES_QUERY_KEY(user?.uid ?? null), mergeSummaries);
+    queryClient.setQueryData<VisibleBatchSummary[]>(EXPANDED_BATCHES_QUERY_KEY(user?.uid ?? null), mergeSummaries);
+  }, [queryClient, user?.uid]);
+
   const handleDemoBatchSelect = useCallback(async () => {
     setDemoBatchLoading(true);
     try {
@@ -652,10 +664,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
       }
 
       const key = encodeBatchKey(demoBatch.deviceId, demoBatch.batchId);
-      queryClient.setQueryData<BatchSummary[]>(BATCHES_QUERY_KEY(userId ?? null), (prev = []) => {
-        const filtered = prev.filter((batch) => encodeBatchKey(batch.deviceId, batch.batchId) !== key);
-        return sortBatchesByProcessedAtDesc([demoBatch, ...filtered]);
-      });
+      upsertBatchSummary({ ...demoBatch, access: "public" });
       handleBatchSelect(key);
     }
     catch (err) {
@@ -665,7 +674,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     finally {
       setDemoBatchLoading(false);
     }
-  }, [handleBatchSelect, queryClient, userId]);
+  }, [handleBatchSelect, upsertBatchSummary]);
 
   const handleMapZoomChange = useCallback((zoom: number) => {
     const nextZoom = Math.min(Math.max(zoom, MIN_PERSISTED_MAP_ZOOM), MAX_PERSISTED_MAP_ZOOM);


### PR DESCRIPTION
## Summary
- restore the missing batch summary cache helper used by the map batch browser
- keep demo/public batch selection caches in sync
- ensure selected map markers stay visible for GPS batches with small precision values

## Verification
- pnpm lint
- pnpm --filter crowdpm-frontend build