### PR TITLE
Fix API routing and hosting deploy guards

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,6 @@ jobs:
           gcloud config set project "$FIREBASE_PROJECT_ID"
           required_keys=(
             FRONTEND_URL
-            VITE_API_BASE
             VITE_GOOGLE_MAPS_API_KEY
             VITE_GOOGLE_MAP_ID
             VITE_FIREBASE_API_KEY
@@ -299,6 +298,26 @@ jobs:
         if: ${{ env.FRONTEND_URL }}
         run: |
           curl --fail --silent --show-error "$FRONTEND_URL" >/dev/null
+
+      - name: Frontend asset MIME check
+        if: ${{ env.FRONTEND_URL }}
+        run: |
+          html="$(curl --fail --silent --show-error "$FRONTEND_URL")"
+          asset_path="$(printf '%s' "$html" | grep -oE '/assets/[^"]+\.js' | head -n1)"
+          test -n "$asset_path" || { echo "Unable to find a built JS asset in the deployed HTML."; exit 1; }
+
+          response_headers="$(mktemp)"
+          curl --fail --silent --show-error -D "$response_headers" -o /dev/null "${FRONTEND_URL%/}$asset_path"
+          content_type="$(awk -F': ' 'tolower($1) == "content-type" { print tolower($2) }' "$response_headers" | tr -d '\r' | tail -n1)"
+          rm -f "$response_headers"
+
+          echo "$content_type" | grep -Eq 'javascript|ecmascript' \
+            || { echo "Unexpected asset content type for $asset_path: ${content_type:-missing}"; exit 1; }
+
+      - name: Frontend API rewrite check
+        if: ${{ env.FRONTEND_URL }}
+        run: |
+          curl --fail --silent --show-error "${FRONTEND_URL%/}/api/health"
 
       - name: API health check
         if: ${{ env.FUNCTIONS_HEALTH_URL }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cp functions/.env.example functions/.env.local
 Edit `frontend/.env.local` with a Google Maps JavaScript API key, vector map ID, Firebase web app config, and the local API base:
 
 ```bash
-VITE_API_BASE=http://127.0.0.1:5001/crowdpm-local/us-central1/crowdpmApi
+VITE_API_BASE=/api
 VITE_FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,7 +40,7 @@ cp functions/.env.example functions/.env.local
 
 Frontend values that normally need editing:
 
-- `VITE_API_BASE=http://127.0.0.1:5001/crowdpm-local/us-central1/crowdpmApi`
+- `VITE_API_BASE=/api`
 - `VITE_GOOGLE_MAPS_API_KEY`
 - `VITE_GOOGLE_MAP_ID`
 - `VITE_FIREBASE_*` web app values

--- a/firebase.json
+++ b/firebase.json
@@ -22,6 +22,9 @@
     "ui": { "enabled": true }
   },
   "hosting": {
+    "predeploy": [
+      "pnpm --filter crowdpm-frontend build"
+    ],
     "public": "frontend/dist",
     "headers": [
       {
@@ -68,6 +71,10 @@
         ]
       }
     ],
-    "rewrites": [{ "source": "**", "destination": "/index.html" }]
+    "rewrites": [
+      { "source": "/api", "function": "crowdpmApi" },
+      { "source": "/api/**", "function": "crowdpmApi" },
+      { "source": "**", "destination": "/index.html" }
+    ]
   }
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
 # Example values for local development.
-VITE_API_BASE=http://127.0.0.1:5001/crowdpm-local/us-central1/crowdpmApi
+VITE_API_BASE=/api
 VITE_GOOGLE_MAPS_API_KEY=replace-with-google-maps-key
 VITE_GOOGLE_MAP_ID=replace-with-google-vector-map-id
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,7 +20,7 @@ Create `frontend/.env.local` from `frontend/.env.example`.
 
 Required values:
 
-- `VITE_API_BASE`: `crowdpmApi` Functions base URL, not the Hosting URL.
+- `VITE_API_BASE`: recommended value is `/api`, which the local Vite dev server proxies to `crowdpmApi` and Firebase Hosting rewrites to the same function in deployed environments. A full Functions base URL also works.
 - `VITE_GOOGLE_MAPS_API_KEY`: Google Maps JavaScript API key.
 - `VITE_GOOGLE_MAP_ID`: vector map ID for WebGL overlays.
 - `VITE_FIREBASE_API_KEY`

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_BASE: string;
+  readonly VITE_API_BASE?: string;
   readonly VITE_GOOGLE_MAPS_API_KEY: string;
   readonly VITE_GOOGLE_MAP_ID: string;
   readonly VITE_FIREBASE_API_KEY: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -28,20 +28,12 @@ import type {
 } from "@crowdpm/types";
 
 const rawBase = import.meta.env.VITE_API_BASE as string | undefined;
-const BASE = rawBase ? rawBase.trim().replace(/\/$/, "") : "";
+const BASE = rawBase ? rawBase.trim().replace(/\/$/, "") : "/api";
 const FIREBASE_HOSTING_DOMAINS = ["web.app", "firebaseapp.com"] as const;
 
-function ensureBase(): string {
-  if (!BASE) {
-    throw new Error("VITE_API_BASE is not configured. Set it to your Functions API (see README).");
-  }
-  return BASE;
-}
-
 function buildUrl(path: string): string {
-  const base = ensureBase();
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
-  return `${base}${normalizedPath}`;
+  return `${BASE}${normalizedPath}`;
 }
 
 function isFirebaseHostingHost(hostname: string | null | undefined): boolean {
@@ -97,9 +89,11 @@ async function requestJson<T>(path: string, init?: RequestInit): Promise<T> {
       }
     })();
     const snippet = bodyText.trim().replace(/\s+/g, " ").slice(0, 160);
-    const hint = isFirebaseHostingHost(hostname)
-      ? "Ensure VITE_API_BASE points to your Functions endpoint instead of the Hosting URL."
-      : "Ensure VITE_API_BASE points to your Functions endpoint.";
+    const hint = url.startsWith("/api")
+      ? "Ensure /api is proxied or rewritten to crowdpmApi, or set VITE_API_BASE to the Functions endpoint."
+      : isFirebaseHostingHost(hostname)
+        ? "Ensure VITE_API_BASE points to your Functions endpoint instead of the Hosting URL."
+        : "Ensure VITE_API_BASE points to your Functions endpoint.";
     const responsePreview = snippet ? ` Response starts with: ${snippet}` : "";
     throw new Error(`Expected JSON from ${host} but received ${contentType || "unknown content"}. ${hint}${responsePreview}`);
   }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,17 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({ plugins: [react()] });
+const FUNCTIONS_PROXY_TARGET = "http://127.0.0.1:5001/crowdpm-local/us-central1/crowdpmApi";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: FUNCTIONS_PROXY_TARGET,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api(?=\/|$)/, ""),
+      },
+    },
+  },
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -18,6 +18,7 @@ import { ensureLocalSuperAdmin } from "./lib/localSuperAdmin.js";
 import { toHttpError } from "./lib/httpError.js";
 import { RateLimitError } from "./lib/rateLimiter.js";
 import { fastifyCorsOptionsForRequest } from "./lib/corsPolicy.js";
+import { stripApiEntryPrefix } from "./lib/http.js";
 adminApp();
 
 const api = Fastify({ logger: true });
@@ -104,6 +105,7 @@ export const crowdpmApi = https.onRequest({
 }, (req, res) => {
   const requestWithRawBody = req as RequestWithRawBody;
   requestWithRawBody.rawBody = requestWithRawBody.rawBody ?? undefined;
+  requestWithRawBody.url = stripApiEntryPrefix(requestWithRawBody.url);
   apiSetup.then(() => api.server.emit("request", req, res));
 });
 

--- a/functions/src/lib/http.ts
+++ b/functions/src/lib/http.ts
@@ -7,6 +7,27 @@ function firstHeaderValue(value: string | string[] | undefined): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+export function stripApiEntryPrefix(url: string | undefined): string {
+  const raw = typeof url === "string" && url.length > 0 ? url : "/";
+  if (!raw.startsWith("/api")) {
+    return raw;
+  }
+
+  const nextChar = raw.charAt("/api".length);
+  if (nextChar && nextChar !== "/" && nextChar !== "?") {
+    return raw;
+  }
+
+  const stripped = raw.slice("/api".length);
+  if (!stripped) {
+    return "/";
+  }
+  if (stripped.startsWith("?")) {
+    return `/${stripped}`;
+  }
+  return stripped;
+}
+
 export function canonicalRequestUrl(url: string | undefined, headers: IncomingHttpHeaders): string {
   const proto = firstHeaderValue(headers["x-forwarded-proto"])
     || firstHeaderValue(headers[":scheme"])

--- a/functions/test/lib/http.test.ts
+++ b/functions/test/lib/http.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { stripApiEntryPrefix } from "../../src/lib/http.js";
+
+describe("stripApiEntryPrefix", () => {
+  it("strips the hosting /api prefix for nested routes", () => {
+    expect(stripApiEntryPrefix("/api/v1/public/batches")).toBe("/v1/public/batches");
+    expect(stripApiEntryPrefix("/api/health")).toBe("/health");
+  });
+
+  it("preserves query strings when stripping the /api prefix", () => {
+    expect(stripApiEntryPrefix("/api/v1/public/batches?limit=20")).toBe("/v1/public/batches?limit=20");
+    expect(stripApiEntryPrefix("/api?check=1")).toBe("/?check=1");
+  });
+
+  it("leaves non-matching paths unchanged", () => {
+    expect(stripApiEntryPrefix("/v1/public/batches")).toBe("/v1/public/batches");
+    expect(stripApiEntryPrefix("/apiv1/public/batches")).toBe("/apiv1/public/batches");
+    expect(stripApiEntryPrefix(undefined)).toBe("/");
+  });
+});


### PR DESCRIPTION
## Summary
- route first-party `/api` requests from Hosting and local Vite to `crowdpmApi`
- default the frontend API base to `/api` and document that configuration
- add deploy checks for JS asset MIME type and `/api/health`

## Testing
- `pnpm --filter crowdpm-functions test`
- `pnpm --filter crowdpm-frontend build`