### PR TITLE
Fix public map batch loading pressure

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,7 @@ import type {
   NodePurchaseReceipt,
   NodePurchaseVariantId,
   PublicBatchDetail,
+  PublicBatchMapResponse,
   PublicBatchSummary,
   SubscriptionOffer,
   SubscriptionOfferId,
@@ -128,6 +129,7 @@ export type {
   NodePurchaseReceipt,
   NodePurchaseVariantId,
   PublicBatchDetail,
+  PublicBatchMapResponse,
   PublicBatchSummary,
   SubscriptionOffer,
   SubscriptionOfferId,
@@ -260,6 +262,21 @@ export async function fetchPublicBatchDetail(deviceId: string, batchId: string):
   const safeDevice = encodeURIComponent(deviceId);
   const safeBatch = encodeURIComponent(batchId);
   return requestJson<PublicBatchDetail>(`/v1/public/batches/${safeDevice}/${safeBatch}`);
+}
+
+export async function fetchPublicBatchMap(params?: {
+  limit?: number;
+  since?: string;
+}): Promise<PublicBatchMapResponse> {
+  const qs = new URLSearchParams();
+  if (typeof params?.limit === "number" && Number.isFinite(params.limit)) {
+    qs.set("limit", String(Math.max(1, Math.floor(params.limit))));
+  }
+  if (typeof params?.since === "string" && params.since.trim().length > 0) {
+    qs.set("since", params.since.trim());
+  }
+  const suffix = qs.toString();
+  return requestJson<PublicBatchMapResponse>(suffix ? `/v1/public/batches/map?${suffix}` : "/v1/public/batches/map");
 }
 
 export async function fetchDemoBatch(): Promise<PublicBatchSummary | null> {

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -4,6 +4,7 @@ import { timestampToMillis, type IngestPoint, type UserThemeAppearance } from "@
 import { Button, Dialog, Flex, Select, Switch, Text } from "@radix-ui/themes";
 import {
   fetchBatchDetail,
+  fetchPublicBatchMap,
   fetchDemoBatch,
   fetchPublicBatchDetail,
   listBatches,
@@ -34,6 +35,7 @@ const NO_BATCH_SELECTED_KEY = "__no_batch_selected__";
 const SEE_ALL_BATCHES_KEY = "__see_all_batches__";
 const SHOW_ALL_PUBLIC_24H_KEY = "__all_public_last_24h__";
 const SHOW_ALL_PUBLIC_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+const SHOW_ALL_PUBLIC_BATCH_LIMIT = 200;
 const EXPANDED_BATCH_FETCH_LIMIT = 500;
 const VIDEO_EXPORT_DURATION_MS = 12_000;
 const VIDEO_EXPORT_FPS = 30;
@@ -379,31 +381,14 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
       if (!batchDetailQueryKey || !selectedBatchKey) return [];
       if (selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY) {
         const cutoff = Date.now() - SHOW_ALL_PUBLIC_LOOKBACK_MS;
-        const publicSummaries = await listPublicBatches(100);
-        const recentSummaries = publicSummaries.filter((batch) => {
-          const processedAtMs = timestampToMillis(batch.processedAt);
-          return processedAtMs !== null && processedAtMs >= cutoff;
+        const cutoffIso = new Date(Math.floor(cutoff / 60_000) * 60_000).toISOString();
+        const mapResponse = await fetchPublicBatchMap({
+          limit: SHOW_ALL_PUBLIC_BATCH_LIMIT,
+          since: cutoffIso,
         });
-        if (!recentSummaries.length) return [];
 
-        const details = await Promise.all(
-          recentSummaries.map(async (batch) => {
-            try {
-              return await fetchPublicBatchDetail(batch.deviceId, batch.batchId);
-            }
-            catch (err) {
-              logWarning("Unable to load public batch detail", {
-                deviceId: batch.deviceId,
-                batchId: batch.batchId
-              }, err);
-              return null;
-            }
-          })
-        );
-
-        return details
+        return mapResponse.batches
           .flatMap((detail) => {
-            if (!detail) return [];
             const batchKey = encodeBatchKey(detail.deviceId, detail.batchId);
             return pointsToMeasurementRecords(detail.points, detail.deviceId, detail.batchId, { batchKey });
           })

--- a/functions/src/openapi.yaml
+++ b/functions/src/openapi.yaml
@@ -752,7 +752,7 @@ paths:
           schema:
             type: integer
             minimum: 1
-            maximum: 100
+            maximum: 500
       responses:
         '200':
           description: Public batches returned.
@@ -762,6 +762,34 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PublicBatchSummary'
+  /v1/public/batches/map:
+    get:
+      operationId: getPublicBatchMap
+      summary: Retrieve public approved batches for the map
+      description: >
+        Returns public approved batch details in a single response for map rendering.
+      security: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - name: since
+          in: query
+          required: false
+          schema:
+            type: string
+          description: ISO timestamp or epoch milliseconds used to filter recent batches.
+      responses:
+        '200':
+          description: Public batch map payload returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicBatchMapResponse'
   /v1/public/batches/{deviceId}/{batchId}:
     get:
       operationId: getPublicBatchDetail
@@ -1249,6 +1277,15 @@ components:
     PublicBatchDetail:
       allOf:
         - $ref: '#/components/schemas/BatchDetail'
+    PublicBatchMapResponse:
+      type: object
+      properties:
+        batches:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicBatchDetail'
+      required:
+        - batches
     AdminSubmissionSummary:
       allOf:
         - $ref: '#/components/schemas/BatchSummary'

--- a/functions/src/routes/publicBatches.ts
+++ b/functions/src/routes/publicBatches.ts
@@ -1,5 +1,5 @@
 import type { IncomingHttpHeaders } from "node:http";
-import type { BatchVisibility, PublicBatchDetail, PublicBatchSummary } from "@crowdpm/types";
+import type { BatchVisibility, PublicBatchDetail, PublicBatchMapResponse, PublicBatchSummary } from "@crowdpm/types";
 import type { firestore } from "firebase-admin";
 import type { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
@@ -9,14 +9,30 @@ import { httpError } from "../lib/httpError.js";
 import { normalizeTimestamp, normalizeVisibility, parseDeviceId } from "../lib/httpValidation.js";
 import { normalizeModerationState } from "../lib/moderation.js";
 import { rateLimitGuard, requestParam } from "../lib/routeGuards.js";
+import { timestampToMillis } from "../lib/time.js";
 import { decodeBatchPayload } from "../services/batchPayloads.js";
 
 const PUBLIC_BATCH_LIST_MAX_LIMIT = 500;
+const PUBLIC_BATCH_MAP_MAX_LIMIT = 200;
+const PUBLIC_BATCH_MAP_DEFAULT_LIMIT = 200;
+const PUBLIC_BATCH_MAP_CONCURRENCY = 8;
+const PUBLIC_BATCH_MAP_CACHE_MS = 30_000;
 const APP_SETTINGS_COLLECTION = "appSettings";
 const DEMO_BATCH_SETTINGS_DOC = "demoBatch";
 const listQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(PUBLIC_BATCH_LIST_MAX_LIMIT).optional(),
 });
+const mapQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(PUBLIC_BATCH_MAP_MAX_LIMIT).optional(),
+  since: z.string().trim().optional(),
+});
+
+type PublicBatchMapCacheEntry = {
+  expiresAt: number;
+  response: PublicBatchMapResponse;
+};
+
+const publicBatchMapCache = new Map<string, PublicBatchMapCacheEntry>();
 
 function requestIp(req: { headers: IncomingHttpHeaders; ip: string }): string {
   return extractClientIp(req.headers) ?? req.ip ?? "unknown";
@@ -44,6 +60,65 @@ function serializeSummary(doc: firestore.QueryDocumentSnapshot | firestore.Docum
     visibility: "public",
     moderationState: normalizeModerationState(data.moderationState),
   };
+}
+
+function parseSinceQuery(value: string | undefined): number | null {
+  if (!value) return null;
+  if (/^\d+$/u.test(value)) {
+    const millis = Number(value);
+    if (Number.isFinite(millis)) {
+      return millis;
+    }
+  }
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    throw httpError(400, "invalid_request", "since must be a valid ISO timestamp or epoch milliseconds.");
+  }
+  return parsed;
+}
+
+function detailFromSummary(summary: PublicBatchSummary, points: PublicBatchDetail["points"]): PublicBatchDetail {
+  return {
+    ...summary,
+    points,
+  };
+}
+
+async function readBatchPoints(storagePath: string): Promise<PublicBatchDetail["points"]> {
+  const [buf] = await bucket().file(storagePath).download();
+  return decodeBatchPayload(buf, storagePath).points;
+}
+
+async function mapWithConcurrency<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  mapper: (value: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= values.length) {
+        return;
+      }
+      results[index] = await mapper(values[index], index);
+    }
+  }));
+
+  return results;
+}
+
+async function listPublicApprovedBatchDocs(limit: number) {
+  const snap = await db().collection("batches")
+    .where("visibility", "==", "public")
+    .where("moderationState", "==", "approved")
+    .orderBy("processedAt", "desc")
+    .limit(limit)
+    .get();
+  return snap.docs;
 }
 
 function ensurePublicApproved(data: firestore.DocumentData | undefined): { visibility: BatchVisibility; moderationState: "approved" } {
@@ -95,14 +170,70 @@ export const publicBatchesRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const limit = parsed.data.limit ?? 50;
-    const snap = await db().collection("batches")
-      .where("visibility", "==", "public")
-      .where("moderationState", "==", "approved")
-      .orderBy("processedAt", "desc")
-      .limit(limit)
-      .get();
+    const docs = await listPublicApprovedBatchDocs(limit);
+    return docs.map((doc) => serializeSummary(doc));
+  });
 
-    return snap.docs.map((doc) => serializeSummary(doc));
+  app.get("/v1/public/batches/map", {
+    preHandler: [
+      rateLimitGuard((req) => `public:batches:map:ip:${requestIp(req)}`, 60, 60_000),
+      rateLimitGuard("public:batches:map:global", 500, 60_000),
+    ],
+  }, async (req, rep): Promise<PublicBatchMapResponse> => {
+    const parsed = mapQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      throw httpError(400, "invalid_request", "invalid query", { details: parsed.error.flatten() });
+    }
+
+    const limit = parsed.data.limit ?? PUBLIC_BATCH_MAP_DEFAULT_LIMIT;
+    const sinceMs = parseSinceQuery(parsed.data.since);
+    const normalizedSinceKey = sinceMs === null ? "all" : String(Math.floor(sinceMs / PUBLIC_BATCH_MAP_CACHE_MS));
+    const cacheKey = `${limit}:${normalizedSinceKey}`;
+    const now = Date.now();
+    const cached = publicBatchMapCache.get(cacheKey);
+    if (cached && cached.expiresAt > now) {
+      rep.header("Cache-Control", "public, max-age=30");
+      return cached.response;
+    }
+
+    const docs = await listPublicApprovedBatchDocs(limit);
+    const filteredDocs = sinceMs === null
+      ? docs
+      : docs.filter((doc) => {
+        const processedAtMs = timestampToMillis(doc.get("processedAt"));
+        return processedAtMs !== null && processedAtMs >= sinceMs;
+      });
+
+    const detailResults = await mapWithConcurrency(filteredDocs, PUBLIC_BATCH_MAP_CONCURRENCY, async (doc) => {
+      const summary = serializeSummary(doc);
+      const storagePath = asString(doc.get("storagePath"));
+      if (!storagePath) {
+        app.log.error({ batchId: summary.batchId, deviceId: summary.deviceId }, "public map batch missing storage path");
+        return null;
+      }
+
+      try {
+        const points = await readBatchPoints(storagePath);
+        return detailFromSummary({
+          ...summary,
+          count: asNumber(doc.get("count"), points.length),
+        }, points);
+      }
+      catch (err) {
+        app.log.error({ err, batchId: summary.batchId, deviceId: summary.deviceId }, "failed to read public batch payload for map");
+        return null;
+      }
+    });
+
+    const response = {
+      batches: detailResults.filter((detail): detail is PublicBatchDetail => Boolean(detail)),
+    } satisfies PublicBatchMapResponse;
+    publicBatchMapCache.set(cacheKey, {
+      expiresAt: now + PUBLIC_BATCH_MAP_CACHE_MS,
+      response,
+    });
+    rep.header("Cache-Control", "public, max-age=30");
+    return response;
   });
 
   app.get<{ Params: { deviceId: string; batchId: string } }>("/v1/public/batches/:deviceId/:batchId", {
@@ -137,20 +268,18 @@ export const publicBatchesRoutes: FastifyPluginAsync = async (app) => {
 
     let points: PublicBatchDetail["points"];
     try {
-      const [buf] = await bucket().file(storagePath).download();
-      points = decodeBatchPayload(buf, storagePath).points;
+      points = await readBatchPoints(storagePath);
     }
     catch (err) {
       app.log.error({ err, batchId, deviceId }, "failed to read public batch payload");
       throw httpError(500, "storage_error", "Unable to read batch payload.");
     }
 
-    return {
+    return detailFromSummary({
       ...serializeSummary(batchSnap),
       count: asNumber(batchData.count, points.length),
       visibility: "public",
       moderationState,
-      points,
-    };
+    }, points);
   });
 };

--- a/functions/test/routes/publicBatches.test.ts
+++ b/functions/test/routes/publicBatches.test.ts
@@ -210,6 +210,42 @@ describe("GET /v1/public/batches", () => {
   });
 });
 
+describe("GET /v1/public/batches/map", () => {
+  it("returns approved public batch details in a single response", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/v1/public/batches/map?since=2024-01-01T00:00:00.000Z" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["cache-control"]).toBe("public, max-age=30");
+    expect(res.json()).toEqual({
+      batches: [
+        expect.objectContaining({
+          batchId: "batch-approved",
+          deviceId: "device-1",
+          visibility: "public",
+          moderationState: "approved",
+          points: [expect.objectContaining({ value: 11 })],
+        }),
+      ],
+    });
+    await app.close();
+  });
+
+  it("returns 400 for an invalid since query", async () => {
+    const app = await buildApp();
+
+    const res = await app.inject({ method: "GET", url: "/v1/public/batches/map?since=not-a-date" });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({
+      error: "invalid_request",
+      message: "since must be a valid ISO timestamp or epoch milliseconds.",
+    });
+    await app.close();
+  });
+});
+
 describe("GET /v1/public/batches/:deviceId/:batchId", () => {
   it("returns gzipped detail for approved public batches", async () => {
     const app = await buildApp();

--- a/shared-types/src/index.ts
+++ b/shared-types/src/index.ts
@@ -170,6 +170,9 @@ export type BatchDetail = BatchSummary & {
 
 export type PublicBatchSummary = BatchSummary;
 export type PublicBatchDetail = BatchDetail;
+export type PublicBatchMapResponse = {
+  batches: PublicBatchDetail[];
+};
 
 export type AdminSubmissionSummary = BatchSummary & {
   moderationReason?: string | null;


### PR DESCRIPTION
## Summary
- add a bulk public map endpoint so the map can load recent public batches in one request instead of N per-batch detail requests
- switch the frontend all-public map view to the bulk endpoint and add the shared API contract + OpenAPI docs
- cover the new endpoint with route tests and keep response caching on the map payload

## Verification
- pnpm --filter crowdpm-functions test -- publicBatches
- pnpm --filter crowdpm-functions build
- pnpm --filter crowdpm-frontend build

## Notes
- production cleanup already removed the 74 single-point public approved batches that were driving the 429 burst
