### PR TITLE
Fix deployed functions runtime admin role imports

### DIFF
--- a/functions/src/lib/adminRoles.ts
+++ b/functions/src/lib/adminRoles.ts
@@ -1,0 +1,23 @@
+import type { AdminRole } from "@crowdpm/types";
+
+export function isAdminRole(value: unknown): value is AdminRole {
+  return value === "super_admin" || value === "moderator";
+}
+
+export function normalizeAdminRoles(value: unknown): AdminRole[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const out = new Set<AdminRole>();
+  value.forEach((entry) => {
+    if (isAdminRole(entry)) {
+      out.add(entry);
+    }
+  });
+  return Array.from(out);
+}
+
+export function readAdminRolesFromClaims(claims: { roles?: unknown } | undefined): AdminRole[] {
+  return normalizeAdminRoles(claims?.roles);
+}

--- a/functions/src/lib/rbac.ts
+++ b/functions/src/lib/rbac.ts
@@ -1,5 +1,6 @@
 import type { DecodedIdToken } from "firebase-admin/auth";
-import { readAdminRolesFromClaims, type AdminRole } from "@crowdpm/types";
+import type { AdminRole } from "@crowdpm/types";
+import { readAdminRolesFromClaims } from "./adminRoles.js";
 
 export type { AdminRole };
 

--- a/functions/src/routes/adminUsers.ts
+++ b/functions/src/routes/adminUsers.ts
@@ -1,6 +1,4 @@
 import {
-  normalizeAdminRoles,
-  readAdminRolesFromClaims,
   type AdminUserSummary,
   type AdminUserUpdateRequest,
   type AdminUsersListResponse,
@@ -9,6 +7,7 @@ import type { auth as FirebaseAuth } from "firebase-admin";
 import type { FastifyPluginAsync } from "fastify";
 import { z } from "zod";
 import { app, db } from "../lib/fire.js";
+import { normalizeAdminRoles, readAdminRolesFromClaims } from "../lib/adminRoles.js";
 import { httpError } from "../lib/httpError.js";
 import { normalizeTimestamp } from "../lib/httpValidation.js";
 import { writeModerationAudit } from "../lib/moderationAudit.js";


### PR DESCRIPTION
## Summary
- move runtime admin-role normalization back into the functions package
- keep `@crowdpm/types` imports type-only in deployed functions code
- fix the main deploy failure where both Cloud Run-backed functions failed to start after merge

## Root cause
The previous refactor introduced runtime imports from `@crowdpm/types` inside `crowdpm-functions`. That package is not declared as a production dependency in `functions/package.json`, so the deployed Cloud Functions container could not resolve it at startup.

Failed main run:
- `Deploy Firebase` run `25935459791` on commit `bc960d0` (May 15, 2026)
- failing step: `Deploy hosting and functions`
- symptom: both `crowdpmApi` and `ingestGateway` failed Cloud Run health checks because the container never started listening on `PORT=8080`

## Verification
- `pnpm --filter crowdpm-functions test`
- `pnpm --filter crowdpm-functions build`
- `pnpm lint`
- verified emitted `functions/lib` contains no runtime `@crowdpm/types` imports
