### PR TITLE
Refactor state boundaries and startup initialization

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { LegalDocumentDialog, LegalDocumentLink, type LegalDocumentId } from "./
 import { APP_ROUTES, getDeepLinkedAppTab, getRouteForDeepLinkedAppTab, isActivationRoute, isDeepLinkedAppRoute, type DeepLinkedAppTab } from "./lib/appRoutes";
 import { PROJECT_LINKS, PROJECT_RESOURCE_LINKS } from "./lib/projectLinks";
 import { logWarning } from "./lib/logger";
+import { pushAppLocation, replaceAppLocation, replaceCurrentUrl, useBrowserLocation } from "./lib/locationStore";
 import { useAuth } from "./providers/AuthProvider";
 import { useUserSettings } from "./providers/UserSettingsProvider";
 import {
@@ -104,68 +105,55 @@ function isDeepLinkedTab(tab: AppTab): tab is DeepLinkedAppTab {
   return tab === "pairing-info" || tab === "about" || tab === "node";
 }
 
-function readThemeCheckoutNotice(): ThemeCheckoutNotice {
-  if (typeof window === "undefined") return null;
-  const status = new URLSearchParams(window.location.search).get("themeCheckout");
+function readThemeCheckoutNotice(search: string): ThemeCheckoutNotice {
+  const status = new URLSearchParams(search).get("themeCheckout");
   return status === "success" || status === "cancelled" ? status : null;
 }
 
 function clearThemeCheckoutNoticeFromUrl() {
-  if (typeof window === "undefined") return;
-  const nextUrl = new URL(window.location.href);
-  nextUrl.searchParams.delete("themeCheckout");
-  nextUrl.searchParams.delete("themeCheckoutSessionId");
-  window.history.replaceState({}, "", `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`);
+  replaceCurrentUrl((nextUrl) => {
+    nextUrl.searchParams.delete("themeCheckout");
+    nextUrl.searchParams.delete("themeCheckoutSessionId");
+  });
 }
 
-function readThemeCheckoutSessionId(): string | null {
-  if (typeof window === "undefined") return null;
-  const sessionId = new URLSearchParams(window.location.search).get("themeCheckoutSessionId");
+function readThemeCheckoutSessionId(search: string): string | null {
+  const sessionId = new URLSearchParams(search).get("themeCheckoutSessionId");
   return typeof sessionId === "string" && sessionId.trim().length > 0 ? sessionId : null;
 }
 
-function readSubscriptionCheckoutNotice(): SubscriptionCheckoutNotice {
-  if (typeof window === "undefined") return null;
-  const status = new URLSearchParams(window.location.search).get("subscriptionCheckout");
+function readSubscriptionCheckoutNotice(search: string): SubscriptionCheckoutNotice {
+  const status = new URLSearchParams(search).get("subscriptionCheckout");
   return status === "success" || status === "cancelled" ? status : null;
 }
 
-function readSubscriptionCheckoutSessionId(): string | null {
-  if (typeof window === "undefined") return null;
-  const sessionId = new URLSearchParams(window.location.search).get("subscriptionCheckoutSessionId");
+function readSubscriptionCheckoutSessionId(search: string): string | null {
+  const sessionId = new URLSearchParams(search).get("subscriptionCheckoutSessionId");
   return typeof sessionId === "string" && sessionId.trim().length > 0 ? sessionId : null;
 }
 
 function clearSubscriptionCheckoutNoticeFromUrl() {
-  if (typeof window === "undefined") return;
-  const nextUrl = new URL(window.location.href);
-  nextUrl.searchParams.delete("subscriptionCheckout");
-  nextUrl.searchParams.delete("subscriptionCheckoutSessionId");
-  window.history.replaceState({}, "", `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`);
+  replaceCurrentUrl((nextUrl) => {
+    nextUrl.searchParams.delete("subscriptionCheckout");
+    nextUrl.searchParams.delete("subscriptionCheckoutSessionId");
+  });
 }
 
 export default function App() {
   const { user, isLoading, signOut, canAccessAdmin } = useAuth();
   const { settings } = useUserSettings();
+  const location = useBrowserLocation();
   const userScopedKey = user?.uid ?? "anon";
-  const initialDeepLinkedTab = typeof window !== "undefined"
-    ? getDeepLinkedAppTab(window.location.pathname)
-    : null;
-  const initialThemeCheckoutNotice = readThemeCheckoutNotice();
-  const initialThemeCheckoutSessionId = readThemeCheckoutSessionId();
-  const initialSubscriptionCheckoutNotice = readSubscriptionCheckoutNotice();
-  const initialSubscriptionCheckoutSessionId = readSubscriptionCheckoutSessionId();
-  const [tab, setTab] = useState<AppTab>(initialDeepLinkedTab ?? "map");
+  const [tab, setTab] = useState<AppTab>(() => getDeepLinkedAppTab(location.pathname) ?? "map");
   const [authMode, setAuthMode] = useState<AuthMode>("login");
   const [isAuthDialogOpen, setAuthDialogOpen] = useState(false);
-  const initialActivationPath = typeof window !== "undefined" && isActivationRoute(window.location.pathname);
-  const [isActivationModalOpen, setActivationModalOpen] = useState(initialActivationPath);
+  const [isActivationModalOpen, setActivationModalOpen] = useState(() => isActivationRoute(location.pathname));
   const [isTeamModalOpen, setTeamModalOpen] = useState(false);
-  const [isThemeModalOpen, setThemeModalOpen] = useState(Boolean(initialThemeCheckoutNotice));
-  const [themeCheckoutNotice, setThemeCheckoutNotice] = useState<ThemeCheckoutNotice>(initialThemeCheckoutNotice);
-  const [themeCheckoutSessionId, setThemeCheckoutSessionId] = useState<string | null>(initialThemeCheckoutSessionId);
-  const [subscriptionCheckoutNotice, setSubscriptionCheckoutNotice] = useState<SubscriptionCheckoutNotice>(initialSubscriptionCheckoutNotice);
-  const [subscriptionCheckoutSessionId, setSubscriptionCheckoutSessionId] = useState<string | null>(initialSubscriptionCheckoutSessionId);
+  const [isThemeModalOpen, setThemeModalOpen] = useState(() => Boolean(readThemeCheckoutNotice(location.search)));
+  const [themeCheckoutNotice, setThemeCheckoutNotice] = useState<ThemeCheckoutNotice>(() => readThemeCheckoutNotice(location.search));
+  const [themeCheckoutSessionId, setThemeCheckoutSessionId] = useState<string | null>(() => readThemeCheckoutSessionId(location.search));
+  const [subscriptionCheckoutNotice, setSubscriptionCheckoutNotice] = useState<SubscriptionCheckoutNotice>(() => readSubscriptionCheckoutNotice(location.search));
+  const [subscriptionCheckoutSessionId, setSubscriptionCheckoutSessionId] = useState<string | null>(() => readSubscriptionCheckoutSessionId(location.search));
   const [themeDraft, setThemeDraft] = useState<UserThemeSettings | null>(null);
   const [dashboardRefreshToken, setDashboardRefreshToken] = useState(0);
 
@@ -223,6 +211,22 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    const nextThemeNotice = readThemeCheckoutNotice(location.search);
+    const nextThemeSessionId = readThemeCheckoutSessionId(location.search);
+    const nextSubscriptionNotice = readSubscriptionCheckoutNotice(location.search);
+    const nextSubscriptionSessionId = readSubscriptionCheckoutSessionId(location.search);
+
+    setThemeCheckoutNotice(nextThemeNotice);
+    setThemeCheckoutSessionId(nextThemeSessionId);
+    setSubscriptionCheckoutNotice(nextSubscriptionNotice);
+    setSubscriptionCheckoutSessionId(nextSubscriptionSessionId);
+
+    if (nextThemeNotice) {
+      setThemeModalOpen(true);
+    }
+  }, [location.search]);
+
+  useEffect(() => {
     if (user) return;
     setThemeDraft(null);
   }, [user]);
@@ -272,47 +276,45 @@ export default function App() {
   }, [toggleThemeModal]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    if (isActivationModalOpen) {
-      if (!isActivationRoute(window.location.pathname)) {
-        window.history.pushState({}, "", APP_ROUTES.activation);
-      }
+    const pathname = location.pathname.toLowerCase();
+    if (isActivationRoute(pathname)) {
+      setActivationModalOpen(true);
+      return;
     }
-    else if (isActivationRoute(window.location.pathname)) {
-      window.history.replaceState({}, "", APP_ROUTES.home);
+    setActivationModalOpen(false);
+
+    const deepLinkedTab = getDeepLinkedAppTab(pathname);
+    if (deepLinkedTab) {
+      setTab(deepLinkedTab);
     }
-  }, [isActivationModalOpen]);
+    else {
+      setTab((currentTab) => isDeepLinkedTab(currentTab) ? "map" : currentTab);
+    }
+  }, [location.pathname]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    const pathname = window.location.pathname.toLowerCase();
+    if (isActivationModalOpen) {
+      if (!isActivationRoute(location.pathname)) {
+        pushAppLocation(APP_ROUTES.activation);
+      }
+    }
+    else if (isActivationRoute(location.pathname)) {
+      replaceAppLocation(APP_ROUTES.home);
+    }
+  }, [isActivationModalOpen, location.pathname]);
+
+  useEffect(() => {
+    const pathname = location.pathname.toLowerCase();
     if (isDeepLinkedTab(tab)) {
       const targetRoute = getRouteForDeepLinkedAppTab(tab);
       if (!pathname.startsWith(targetRoute)) {
-        window.history.pushState({}, "", targetRoute);
+        pushAppLocation(targetRoute);
       }
     }
     else if (isDeepLinkedAppRoute(pathname)) {
-      window.history.replaceState({}, "", APP_ROUTES.home);
+      replaceAppLocation(APP_ROUTES.home);
     }
-  }, [tab]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const handlePopState = () => {
-      const pathname = window.location.pathname.toLowerCase();
-      const deepLinkedTab = getDeepLinkedAppTab(pathname);
-      setActivationModalOpen(isActivationRoute(pathname));
-      if (deepLinkedTab) {
-        setTab(deepLinkedTab);
-      }
-      else if (isDeepLinkedTab(tab)) {
-        setTab("map");
-      }
-    };
-    window.addEventListener("popstate", handlePopState);
-    return () => window.removeEventListener("popstate", handlePopState);
-  }, [tab]);
+  }, [location.pathname, tab]);
 
   const openActivationModal = () => {
     if (!user) {

--- a/frontend/src/components/Map3D.tsx
+++ b/frontend/src/components/Map3D.tsx
@@ -8,6 +8,12 @@ import type { Layer } from "@deck.gl/core";
 import { getMapsLoader, normalizeGoogleMapId } from "../lib/mapsLoader";
 import { logError, logWarning } from "../lib/logger";
 import { canCaptureCanvas } from "../lib/videoExport";
+import {
+  planExportCameraBase,
+  planExportCameraFrame,
+  planSelectionCamera,
+  type CameraState,
+} from "../lib/mapCamera";
 
 type MeasurementPoint = {
   lat: number;
@@ -55,12 +61,7 @@ export type Map3DHandle = {
   setExportCameraFrame: (frame: Map3DExportCameraFrame | null) => void;
 };
 
-type MapCameraState = {
-  center: { lat: number; lng: number };
-  zoom?: number;
-  tilt?: number;
-  heading?: number;
-};
+type MapCameraState = CameraState;
 
 type Map3DProps = {
   data: MeasurementPoint[];
@@ -114,22 +115,6 @@ async function waitForAnimationFrames(count: number) {
   for (let index = 0; index < count; index += 1) {
     await waitForNextAnimationFrame();
   }
-}
-
-function clamp01(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Math.min(Math.max(value, 0), 1);
-}
-
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * t;
-}
-
-function easeInOutCubic(t: number): number {
-  const clamped = clamp01(t);
-  return clamped < 0.5
-    ? 4 * clamped * clamped * clamped
-    : 1 - Math.pow(-2 * clamped + 2, 3) / 2;
 }
 
 function waitForMapIdle(map: google.maps.Map | null, timeoutMs: number): Promise<void> {
@@ -912,19 +897,18 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
     const series = latestDataRef.current;
     const current = series[selectedIndexRef.current] ?? series[0];
     if (current) {
-      const center = { lat: current.lat, lng: current.lon };
       const map = mapRef.current;
       if (map && (!hasUserControlRef.current || options?.forceCenter || forceFollowSelection)) {
         if (exportCameraActiveRef.current) {
           requestOverlayRedraw(overlay);
           return;
         }
-        const targetZoom = forceFollowSelection
-          ? Math.max(map.getZoom() ?? 18, 18)
-          : Math.max(map.getZoom() ?? 17, 16);
-        const currentTilt = map.getTilt() ?? 0;
-        const targetTilt = currentTilt < 10 ? 67.5 : undefined;
-        moveMapCamera(map, { center, zoom: targetZoom, tilt: targetTilt });
+        moveMapCamera(map, planSelectionCamera({
+          point: current,
+          currentZoom: map.getZoom() ?? undefined,
+          currentTilt: map.getTilt() ?? undefined,
+          forceFollowSelection,
+        }));
       }
     }
 
@@ -962,33 +946,22 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
     const series = latestDataRef.current;
     if (!map || !series.length) return;
 
-    const maxIndex = series.length - 1;
-    const fromIndex = Math.min(Math.max(Math.round(frame.fromIndex), 0), maxIndex);
-    const toIndex = Math.min(Math.max(Math.round(frame.toIndex), 0), maxIndex);
-    const from = series[fromIndex];
-    const to = series[toIndex] ?? from;
-    if (!from || !to) return;
-
     if (!exportCameraBaseRef.current) {
-      const currentCamera = readMapCameraState(map);
-      exportCameraBaseRef.current = {
-        zoom: Math.max(currentCamera?.zoom ?? map.getZoom() ?? 18, forceFollowSelection ? 18 : 16),
-        tilt: currentCamera?.tilt ?? map.getTilt() ?? 67.5,
-        heading: currentCamera?.heading ?? map.getHeading() ?? 0,
-      };
+      exportCameraBaseRef.current = planExportCameraBase({
+        currentCamera: readMapCameraState(map),
+        currentZoom: map.getZoom() ?? undefined,
+        currentTilt: map.getTilt() ?? undefined,
+        currentHeading: map.getHeading() ?? undefined,
+        forceFollowSelection,
+      });
     }
 
-    const easedProgress = easeInOutCubic(frame.progress);
-    const baseCamera = exportCameraBaseRef.current;
-    moveMapCamera(map, {
-      center: {
-        lat: lerp(from.lat, to.lat, easedProgress),
-        lng: lerp(from.lon, to.lon, easedProgress),
-      },
-      zoom: frame.zoom ?? baseCamera.zoom,
-      tilt: frame.tilt ?? (baseCamera.tilt < 10 ? 67.5 : baseCamera.tilt),
-      heading: baseCamera.heading + (frame.headingOffsetDeg ?? 0),
+    const nextCamera = planExportCameraFrame({
+      frame,
+      series,
+      baseCamera: exportCameraBaseRef.current,
     });
+    if (nextCamera) moveMapCamera(map, nextCamera);
   }, [forceFollowSelection]);
 
   useImperativeHandle(ref, () => ({

--- a/frontend/src/lib/locationStore.ts
+++ b/frontend/src/lib/locationStore.ts
@@ -1,0 +1,60 @@
+import { useSyncExternalStore } from "react";
+
+export type BrowserLocationSnapshot = {
+  href: string;
+  pathname: string;
+  search: string;
+  hash: string;
+};
+
+const LOCATION_CHANGE_EVENT = "crowdpm:locationchange";
+const SERVER_LOCATION: BrowserLocationSnapshot = {
+  href: "https://crowdpmplatform.web.app/",
+  pathname: "/",
+  search: "",
+  hash: "",
+};
+
+function readBrowserLocation(): BrowserLocationSnapshot {
+  if (typeof window === "undefined") return SERVER_LOCATION;
+  const { href, pathname, search, hash } = window.location;
+  return { href, pathname, search, hash };
+}
+
+function emitLocationChange(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT));
+}
+
+function subscribeToBrowserLocation(onStoreChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener("popstate", onStoreChange);
+  window.addEventListener(LOCATION_CHANGE_EVENT, onStoreChange);
+  return () => {
+    window.removeEventListener("popstate", onStoreChange);
+    window.removeEventListener(LOCATION_CHANGE_EVENT, onStoreChange);
+  };
+}
+
+export function useBrowserLocation(): BrowserLocationSnapshot {
+  return useSyncExternalStore(subscribeToBrowserLocation, readBrowserLocation, () => SERVER_LOCATION);
+}
+
+export function pushAppLocation(url: string | URL): void {
+  if (typeof window === "undefined") return;
+  window.history.pushState({}, "", url);
+  emitLocationChange();
+}
+
+export function replaceAppLocation(url: string | URL): void {
+  if (typeof window === "undefined") return;
+  window.history.replaceState({}, "", url);
+  emitLocationChange();
+}
+
+export function replaceCurrentUrl(updater: (url: URL) => void): void {
+  if (typeof window === "undefined") return;
+  const nextUrl = new URL(window.location.href);
+  updater(nextUrl);
+  replaceAppLocation(`${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`);
+}

--- a/frontend/src/lib/mapCamera.ts
+++ b/frontend/src/lib/mapCamera.ts
@@ -1,0 +1,92 @@
+export type CameraPoint = {
+  lat: number;
+  lon: number;
+};
+
+export type CameraState = {
+  center: { lat: number; lng: number };
+  zoom?: number;
+  tilt?: number;
+  heading?: number;
+};
+
+export type ExportCameraFrame = {
+  fromIndex: number;
+  toIndex: number;
+  progress: number;
+  headingOffsetDeg?: number;
+  tilt?: number;
+  zoom?: number;
+};
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(value, 0), 1);
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function easeInOutCubic(t: number): number {
+  const clamped = clamp01(t);
+  return clamped < 0.5
+    ? 4 * clamped * clamped * clamped
+    : 1 - Math.pow(-2 * clamped + 2, 3) / 2;
+}
+
+export function planSelectionCamera(args: {
+  point: CameraPoint;
+  currentZoom: number | undefined;
+  currentTilt: number | undefined;
+  forceFollowSelection: boolean;
+}): CameraState {
+  const targetZoom = args.forceFollowSelection
+    ? Math.max(args.currentZoom ?? 18, 18)
+    : Math.max(args.currentZoom ?? 17, 16);
+  const targetTilt = (args.currentTilt ?? 0) < 10 ? 67.5 : undefined;
+  return {
+    center: { lat: args.point.lat, lng: args.point.lon },
+    zoom: targetZoom,
+    tilt: targetTilt,
+  };
+}
+
+export function planExportCameraBase(args: {
+  currentCamera: CameraState | null;
+  currentZoom: number | undefined;
+  currentTilt: number | undefined;
+  currentHeading: number | undefined;
+  forceFollowSelection: boolean;
+}): Required<Pick<CameraState, "zoom" | "tilt" | "heading">> {
+  return {
+    zoom: Math.max(args.currentCamera?.zoom ?? args.currentZoom ?? 18, args.forceFollowSelection ? 18 : 16),
+    tilt: args.currentCamera?.tilt ?? args.currentTilt ?? 67.5,
+    heading: args.currentCamera?.heading ?? args.currentHeading ?? 0,
+  };
+}
+
+export function planExportCameraFrame(args: {
+  frame: ExportCameraFrame;
+  series: CameraPoint[];
+  baseCamera: Required<Pick<CameraState, "zoom" | "tilt" | "heading">>;
+}): CameraState | null {
+  if (!args.series.length) return null;
+  const maxIndex = args.series.length - 1;
+  const fromIndex = Math.min(Math.max(Math.round(args.frame.fromIndex), 0), maxIndex);
+  const toIndex = Math.min(Math.max(Math.round(args.frame.toIndex), 0), maxIndex);
+  const from = args.series[fromIndex];
+  const to = args.series[toIndex] ?? from;
+  if (!from || !to) return null;
+
+  const easedProgress = easeInOutCubic(args.frame.progress);
+  return {
+    center: {
+      lat: lerp(from.lat, to.lat, easedProgress),
+      lng: lerp(from.lon, to.lon, easedProgress),
+    },
+    zoom: args.frame.zoom ?? args.baseCamera.zoom,
+    tilt: args.frame.tilt ?? (args.baseCamera.tilt < 10 ? 67.5 : args.baseCamera.tilt),
+    heading: args.baseCamera.heading + (args.frame.headingOffsetDeg ?? 0),
+  };
+}

--- a/frontend/src/lib/mapSelection.ts
+++ b/frontend/src/lib/mapSelection.ts
@@ -1,0 +1,65 @@
+import { decodeBatchKey } from "./batchKeys";
+
+export const MAP_SELECTION_STORAGE_KEYS = {
+  lastSelection: "crowdpm:lastBatchSelection",
+  lastMapZoom: "crowdpm:lastMapZoom",
+  lastTimelineIndex: "crowdpm:lastTimelineIndex",
+} as const;
+
+export const SHOW_ALL_PUBLIC_24H_KEY = "__all_public_last_24h__";
+export const MIN_PERSISTED_MAP_ZOOM = 0;
+export const MAX_PERSISTED_MAP_ZOOM = 22;
+
+export type StoredTimelineIndexes = Record<string, number>;
+
+export function clampTimelineIndex(index: number, maxIndex: number): number {
+  return Math.min(Math.max(Math.round(index), 0), Math.max(maxIndex, 0));
+}
+
+export function parseStoredMapZoom(raw: string | null): number | null {
+  if (!raw) return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.min(Math.max(parsed, MIN_PERSISTED_MAP_ZOOM), MAX_PERSISTED_MAP_ZOOM);
+}
+
+export function parseStoredTimelineIndexes(raw: string | null): StoredTimelineIndexes {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown> | null;
+    if (!parsed || typeof parsed !== "object") return {};
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .filter((entry): entry is [string, number] => typeof entry[1] === "number" && Number.isFinite(entry[1]))
+    );
+  }
+  catch {
+    return {};
+  }
+}
+
+export function readStoredTimelineIndex(raw: string | null, batchKey: string, maxIndex: number): number | null {
+  const index = parseStoredTimelineIndexes(raw)[batchKey];
+  if (typeof index !== "number" || !Number.isFinite(index)) return null;
+  return clampTimelineIndex(index, maxIndex);
+}
+
+export function writeStoredTimelineIndex(raw: string | null, batchKey: string, index: number): string {
+  return JSON.stringify({
+    ...parseStoredTimelineIndexes(raw),
+    [batchKey]: index,
+  });
+}
+
+export function normalizeStoredBatchSelection(raw: string | null): {
+  value: string;
+  shouldClearInvalid: boolean;
+} {
+  if (!raw) {
+    return { value: "", shouldClearInvalid: false };
+  }
+  if (raw === SHOW_ALL_PUBLIC_24H_KEY || decodeBatchKey(raw)) {
+    return { value: raw, shouldClearInvalid: false };
+  }
+  return { value: "", shouldClearInvalid: true };
+}

--- a/frontend/src/pages/ActivationPage.tsx
+++ b/frontend/src/pages/ActivationPage.tsx
@@ -10,36 +10,27 @@ import {
   type ActivationSession,
 } from "../lib/api";
 import { APP_ROUTES } from "../lib/appRoutes";
+import { replaceCurrentUrl, useBrowserLocation } from "../lib/locationStore";
 
 type ActivationPageProps = {
   layout?: "standalone" | "dialog";
   onActivationComplete?: () => void;
 };
 
-function getInitialCode(): string {
-  try {
-    const params = new URLSearchParams(window.location.search);
-    return params.get("code") ?? "";
-  }
-  catch {
-    return "";
-  }
+function readCodeFromSearch(search: string): string {
+  const params = new URLSearchParams(search);
+  return params.get("code") ?? "";
 }
 
 function updateQueryParam(code: string) {
-  try {
-    const url = new URL(window.location.href);
+  replaceCurrentUrl((url) => {
     if (code) {
       url.searchParams.set("code", code);
     }
     else {
       url.searchParams.delete("code");
     }
-    window.history.replaceState({}, "", url.toString());
-  }
-  catch {
-    // ignore
-  }
+  });
 }
 
 function formatDuration(ms: number): string {
@@ -51,10 +42,11 @@ function formatDuration(ms: number): string {
 
 export function ActivationPage({ layout = "standalone", onActivationComplete }: ActivationPageProps = {}) {
   const { user, isLoading: isAuthLoading } = useAuth();
+  const location = useBrowserLocation();
   const [authDialogOpen, setAuthDialogOpen] = useState(false);
   const [authMode, setAuthMode] = useState<AuthMode>("login");
 
-  const [userCode, setUserCode] = useState(() => getInitialCode());
+  const [userCode, setUserCode] = useState(() => readCodeFromSearch(location.search));
   const [session, setSession] = useState<ActivationSession | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isAuthorizing, setIsAuthorizing] = useState(false);
@@ -187,14 +179,14 @@ export function ActivationPage({ layout = "standalone", onActivationComplete }: 
   const deepLink = useMemo(() => {
     if (!session) return null;
     try {
-      const url = new URL(window.location.href);
+      const url = new URL(location.href);
       url.searchParams.set("code", session.user_code);
       return url.toString();
     }
     catch {
       return null;
     }
-  }, [session]);
+  }, [location.href, session]);
 
   const requestedAtLabel = useMemo(() => {
     const requestedAtMs = session ? timestampToMillis(session.requested_at) : null;

--- a/frontend/src/pages/AdminModerationPage.tsx
+++ b/frontend/src/pages/AdminModerationPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { timestampToMillis } from "@crowdpm/types";
 import {
   Badge,
@@ -32,6 +33,15 @@ import { useAuth } from "../providers/AuthProvider";
 import { clampPageIndex, getPaginationWindow, ResultCountControl } from "../components/PaginationControl";
 
 const NO_DEMO_BATCH_KEY = "__no_demo_batch__";
+const ADMIN_QUERY_KEYS = {
+  submissions: (params: { moderationState?: ModerationState; visibility?: BatchVisibility; limit: number }) => ["admin", "submissions", params] as const,
+  demoBatchOptions: ["admin", "demoBatchOptions"] as const,
+  users: (pageToken: string | null) => ["admin", "users", pageToken ?? "first"] as const,
+};
+const EMPTY_SUBMISSIONS: AdminSubmissionSummary[] = [];
+const EMPTY_USERS: AdminUserSummary[] = [];
+const EMPTY_DEMO_BATCH_OPTIONS = { batches: EMPTY_SUBMISSIONS, selectedKey: NO_DEMO_BATCH_KEY };
+const EMPTY_USER_PAGE = { users: EMPTY_USERS, nextPageToken: null as string | null };
 
 function formatTimestamp(value: string | null): string {
   const ms = timestampToMillis(value);
@@ -123,23 +133,16 @@ function confirmationCopy(action: PendingConfirmation | null): {
 
 export default function AdminModerationPage() {
   const { isSuperAdmin, canAccessAdmin } = useAuth();
+  const queryClient = useQueryClient();
 
-  const [submissions, setSubmissions] = useState<AdminSubmissionSummary[]>([]);
-  const [demoBatches, setDemoBatches] = useState<AdminSubmissionSummary[]>([]);
-  const [users, setUsers] = useState<AdminUserSummary[]>([]);
-  const [usersPageToken, setUsersPageToken] = useState<string | null>(null);
-
-  const [submissionsLoading, setSubmissionsLoading] = useState(false);
-  const [demoBatchLoading, setDemoBatchLoading] = useState(false);
   const [demoBatchSaving, setDemoBatchSaving] = useState(false);
-  const [usersLoading, setUsersLoading] = useState(false);
   const [actionBusyId, setActionBusyId] = useState<string | null>(null);
 
-  const [submissionError, setSubmissionError] = useState<string | null>(null);
-  const [demoBatchError, setDemoBatchError] = useState<string | null>(null);
+  const [submissionActionError, setSubmissionActionError] = useState<string | null>(null);
+  const [demoBatchActionError, setDemoBatchActionError] = useState<string | null>(null);
   const [demoBatchMessage, setDemoBatchMessage] = useState<string | null>(null);
-  const [userError, setUserError] = useState<string | null>(null);
-  const [demoBatchKey, setDemoBatchKey] = useState<string>(NO_DEMO_BATCH_KEY);
+  const [userActionError, setUserActionError] = useState<string | null>(null);
+  const [usersPageTokenInput, setUsersPageTokenInput] = useState<string | null>(null);
 
   const [moderationFilter, setModerationFilter] = useState<SubmissionFilterState>("all");
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilterState>("all");
@@ -155,6 +158,49 @@ export default function AdminModerationPage() {
     visibility: visibilityFilter === "all" ? undefined : visibilityFilter,
     limit: 100,
   }), [moderationFilter, visibilityFilter]);
+  const submissionsQueryKey = useMemo(() => ADMIN_QUERY_KEYS.submissions(submissionParams), [submissionParams]);
+  const usersQueryKey = useMemo(() => ADMIN_QUERY_KEYS.users(usersPageTokenInput), [usersPageTokenInput]);
+  const submissionsQuery = useQuery<AdminSubmissionSummary[]>({
+    queryKey: submissionsQueryKey,
+    enabled: canAccessAdmin,
+    queryFn: () => listAdminSubmissions(submissionParams),
+    placeholderData: EMPTY_SUBMISSIONS,
+  });
+  const demoBatchOptionsQuery = useQuery({
+    queryKey: ADMIN_QUERY_KEYS.demoBatchOptions,
+    enabled: canAccessAdmin,
+    queryFn: async () => {
+      const [setting, batches] = await Promise.all([
+        getAdminDemoBatch(),
+        listAdminSubmissions({ moderationState: "approved", visibility: "public", limit: 200 }),
+      ]);
+      return {
+        batches: mergeDemoBatchOptions(batches, setting?.summary ?? null),
+        selectedKey: setting ? encodeBatchKey(setting.deviceId, setting.batchId) : NO_DEMO_BATCH_KEY,
+      };
+    },
+    placeholderData: EMPTY_DEMO_BATCH_OPTIONS,
+  });
+  const usersQuery = useQuery({
+    queryKey: usersQueryKey,
+    enabled: canManageUsers,
+    queryFn: () => listAdminUsers({ limit: 100, pageToken: usersPageTokenInput ?? undefined }),
+    placeholderData: EMPTY_USER_PAGE,
+  });
+  const submissions = submissionsQuery.data ?? EMPTY_SUBMISSIONS;
+  const demoBatches = demoBatchOptionsQuery.data?.batches ?? EMPTY_SUBMISSIONS;
+  const demoBatchKey = demoBatchOptionsQuery.data?.selectedKey ?? NO_DEMO_BATCH_KEY;
+  const users = usersQuery.data?.users ?? EMPTY_USERS;
+  const usersPageToken = usersQuery.data?.nextPageToken ?? null;
+  const submissionsLoading = submissionsQuery.isFetching;
+  const demoBatchLoading = demoBatchOptionsQuery.isFetching;
+  const usersLoading = usersQuery.isFetching;
+  const submissionError = submissionActionError
+    ?? (submissionsQuery.error instanceof Error ? submissionsQuery.error.message : null);
+  const demoBatchError = demoBatchActionError
+    ?? (demoBatchOptionsQuery.error instanceof Error ? demoBatchOptionsQuery.error.message : null);
+  const userError = userActionError
+    ?? (usersQuery.error instanceof Error ? usersQuery.error.message : null);
   const submissionPagination = useMemo(
     () => getPaginationWindow(submissions.length, submissionPageIndex),
     [submissionPageIndex, submissions.length],
@@ -172,78 +218,29 @@ export default function AdminModerationPage() {
     [userPagination.pageEnd, userPagination.pageStart, users],
   );
 
-  const refreshDemoBatchOptions = useCallback(async () => {
-    if (!canAccessAdmin) return;
-    setDemoBatchLoading(true);
-    setDemoBatchError(null);
-    try {
-      const [setting, batches] = await Promise.all([
-        getAdminDemoBatch(),
-        listAdminSubmissions({ moderationState: "approved", visibility: "public", limit: 200 }),
-      ]);
-      setDemoBatches(mergeDemoBatchOptions(batches, setting?.summary ?? null));
-      setDemoBatchKey(setting ? encodeBatchKey(setting.deviceId, setting.batchId) : NO_DEMO_BATCH_KEY);
-    }
-    catch (err) {
-      setDemoBatchError(err instanceof Error ? err.message : "Unable to load demo batch options.");
-      setDemoBatches([]);
-      setDemoBatchKey(NO_DEMO_BATCH_KEY);
-    }
-    finally {
-      setDemoBatchLoading(false);
-    }
-  }, [canAccessAdmin]);
-
   const refreshSubmissions = useCallback(async () => {
     if (!canAccessAdmin) return;
-    setSubmissionsLoading(true);
-    setSubmissionError(null);
-    try {
-      const list = await listAdminSubmissions(submissionParams);
-      setSubmissions(list);
-    }
-    catch (err) {
-      setSubmissionError(err instanceof Error ? err.message : "Unable to load submissions.");
-      setSubmissions([]);
-    }
-    finally {
-      setSubmissionsLoading(false);
-    }
-  }, [canAccessAdmin, submissionParams]);
+    setSubmissionActionError(null);
+    await submissionsQuery.refetch();
+  }, [canAccessAdmin, submissionsQuery]);
+
+  const refreshDemoBatchOptions = useCallback(async () => {
+    if (!canAccessAdmin) return;
+    setDemoBatchActionError(null);
+    await demoBatchOptionsQuery.refetch();
+  }, [canAccessAdmin, demoBatchOptionsQuery]);
 
   const refreshUsers = useCallback(async (nextPageToken?: string | null) => {
     if (!canManageUsers) return;
-    setUsersLoading(true);
-    setUserError(null);
-    try {
-      const response = await listAdminUsers({ limit: 100, pageToken: nextPageToken ?? undefined });
-      setUsers(response.users);
-      setUsersPageToken(response.nextPageToken);
+    setUserActionError(null);
+    const nextToken = nextPageToken ?? null;
+    if (nextToken !== usersPageTokenInput) {
+      setUsersPageTokenInput(nextToken);
+      setUserPageIndex(0);
+      return;
     }
-    catch (err) {
-      setUserError(err instanceof Error ? err.message : "Unable to load users.");
-      setUsers([]);
-      setUsersPageToken(null);
-    }
-    finally {
-      setUsersLoading(false);
-    }
-  }, [canManageUsers]);
-
-  useEffect(() => {
-    if (!canAccessAdmin) return;
-    void refreshSubmissions();
-  }, [canAccessAdmin, refreshSubmissions]);
-
-  useEffect(() => {
-    if (!canAccessAdmin) return;
-    void refreshDemoBatchOptions();
-  }, [canAccessAdmin, refreshDemoBatchOptions]);
-
-  useEffect(() => {
-    if (!canManageUsers) return;
-    void refreshUsers();
-  }, [canManageUsers, refreshUsers]);
+    await usersQuery.refetch();
+  }, [canManageUsers, usersPageTokenInput, usersQuery]);
 
   useEffect(() => {
     const nextPageIndex = clampPageIndex(submissions.length, submissionPageIndex);
@@ -292,7 +289,7 @@ export default function AdminModerationPage() {
 
     if (action.kind === "submission") {
       setActionBusyId(`submission:${action.entry.deviceId}:${action.entry.batchId}`);
-      setSubmissionError(null);
+      setSubmissionActionError(null);
       try {
         await moderateAdminSubmission(action.entry.deviceId, action.entry.batchId, {
           moderationState: action.moderationState,
@@ -301,7 +298,7 @@ export default function AdminModerationPage() {
         await refreshSubmissions();
       }
       catch (err) {
-        setSubmissionError(err instanceof Error ? err.message : "Unable to update submission moderation.");
+        setSubmissionActionError(err instanceof Error ? err.message : "Unable to update submission moderation.");
       }
       finally {
         setActionBusyId(null);
@@ -311,13 +308,13 @@ export default function AdminModerationPage() {
 
     if (action.kind === "toggleDisabled") {
       setActionBusyId(`user:${action.entry.uid}:disabled`);
-      setUserError(null);
+      setUserActionError(null);
       try {
         await updateAdminUser(action.entry.uid, { disabled: action.nextDisabled, reason: normalizedReason });
         await refreshUsers();
       }
       catch (err) {
-        setUserError(err instanceof Error ? err.message : "Unable to update user status.");
+        setUserActionError(err instanceof Error ? err.message : "Unable to update user status.");
       }
       finally {
         setActionBusyId(null);
@@ -326,13 +323,13 @@ export default function AdminModerationPage() {
     }
 
     setActionBusyId(`user:${action.entry.uid}:roles`);
-    setUserError(null);
+    setUserActionError(null);
     try {
       await updateAdminUser(action.entry.uid, { roles: action.roles, reason: normalizedReason });
       await refreshUsers();
     }
     catch (err) {
-      setUserError(err instanceof Error ? err.message : "Unable to update user roles.");
+      setUserActionError(err instanceof Error ? err.message : "Unable to update user roles.");
     }
     finally {
       setActionBusyId(null);
@@ -345,20 +342,23 @@ export default function AdminModerationPage() {
     if (!parsed) return;
 
     setDemoBatchSaving(true);
-    setDemoBatchError(null);
+    setDemoBatchActionError(null);
     setDemoBatchMessage(null);
     try {
       const setting = await setAdminDemoBatch(parsed.deviceId, parsed.batchId);
-      setDemoBatchKey(encodeBatchKey(setting.deviceId, setting.batchId));
+      queryClient.setQueryData(ADMIN_QUERY_KEYS.demoBatchOptions, {
+        batches: demoBatches,
+        selectedKey: encodeBatchKey(setting.deviceId, setting.batchId),
+      });
       setDemoBatchMessage("Front page demo data updated.");
     }
     catch (err) {
-      setDemoBatchError(err instanceof Error ? err.message : "Unable to update demo batch.");
+      setDemoBatchActionError(err instanceof Error ? err.message : "Unable to update demo batch.");
     }
     finally {
       setDemoBatchSaving(false);
     }
-  }, []);
+  }, [demoBatches, queryClient]);
 
   if (!canAccessAdmin) {
     return (

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -17,6 +17,17 @@ import { APP_ROUTES, openAppRouteInNewTab } from "../lib/appRoutes";
 import { logWarning } from "../lib/logger";
 import { safeLocalStorageGet, safeLocalStorageRemove, safeLocalStorageSet, scopedStorageKey } from "../lib/storage";
 import {
+  clampTimelineIndex,
+  MAP_SELECTION_STORAGE_KEYS,
+  MAX_PERSISTED_MAP_ZOOM,
+  MIN_PERSISTED_MAP_ZOOM,
+  normalizeStoredBatchSelection,
+  parseStoredMapZoom,
+  readStoredTimelineIndex,
+  SHOW_ALL_PUBLIC_24H_KEY,
+  writeStoredTimelineIndex,
+} from "../lib/mapSelection";
+import {
   detectCanvasVideoExportSupport,
   startCanvasRecording,
 } from "../lib/videoExport";
@@ -25,15 +36,10 @@ import { useUserSettings } from "../providers/UserSettingsProvider";
 import type { Map3DCaptureSession, Map3DHandle } from "../components/Map3D";
 import { clampPageIndex, getPaginationWindow, ResultCountControl } from "../components/PaginationControl";
 
-// Keys used to scope localStorage entries per user so shared browsers do not mix data.
-const LAST_SELECTION_KEY = "crowdpm:lastBatchSelection";
-const LAST_MAP_ZOOM_KEY = "crowdpm:lastMapZoom";
-const LAST_TIMELINE_INDEX_KEY = "crowdpm:lastTimelineIndex";
 const BATCH_LIST_STALE_MS = 30_000; // keep batch list warm for 30 seconds to avoid redundant refetches
 const DROPDOWN_BATCH_LIMIT = 20;
 const NO_BATCH_SELECTED_KEY = "__no_batch_selected__";
 const SEE_ALL_BATCHES_KEY = "__see_all_batches__";
-const SHOW_ALL_PUBLIC_24H_KEY = "__all_public_last_24h__";
 const SHOW_ALL_PUBLIC_LOOKBACK_MS = 24 * 60 * 60 * 1000;
 const SHOW_ALL_PUBLIC_BATCH_LIMIT = 200;
 const EXPANDED_BATCH_FETCH_LIMIT = 500;
@@ -61,8 +67,6 @@ const VIDEO_EXPORT_ORBIT_DEGREES = 24;
 const VIDEO_EXPORT_START_TILT = 45;
 const VIDEO_EXPORT_TARGET_TILT = 67.5;
 const VIDEO_EXPORT_TILT_RAMP_PORTION = 0.2;
-const MIN_PERSISTED_MAP_ZOOM = 0;
-const MAX_PERSISTED_MAP_ZOOM = 22;
 const MAP_PANEL_BACKGROUND = "color-mix(in srgb, var(--color-panel-solid) 88%, transparent)";
 const MAP_PANEL_BORDER = "1px solid var(--gray-a6)";
 const MAP_PANEL_BLUR = "blur(12px)";
@@ -114,8 +118,6 @@ type MapMeasurementRecord = MeasurementRecord & {
   batchKey?: string;
   batchPointIndex?: number;
 };
-
-type StoredTimelineIndexes = Record<string, number>;
 
 type MapPageProps = {
   mapAppearance: UserThemeAppearance;
@@ -424,54 +426,21 @@ function sanitizeFileSegment(value: string | null | undefined): string {
   return normalized || "batch";
 }
 
-function parseStoredMapZoom(raw: string | null): number | null {
-  if (!raw) return null;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed)) return null;
-  return Math.min(Math.max(parsed, MIN_PERSISTED_MAP_ZOOM), MAX_PERSISTED_MAP_ZOOM);
-}
-
-function parseStoredTimelineIndexes(raw: string | null): StoredTimelineIndexes {
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw) as Record<string, unknown> | null;
-    if (!parsed || typeof parsed !== "object") return {};
-    return Object.fromEntries(
-      Object.entries(parsed)
-        .filter((entry): entry is [string, number] => typeof entry[1] === "number" && Number.isFinite(entry[1]))
-    );
-  }
-  catch {
-    return {};
-  }
-}
-
-function getStoredTimelineIndex(storageKey: string, batchKey: string, maxIndex: number, userId?: string | null): number | null {
-  const stored = parseStoredTimelineIndexes(safeLocalStorageGet(
-    storageKey,
-    null,
-    { context: "map:timeline:read", userId }
-  ));
-  const index = stored[batchKey];
-  if (typeof index !== "number" || !Number.isFinite(index)) return null;
-  return Math.min(Math.max(Math.round(index), 0), maxIndex);
-}
-
 export default function MapPage({ mapAppearance }: MapPageProps) {
   const { user, isLoading: isAuthLoading } = useAuth();
   const { settings } = useUserSettings();
   const queryClient = useQueryClient();
 
   const userScopedSelectionKey = useMemo(
-    () => scopedStorageKey(LAST_SELECTION_KEY, user?.uid ?? undefined),
+    () => scopedStorageKey(MAP_SELECTION_STORAGE_KEYS.lastSelection, user?.uid ?? undefined),
     [user?.uid]
   );
   const userScopedZoomKey = useMemo(
-    () => scopedStorageKey(LAST_MAP_ZOOM_KEY, user?.uid ?? undefined),
+    () => scopedStorageKey(MAP_SELECTION_STORAGE_KEYS.lastMapZoom, user?.uid ?? undefined),
     [user?.uid]
   );
   const userScopedTimelineKey = useMemo(
-    () => scopedStorageKey(LAST_TIMELINE_INDEX_KEY, user?.uid ?? undefined),
+    () => scopedStorageKey(MAP_SELECTION_STORAGE_KEYS.lastTimelineIndex, user?.uid ?? undefined),
     [user?.uid]
   );
 
@@ -700,11 +669,14 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     if (timelineHydratedRef.current === hydrationKey) return;
     timelineHydratedRef.current = hydrationKey;
 
-    const storedIndex = getStoredTimelineIndex(
-      userScopedTimelineKey,
+    const storedIndex = readStoredTimelineIndex(
+      safeLocalStorageGet(
+        userScopedTimelineKey,
+        null,
+        { context: "map:timeline:read", userId: user?.uid }
+      ),
       selectedBatchKey,
-      rows.length - 1,
-      user?.uid
+      rows.length - 1
     );
     if (storedIndex !== null) {
       setIndexOverride(storedIndex);
@@ -730,26 +702,18 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     if (selectionHydratedRef.current === userScopedSelectionKey) return;
     selectionHydratedRef.current = userScopedSelectionKey;
 
-    const storedSelection = safeLocalStorageGet(
+    const storedSelection = normalizeStoredBatchSelection(safeLocalStorageGet(
       userScopedSelectionKey,
       null,
       { context: "map:selected-batch:hydrate", userId: user?.uid }
-    );
-    if (!storedSelection) {
-      setSelectedBatchKey("");
-      return;
+    ));
+    setSelectedBatchKey(storedSelection.value);
+    if (storedSelection.shouldClearInvalid) {
+      safeLocalStorageRemove(
+        userScopedSelectionKey,
+        { context: "map:selected-batch:clear-invalid", userId: user?.uid }
+      );
     }
-
-    if (storedSelection === SHOW_ALL_PUBLIC_24H_KEY || decodeBatchKey(storedSelection)) {
-      setSelectedBatchKey(storedSelection);
-      return;
-    }
-
-    setSelectedBatchKey("");
-    safeLocalStorageRemove(
-      userScopedSelectionKey,
-      { context: "map:selected-batch:clear-invalid", userId: user?.uid }
-    );
   }, [isAuthLoading, user?.uid, userScopedSelectionKey]);
 
   useEffect(() => {
@@ -902,21 +866,21 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
 
   const handleTimelineIndexChange = useCallback((nextIndex: number) => {
     const maxIndex = Math.max(rows.length - 1, 0);
-    const clampedIndex = Math.min(Math.max(Math.round(nextIndex), 0), maxIndex);
+    const clampedIndex = clampTimelineIndex(nextIndex, maxIndex);
     setIndexOverride(clampedIndex);
 
     if (!selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY || !rows.length) return;
-    const stored = parseStoredTimelineIndexes(safeLocalStorageGet(
-      userScopedTimelineKey,
-      null,
-      { context: "map:timeline:read", userId: user?.uid }
-    ));
     safeLocalStorageSet(
       userScopedTimelineKey,
-      JSON.stringify({
-        ...stored,
-        [selectedBatchKey]: clampedIndex,
-      }),
+      writeStoredTimelineIndex(
+        safeLocalStorageGet(
+          userScopedTimelineKey,
+          null,
+          { context: "map:timeline:read", userId: user?.uid }
+        ),
+        selectedBatchKey,
+        clampedIndex
+      ),
       { context: "map:timeline:update", userId: user?.uid }
     );
   }, [rows.length, selectedBatchKey, user?.uid, userScopedTimelineKey]);
@@ -946,17 +910,17 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     const pointIndex = typeof point.batchPointIndex === "number" ? point.batchPointIndex : null;
     setIndexOverride(pointIndex);
     if (pointIndex !== null) {
-      const stored = parseStoredTimelineIndexes(safeLocalStorageGet(
-        userScopedTimelineKey,
-        null,
-        { context: "map:timeline:read-from-all", userId: user?.uid }
-      ));
       safeLocalStorageSet(
         userScopedTimelineKey,
-        JSON.stringify({
-          ...stored,
-          [point.batchKey]: pointIndex,
-        }),
+        writeStoredTimelineIndex(
+          safeLocalStorageGet(
+            userScopedTimelineKey,
+            null,
+            { context: "map:timeline:read-from-all", userId: user?.uid }
+          ),
+          point.batchKey,
+          pointIndex
+        ),
         { context: "map:timeline:update-from-all", userId: user?.uid }
       );
     }

--- a/frontend/src/pages/NodePage.tsx
+++ b/frontend/src/pages/NodePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import {
   Box,
   Button,
@@ -21,6 +21,7 @@ import {
 } from "../components/LegalDocumentDialog";
 import { APP_ROUTES } from "../lib/appRoutes";
 import { createNodePurchaseCheckoutSession } from "../lib/api";
+import { useBrowserLocation } from "../lib/locationStore";
 
 type SectionProps = {
   title: string;
@@ -357,18 +358,16 @@ function ProductGallery() {
 
 type CheckoutNotice = "success" | "cancelled" | null;
 
-function readCheckoutNotice(): CheckoutNotice {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  const status = new URLSearchParams(window.location.search).get("checkout");
+function readCheckoutNotice(search: string): CheckoutNotice {
+  const status = new URLSearchParams(search).get("checkout");
   return status === "success" || status === "cancelled" ? status : null;
 }
 
 export default function NodePage() {
+  const location = useBrowserLocation();
   const [isStartingCheckout, setIsStartingCheckout] = useState(false);
   const [checkoutError, setCheckoutError] = useState("");
-  const [checkoutNotice, setCheckoutNotice] = useState<CheckoutNotice>(readCheckoutNotice);
+  const checkoutNotice = readCheckoutNotice(location.search);
   const [openLegalDocument, setOpenLegalDocument] = useState<LegalDocumentId | null>(null);
   const [includeCo2, setIncludeCo2] = useState(false);
   const [includeNo2, setIncludeNo2] = useState(false);
@@ -378,10 +377,6 @@ export default function NodePage() {
   const unitAddOnAmountCents = selectedVariant.addOnAmountCents;
   const unitTotalAmountCents = selectedVariant.totalAmountCents;
   const orderSubtotalCents = unitTotalAmountCents * quantity;
-
-  useEffect(() => {
-    setCheckoutNotice(readCheckoutNotice());
-  }, []);
 
   const handlePurchaseNode = async () => {
     setCheckoutError("");

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Badge, Box, Button, Callout, Card, Flex, Heading, Link, SegmentedControl, Select, Separator, Switch, Table, Text, TextField } from "@radix-ui/themes";
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { timestampToMillis } from "@crowdpm/types";
@@ -33,6 +34,15 @@ type UserDashboardProps = {
   onSubscriptionCheckoutHandled?: () => void;
   refreshToken?: number;
 };
+
+const DASHBOARD_QUERY_KEYS = {
+  devices: (userId: string | null) => ["dashboard", "devices", userId ?? "anon"] as const,
+  batches: (userId: string | null) => ["dashboard", "batches", userId ?? "anon"] as const,
+  receipts: (userId: string | null) => ["dashboard", "receipts", userId ?? "anon"] as const,
+};
+const EMPTY_DEVICES: DeviceSummary[] = [];
+const EMPTY_BATCHES: BatchSummary[] = [];
+const EMPTY_RECEIPTS: NodePurchaseReceipt[] = [];
 
 function describeStatus(status?: string | null): { label: string; tone: "green" | "yellow" | "red" | "gray" } {
   const normalized = (status ?? "").toLowerCase();
@@ -76,24 +86,44 @@ export default function UserDashboard({
 }: UserDashboardProps) {
   const { user } = useAuth();
   const { settings, isLoading: isSettingsLoading, isSaving: isSettingsSaving, error: settingsError, refresh, updateSettings } = useUserSettings();
-  const [devices, setDevices] = useState<DeviceSummary[]>([]);
-  const [isLoadingDevices, setIsLoadingDevices] = useState(false);
-  const [devicesError, setDevicesError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const userId = user?.uid ?? null;
+  const devicesQueryKey = useMemo(() => DASHBOARD_QUERY_KEYS.devices(userId), [userId]);
+  const batchesQueryKey = useMemo(() => DASHBOARD_QUERY_KEYS.batches(userId), [userId]);
+  const receiptsQueryKey = useMemo(() => DASHBOARD_QUERY_KEYS.receipts(userId), [userId]);
+  const devicesQuery = useQuery<DeviceSummary[]>({
+    queryKey: devicesQueryKey,
+    enabled: Boolean(user),
+    queryFn: listDevices,
+    placeholderData: EMPTY_DEVICES,
+  });
+  const batchesQuery = useQuery<BatchSummary[]>({
+    queryKey: batchesQueryKey,
+    enabled: Boolean(user),
+    queryFn: () => listBatches(),
+    placeholderData: EMPTY_BATCHES,
+  });
+  const receiptsQuery = useQuery<NodePurchaseReceipt[]>({
+    queryKey: receiptsQueryKey,
+    enabled: Boolean(user),
+    queryFn: listNodePurchaseReceipts,
+    placeholderData: EMPTY_RECEIPTS,
+  });
+  const devices = user ? devicesQuery.data ?? EMPTY_DEVICES : EMPTY_DEVICES;
+  const batches = user ? batchesQuery.data ?? EMPTY_BATCHES : EMPTY_BATCHES;
+  const receipts = user ? receiptsQuery.data ?? EMPTY_RECEIPTS : EMPTY_RECEIPTS;
+  const isLoadingDevices = Boolean(user) && devicesQuery.isFetching;
+  const isLoadingBatches = Boolean(user) && batchesQuery.isFetching;
+  const isLoadingReceipts = Boolean(user) && receiptsQuery.isFetching;
+  const devicesError = devicesQuery.error instanceof Error ? devicesQuery.error.message : null;
+  const batchesError = batchesQuery.error instanceof Error ? batchesQuery.error.message : null;
+  const receiptsError = receiptsQuery.error instanceof Error ? receiptsQuery.error.message : null;
   const [revokeError, setRevokeError] = useState<string | null>(null);
-  const [revokingId, setRevokingId] = useState<string | null>(null);
   const [devicePageIndex, setDevicePageIndex] = useState(0);
-  const [batches, setBatches] = useState<BatchSummary[]>([]);
-  const [isLoadingBatches, setIsLoadingBatches] = useState(false);
-  const [batchesError, setBatchesError] = useState<string | null>(null);
   const [selectedBatchDeviceId, setSelectedBatchDeviceId] = useState<string>("all");
   const [batchActionError, setBatchActionError] = useState<string | null>(null);
   const [batchActionMessage, setBatchActionMessage] = useState<string | null>(null);
-  const [updatingBatchKey, setUpdatingBatchKey] = useState<string | null>(null);
-  const [deletingBatchKey, setDeletingBatchKey] = useState<string | null>(null);
   const [batchPageIndex, setBatchPageIndex] = useState(0);
-  const [receipts, setReceipts] = useState<NodePurchaseReceipt[]>([]);
-  const [isLoadingReceipts, setIsLoadingReceipts] = useState(false);
-  const [receiptsError, setReceiptsError] = useState<string | null>(null);
   const [settingsMessage, setSettingsMessage] = useState<string | null>(null);
   const [settingsLocalError, setSettingsLocalError] = useState<string | null>(null);
   const [subscriptionMessage, setSubscriptionMessage] = useState<string | null>(null);
@@ -104,73 +134,62 @@ export default function UserDashboard({
   const [activationLinkMessage, setActivationLinkMessage] = useState<string | null>(null);
 
   const refreshDevices = useCallback(async () => {
-    if (!user) {
-      setDevices([]);
-      setDevicesError(null);
-      return;
-    }
-    setIsLoadingDevices(true);
-    setDevicesError(null);
-    try {
-      const next = await listDevices();
-      setDevices(next);
-    }
-    catch (err) {
-      setDevices([]);
-      setDevicesError(err instanceof Error ? err.message : "Unable to load devices");
-    }
-    finally {
-      setIsLoadingDevices(false);
-    }
-  }, [user]);
+    if (!user) return;
+    await devicesQuery.refetch();
+  }, [devicesQuery, user]);
 
   const refreshBatches = useCallback(async () => {
-    if (!user) {
-      setBatches([]);
-      setBatchesError(null);
-      return;
-    }
-    setIsLoadingBatches(true);
-    setBatchesError(null);
-    try {
-      const next = await listBatches();
-      setBatches(next);
-    }
-    catch (err) {
-      setBatches([]);
-      setBatchesError(err instanceof Error ? err.message : "Unable to load batches");
-    }
-    finally {
-      setIsLoadingBatches(false);
-    }
-  }, [user]);
+    if (!user) return;
+    await batchesQuery.refetch();
+  }, [batchesQuery, user]);
 
   const refreshReceipts = useCallback(async () => {
-    if (!user) {
-      setReceipts([]);
-      setReceiptsError(null);
-      return;
-    }
-    setIsLoadingReceipts(true);
-    setReceiptsError(null);
-    try {
-      const next = await listNodePurchaseReceipts();
-      setReceipts(next);
-    }
-    catch (err) {
-      setReceipts([]);
-      setReceiptsError(err instanceof Error ? err.message : "Unable to load hardware receipts");
-    }
-    finally {
-      setIsLoadingReceipts(false);
-    }
-  }, [user]);
+    if (!user) return;
+    await receiptsQuery.refetch();
+  }, [receiptsQuery, user]);
 
   useEffect(() => {
+    if (!user || refreshToken === 0) return;
     void refreshDevices();
     void refreshBatches();
     void refreshReceipts();
-  }, [refreshBatches, refreshDevices, refreshReceipts, refreshToken]);
+  }, [refreshBatches, refreshDevices, refreshReceipts, refreshToken, user]);
+
+  const revokeDeviceMutation = useMutation({
+    mutationFn: revokeDevice,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: devicesQueryKey }),
+        queryClient.invalidateQueries({ queryKey: batchesQueryKey }),
+      ]);
+    },
+  });
+  const updateBatchVisibilityMutation = useMutation({
+    mutationFn: async (args: { batch: BatchSummary; nextVisibility: BatchVisibility; actionKey: string }) => {
+      return updateBatchVisibility(args.batch.deviceId, args.batch.batchId, args.nextVisibility);
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData<BatchSummary[]>(batchesQueryKey, (prev = []) => prev.map((row) => (
+        row.deviceId === updated.deviceId && row.batchId === updated.batchId ? updated : row
+      )));
+    },
+  });
+  const deleteBatchMutation = useMutation({
+    mutationFn: async (batch: BatchSummary) => {
+      await deleteBatch(batch.deviceId, batch.batchId);
+      return batch;
+    },
+    onSuccess: (deletedBatch) => {
+      queryClient.setQueryData<BatchSummary[]>(batchesQueryKey, (prev = []) => prev.filter((row) => (
+        row.deviceId !== deletedBatch.deviceId || row.batchId !== deletedBatch.batchId
+      )));
+    },
+  });
+  const revokingId = revokeDeviceMutation.isPending ? revokeDeviceMutation.variables ?? null : null;
+  const updatingBatchKey = updateBatchVisibilityMutation.isPending ? updateBatchVisibilityMutation.variables?.actionKey ?? null : null;
+  const deletingBatchKey = deleteBatchMutation.isPending
+    ? `${deleteBatchMutation.variables?.deviceId ?? ""}:${deleteBatchMutation.variables?.batchId ?? ""}`
+    : null;
 
   useEffect(() => {
     if (!user || !subscriptionCheckoutNotice) {
@@ -371,30 +390,21 @@ export default function UserDashboard({
       return;
     }
     setRevokeError(null);
-    setRevokingId(deviceId);
     try {
-      await revokeDevice(deviceId);
-      await Promise.all([refreshDevices(), refreshBatches()]);
+      await revokeDeviceMutation.mutateAsync(deviceId);
     }
     catch (err) {
       setRevokeError(err instanceof Error ? err.message : "Unable to revoke device.");
     }
-    finally {
-      setRevokingId(null);
-    }
-  }, [refreshBatches, refreshDevices]);
+  }, [revokeDeviceMutation]);
 
   const handleToggleBatchVisibility = useCallback(async (batch: BatchSummary) => {
     const actionKey = `${batch.deviceId}:${batch.batchId}`;
     const nextVisibility: BatchVisibility = batch.visibility === "public" ? "private" : "public";
     setBatchActionError(null);
     setBatchActionMessage(null);
-    setUpdatingBatchKey(actionKey);
     try {
-      const updated = await updateBatchVisibility(batch.deviceId, batch.batchId, nextVisibility);
-      setBatches((prev) => prev.map((row) => (
-        row.deviceId === updated.deviceId && row.batchId === updated.batchId ? updated : row
-      )));
+      await updateBatchVisibilityMutation.mutateAsync({ batch, nextVisibility, actionKey });
       setBatchActionMessage(
         nextVisibility === "public"
           ? `Batch ${batch.batchId} is now public.`
@@ -404,31 +414,22 @@ export default function UserDashboard({
     catch (err) {
       setBatchActionError(err instanceof Error ? err.message : "Unable to update batch visibility.");
     }
-    finally {
-      setUpdatingBatchKey(null);
-    }
-  }, []);
+  }, [updateBatchVisibilityMutation]);
 
   const handleDeleteBatch = useCallback(async (batch: BatchSummary) => {
     if (!window.confirm(`Delete batch ${batch.batchId}? This removes the saved payload and batch metadata.`)) {
       return;
     }
-    const actionKey = `${batch.deviceId}:${batch.batchId}`;
     setBatchActionError(null);
     setBatchActionMessage(null);
-    setDeletingBatchKey(actionKey);
     try {
-      await deleteBatch(batch.deviceId, batch.batchId);
-      setBatches((prev) => prev.filter((row) => !(row.deviceId === batch.deviceId && row.batchId === batch.batchId)));
+      await deleteBatchMutation.mutateAsync(batch);
       setBatchActionMessage(`Deleted batch ${batch.batchId}.`);
     }
     catch (err) {
       setBatchActionError(err instanceof Error ? err.message : "Unable to delete batch.");
     }
-    finally {
-      setDeletingBatchKey(null);
-    }
-  }, []);
+  }, [deleteBatchMutation]);
 
   const handleOpenActivation = useCallback(() => {
     onRequestActivation();

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -92,14 +92,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, [queryClient]);
 
-  const clearCachesOnSignOut = useCallback(() => {
-    queryClient.clear();
-    safeLocalStorageRemove(
-      AUTH_SCOPED_STORAGE_KEYS,
-      { context: "auth:sign-out-clear" }
-    );
-  }, [queryClient]);
-
   const signIn = useCallback(async (email: string, password: string) => {
     const { auth, signInWithEmailAndPassword } = await loadFirebaseAuth();
     return signInWithEmailAndPassword(auth, email.trim(), password);
@@ -112,10 +104,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const signOut = useCallback(async () => {
     const { auth, signOut: firebaseSignOut } = await loadFirebaseAuth();
-    clearCachesOnSignOut();
-    setRoles([]);
     await firebaseSignOut(auth);
-  }, [clearCachesOnSignOut]);
+  }, []);
 
   const value = useMemo<AuthContextValue>(
     () => {

--- a/frontend/src/providers/UserSettingsProvider.tsx
+++ b/frontend/src/providers/UserSettingsProvider.tsx
@@ -1,4 +1,5 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { UserSettings } from "../lib/api";
 import { useAuth } from "./AuthProvider";
 
@@ -65,6 +66,7 @@ function applyUserSettingsDefaults(next: Partial<UserSettings>): UserSettings {
 }
 
 const UserSettingsContext = createContext<UserSettingsContextValue | undefined>(undefined);
+const USER_SETTINGS_QUERY_KEY = "userSettings";
 
 async function loadUserSettingsApi() {
   const { fetchUserSettings, updateUserSettings } = await import("../lib/api");
@@ -73,59 +75,47 @@ async function loadUserSettingsApi() {
 
 export function UserSettingsProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth();
-  const [settings, setSettings] = useState<UserSettings>(DEFAULT_USER_SETTINGS);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const queryKey = useMemo(() => [USER_SETTINGS_QUERY_KEY, user?.uid ?? "anon"], [user?.uid]);
 
-  const refresh = useCallback(async () => {
-    if (!user) {
-      setSettings(DEFAULT_USER_SETTINGS);
-      setError(null);
-      setIsLoading(false);
-      return;
-    }
-    setIsLoading(true);
-    setError(null);
-    try {
+  const settingsQuery = useQuery({
+    queryKey,
+    enabled: Boolean(user),
+    queryFn: async () => {
       const { fetchUserSettings } = await loadUserSettingsApi();
       const next = await fetchUserSettings();
-      setSettings(applyUserSettingsDefaults(next));
-    }
-    catch (err) {
-      const message = err instanceof Error ? err.message : "Unable to load user settings";
-      setError(message);
-      setSettings(DEFAULT_USER_SETTINGS);
-    }
-    finally {
-      setIsLoading(false);
-    }
-  }, [user]);
+      return applyUserSettingsDefaults(next);
+    },
+    placeholderData: DEFAULT_USER_SETTINGS,
+  });
 
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
-
-  const updateSettingsHandler = useCallback(async (next: Partial<UserSettings>) => {
-    if (!user) throw new Error("Sign in is required to update settings.");
-    setIsSaving(true);
-    setError(null);
-    try {
+  const updateSettingsMutation = useMutation({
+    mutationFn: async (next: Partial<UserSettings>) => {
+      if (!user) throw new Error("Sign in is required to update settings.");
       const { updateUserSettings } = await loadUserSettingsApi();
       const updated = await updateUserSettings(next);
-      const normalized = applyUserSettingsDefaults(updated);
-      setSettings(normalized);
-      return normalized;
-    }
-    catch (err) {
-      const message = err instanceof Error ? err.message : "Unable to update settings";
-      setError(message);
-      throw err;
-    }
-    finally {
-      setIsSaving(false);
-    }
-  }, [user]);
+      return applyUserSettingsDefaults(updated);
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(queryKey, updated);
+    },
+  });
+
+  const refresh = useCallback(async () => {
+    if (!user) return;
+    await settingsQuery.refetch();
+  }, [settingsQuery, user]);
+
+  const updateSettingsHandler = useCallback(async (next: Partial<UserSettings>) => {
+    return updateSettingsMutation.mutateAsync(next);
+  }, [updateSettingsMutation]);
+
+  const settings = user ? settingsQuery.data ?? DEFAULT_USER_SETTINGS : DEFAULT_USER_SETTINGS;
+  const queryError = settingsQuery.error instanceof Error ? settingsQuery.error.message : null;
+  const mutationError = updateSettingsMutation.error instanceof Error ? updateSettingsMutation.error.message : null;
+  const error = mutationError ?? queryError;
+  const isLoading = Boolean(user) && settingsQuery.isLoading;
+  const isSaving = updateSettingsMutation.isPending;
 
   const value = useMemo<UserSettingsContextValue>(() => ({
     settings,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,5 @@
 import * as https from "firebase-functions/v2/https";
-import Fastify from "fastify";
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from "fastify";
 import cors from "@fastify/cors";
 import rateLimit from "fastify-rate-limit";
 import { Readable } from "node:stream";
@@ -19,61 +19,94 @@ import { toHttpError } from "./lib/httpError.js";
 import { RateLimitError } from "./lib/rateLimiter.js";
 import { fastifyCorsOptionsForRequest } from "./lib/corsPolicy.js";
 import { stripApiEntryPrefix } from "./lib/http.js";
-adminApp();
-
-const api = Fastify({ logger: true });
-
-const parseJsonBody = (req: unknown, body: unknown, done: (err: Error | null, value?: unknown) => void) => {
-  try {
-    const text = typeof body === "string" ? body : body ? (body as Buffer).toString("utf8") : "";
-    api.log.info(
-      { parser: "json", contentType: (req as { headers?: Record<string, unknown> })?.headers?.["content-type"], length: typeof text === "string" ? text.length : undefined },
-      "json parser invoked"
-    );
-    done(null, text ? JSON.parse(text) : {});
-  }
-  catch (err) {
-    done(err as Error);
-  }
-};
-
-api.removeContentTypeParser("application/json");
-api.addContentTypeParser("application/json", { parseAs: "string" }, parseJsonBody);
-api.addContentTypeParser(/^application\/(?:.+\+)?json(?:\s*;.*)?$/i, { parseAs: "string" }, parseJsonBody);
-
-api.addHook("preParsing", (request, reply, payload, done) => {
-  const rawBody = (request.raw as RequestWithRawBody).rawBody;
-  if (rawBody === undefined) {
-    done(null, payload);
-    return;
-  }
-  const buffer = typeof rawBody === "string" ? Buffer.from(rawBody, "utf8") : rawBody;
-  const stream = Readable.from(buffer);
-  done(null, stream);
-});
-
-api.setErrorHandler((err, req, rep) => {
-  const normalized = toHttpError(err);
-  const log = normalized.statusCode >= 500 ? req.log.error.bind(req.log) : req.log.warn.bind(req.log);
-  log({ err }, "request failed");
-  if (normalized.headers) rep.headers(normalized.headers);
-  rep.code(normalized.statusCode).send(normalized.body);
-});
 
 type RequestWithRawBody = https.Request & { rawBody?: Buffer | string };
-const isEmulatorRuntime = process.env.FUNCTIONS_EMULATOR === "true"
-  || Boolean(process.env.FIREBASE_EMULATOR_HUB);
-const rateLimitsEnabled = process.env.ENABLE_RATE_LIMITS === "true"
-  || (!isEmulatorRuntime && process.env.NODE_ENV !== "test");
+type ResponseLike = {
+  headersSent?: boolean;
+  writeHead: (statusCode: number, headers: Record<string, string>) => void;
+  end: (chunk?: string) => void;
+};
 
-const apiSetup = (async () => {
-  await ensureLocalSuperAdmin();
+type ApiDependencies = {
+  initializeAdminApp?: () => unknown;
+  ensureLocalSuperAdmin?: () => Promise<void>;
+  rateLimitsEnabled?: boolean;
+  routes?: FastifyPluginAsync[];
+  logger?: boolean;
+};
+
+const DEFAULT_API_ROUTES: FastifyPluginAsync[] = [
+  devicesRoutes,
+  adminRoutes,
+  adminSubmissionsRoutes,
+  adminUsersRoutes,
+  batchesRoutes,
+  publicBatchesRoutes,
+  userSettingsRoutes,
+  pairingRoutes,
+  activationRoutes,
+  nodePurchaseRoutes,
+];
+
+function defaultRateLimitsEnabled(): boolean {
+  const isEmulatorRuntime = process.env.FUNCTIONS_EMULATOR === "true"
+    || Boolean(process.env.FIREBASE_EMULATOR_HUB);
+  return process.env.ENABLE_RATE_LIMITS === "true"
+    || (!isEmulatorRuntime && process.env.NODE_ENV !== "test");
+}
+
+function createJsonBodyParser(api: FastifyInstance) {
+  return (req: unknown, body: unknown, done: (err: Error | null, value?: unknown) => void) => {
+    try {
+      const text = typeof body === "string" ? body : body ? (body as Buffer).toString("utf8") : "";
+      api.log.info(
+        { parser: "json", contentType: (req as { headers?: Record<string, unknown> })?.headers?.["content-type"], length: typeof text === "string" ? text.length : undefined },
+        "json parser invoked"
+      );
+      done(null, text ? JSON.parse(text) : {});
+    }
+    catch (err) {
+      done(err as Error);
+    }
+  };
+}
+
+export async function buildApi(deps: ApiDependencies = {}): Promise<FastifyInstance> {
+  (deps.initializeAdminApp ?? adminApp)();
+  const api = Fastify({ logger: deps.logger ?? true });
+  const parseJsonBody = createJsonBodyParser(api);
+
+  api.removeContentTypeParser("application/json");
+  api.addContentTypeParser("application/json", { parseAs: "string" }, parseJsonBody);
+  api.addContentTypeParser(/^application\/(?:.+\+)?json(?:\s*;.*)?$/i, { parseAs: "string" }, parseJsonBody);
+
+  api.addHook("preParsing", (request, reply, payload, done) => {
+    const rawBody = (request.raw as RequestWithRawBody).rawBody;
+    if (rawBody === undefined) {
+      done(null, payload);
+      return;
+    }
+    const buffer = typeof rawBody === "string" ? Buffer.from(rawBody, "utf8") : rawBody;
+    const stream = Readable.from(buffer);
+    done(null, stream);
+  });
+
+  api.setErrorHandler((err, req, rep) => {
+    const normalized = toHttpError(err);
+    const log = normalized.statusCode >= 500 ? req.log.error.bind(req.log) : req.log.warn.bind(req.log);
+    log({ err }, "request failed");
+    if (normalized.headers) rep.headers(normalized.headers);
+    rep.code(normalized.statusCode).send(normalized.body);
+  });
+
+  await (deps.ensureLocalSuperAdmin ?? ensureLocalSuperAdmin)();
   await api.register(cors, {
     delegator: (req, callback) => {
       callback(null, fastifyCorsOptionsForRequest(req));
     },
   });
-  if (rateLimitsEnabled) {
+
+  if (deps.rateLimitsEnabled ?? defaultRateLimitsEnabled()) {
     await api.register(rateLimit, {
       max: 100,
       timeWindow: "1 minute",
@@ -82,31 +115,54 @@ const apiSetup = (async () => {
   }
 
   api.get("/health", async () => ({ ok: true }));
-  await api.register(devicesRoutes);
-  await api.register(adminRoutes);
-  await api.register(adminSubmissionsRoutes);
-  await api.register(adminUsersRoutes);
-  await api.register(batchesRoutes);
-  await api.register(publicBatchesRoutes);
-  await api.register(userSettingsRoutes);
-  await api.register(pairingRoutes);
-  await api.register(activationRoutes);
-  await api.register(nodePurchaseRoutes);
+  for (const route of deps.routes ?? DEFAULT_API_ROUTES) {
+    await api.register(route);
+  }
 
-  // Ensure all lifecycle hooks are ready before handling traffic.
   await api.ready();
-})().catch((err) => {
-  api.log.error(err, "failed to initialise API");
-  throw err;
-});
+  return api;
+}
+
+let apiServerPromise: Promise<FastifyInstance> | null = null;
+
+function getApiServer(): Promise<FastifyInstance> {
+  if (!apiServerPromise) {
+    apiServerPromise = buildApi().catch((err) => {
+      apiServerPromise = null;
+      throw err;
+    });
+  }
+  return apiServerPromise;
+}
+
+function sendStartupError(res: ResponseLike, err: unknown): void {
+  const normalized = toHttpError(err, 503);
+  const headers = {
+    "content-type": "application/json; charset=utf-8",
+    ...(normalized.headers ?? {}),
+  };
+  if ((res as { headersSent?: boolean }).headersSent) {
+    res.end();
+    return;
+  }
+  res.writeHead(normalized.statusCode, headers);
+  res.end(JSON.stringify(normalized.body));
+}
 
 export const crowdpmApi = https.onRequest({
   secrets: ["DEVICE_TOKEN_PRIVATE_KEY", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
-}, (req, res) => {
-  const requestWithRawBody = req as RequestWithRawBody;
-  requestWithRawBody.rawBody = requestWithRawBody.rawBody ?? undefined;
-  requestWithRawBody.url = stripApiEntryPrefix(requestWithRawBody.url);
-  apiSetup.then(() => api.server.emit("request", req, res));
+}, async (req, res) => {
+  try {
+    const requestWithRawBody = req as RequestWithRawBody;
+    requestWithRawBody.rawBody = requestWithRawBody.rawBody ?? undefined;
+    requestWithRawBody.url = stripApiEntryPrefix(requestWithRawBody.url);
+    const api = await getApiServer();
+    api.server.emit("request", req, res);
+  }
+  catch (err) {
+    console.error("failed to initialise API", err);
+    sendStartupError(res, err);
+  }
 });
 
 export { ingestGateway } from "./services/ingestGateway.js";

--- a/functions/src/services/ingestService.ts
+++ b/functions/src/services/ingestService.ts
@@ -1,5 +1,5 @@
 import type { Firestore } from "firebase-admin/firestore";
-import type { BatchVisibility, IngestBody as SharedIngestBody, IngestResult } from "@crowdpm/types";
+import type { BatchVisibility, IngestBody as SharedIngestBody, IngestResult, SubscriptionSummary } from "@crowdpm/types";
 import crypto from "node:crypto";
 import {
   getDeviceDefaultBatchVisibility,
@@ -77,6 +77,97 @@ function isForbiddenDevice(status: string | null, registryStatus: string | null)
     || normalizedStatus === "REVOKED";
 }
 
+export function parseIngestPayload(rawBody: string): IngestPayload {
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(rawBody);
+  }
+  catch {
+    throw new IngestServiceError("invalid_payload", "invalid JSON payload", 400);
+  }
+
+  const parsed = IngestPayload.safeParse(parsedJson);
+  if (!parsed.success) {
+    throw new IngestServiceError("invalid_payload", "invalid ingest payload", 400);
+  }
+
+  return parsed.data;
+}
+
+export function resolveIngestDeviceId(payload: IngestPayload, requestDeviceId: string): string {
+  const payloadDeviceId = payload.device_id || payload.points?.[0]?.device_id;
+  const deviceId = requestDeviceId || payloadDeviceId;
+  if (!deviceId) {
+    throw new IngestServiceError("missing_device_id", "missing device_id", 400);
+  }
+  if (payloadDeviceId && payloadDeviceId !== deviceId) {
+    throw new IngestServiceError("invalid_payload", "device_id mismatch between payload and request", 400);
+  }
+  return deviceId;
+}
+
+export type IngestPlan = {
+  deviceId: string;
+  ownerUserId: string;
+  ownerUserIds: string[];
+  visibility: BatchVisibility;
+  storagePath: string;
+  batchPayload: IngestPayload;
+};
+
+export type IngestDeviceOwner = Pick<IngestPlan, "ownerUserId" | "ownerUserIds">;
+
+export function resolveIngestDeviceOwner(args: {
+  deviceData: Record<string, unknown>;
+  status: string | null;
+  registryStatus: string | null;
+}): IngestDeviceOwner {
+  if (isForbiddenDevice(args.status, args.registryStatus)) {
+    throw new IngestServiceError("device_forbidden", "device not allowed", 403);
+  }
+
+  const ownerUserIds = normalizeOwnerIds(args.deviceData);
+  const ownerUserId = primaryOwnerUserId(args.deviceData);
+  if (!ownerUserId || !ownerUserIds.length) {
+    throw new IngestServiceError("device_forbidden", "device owner unavailable", 403);
+  }
+  return { ownerUserId, ownerUserIds };
+}
+
+export function planIngest(args: {
+  payload: IngestPayload;
+  deviceId: string;
+  ownerUserId: string;
+  ownerUserIds: string[];
+  ownerSubscription: SubscriptionSummary;
+  ownerDefaultVisibility: BatchVisibility | null;
+  requestedVisibility?: BatchVisibility | null;
+  batchId: string;
+}): IngestPlan {
+  const mismatchedPoint = args.payload.points.find((point) => point.device_id !== args.deviceId);
+  if (mismatchedPoint) {
+    throw new IngestServiceError("invalid_payload", "all points must match the device_id in the request", 400);
+  }
+
+  const visibility = normalizeVisibility(
+    args.requestedVisibility,
+    args.ownerDefaultVisibility ?? defaultBatchVisibilityForSubscription(args.ownerSubscription),
+  );
+  const batchPayload = { ...args.payload, device_id: args.deviceId };
+  return {
+    deviceId: args.deviceId,
+    ownerUserId: args.ownerUserId,
+    ownerUserIds: args.ownerUserIds,
+    visibility,
+    batchPayload,
+    storagePath: buildBatchStoragePath({
+      primaryOwnerUserId: args.ownerUserId,
+      deviceId: args.deviceId,
+      batchId: args.batchId,
+    }),
+  };
+}
+
 export class IngestService {
   private readonly deps: ResolvedIngestDependencies;
 
@@ -99,15 +190,8 @@ export class IngestService {
   async ingest(request: IngestRequest): Promise<IngestResult> {
     const db = this.deps.getDb();
     const bucket = this.deps.getBucket();
-    const parsedBody = this.normalizeIngestPayload(request.rawBody);
-    const payloadDeviceId = parsedBody.device_id || parsedBody.points?.[0]?.device_id;
-    const deviceId = request.deviceId || payloadDeviceId;
-    if (!deviceId) {
-      throw new IngestServiceError("missing_device_id", "missing device_id", 400);
-    }
-    if (payloadDeviceId && payloadDeviceId !== deviceId) {
-      throw new IngestServiceError("invalid_payload", "device_id mismatch between payload and request", 400);
-    }
+    const parsedBody = parseIngestPayload(request.rawBody);
+    const deviceId = resolveIngestDeviceId(parsedBody, request.deviceId);
 
     const devRef = db.collection("devices").doc(deviceId);
     const devSnap = await devRef.get();
@@ -117,30 +201,26 @@ export class IngestService {
     const devData = devSnap.data() ?? {};
     const status = normalizeStatus(devSnap.get("status"), (value) => value.toUpperCase());
     const registryStatus = normalizeStatus(devSnap.get("registryStatus"), (value) => value.toLowerCase());
-    if (isForbiddenDevice(status, registryStatus)) {
-      throw new IngestServiceError("device_forbidden", "device not allowed", 403);
-    }
-    const ownerUserIds = normalizeOwnerIds(devData);
-    const effectiveOwnerUserIds = ownerUserIds;
-    const ownerUserId = primaryOwnerUserId(devData);
-    if (!ownerUserId || !effectiveOwnerUserIds.length) {
-      throw new IngestServiceError("device_forbidden", "device owner unavailable", 403);
-    }
-
-    const mismatchedPoint = parsedBody.points.find((point) => point.device_id !== deviceId);
-    if (mismatchedPoint) {
-      throw new IngestServiceError("invalid_payload", "all points must match the device_id in the request", 400);
-    }
+    const { ownerUserId, ownerUserIds } = resolveIngestDeviceOwner({
+      deviceData: devData,
+      status,
+      registryStatus,
+    });
 
     const batchId = crypto.randomUUID();
     const ownerSubscription = await this.deps.getSubscriptionSummary(ownerUserId, db);
     const ownerDefaultVisibility = await getDeviceDefaultBatchVisibility(devSnap);
-    const visibility = normalizeVisibility(
-      request.visibility,
-      ownerDefaultVisibility ?? defaultBatchVisibilityForSubscription(ownerSubscription),
-    );
-    const storagePath = buildBatchStoragePath({ primaryOwnerUserId: ownerUserId, deviceId, batchId });
-    const batchPayload = { ...parsedBody, device_id: deviceId };
+    const plan = planIngest({
+      payload: parsedBody,
+      deviceId,
+      ownerUserId,
+      ownerUserIds,
+      ownerSubscription,
+      ownerDefaultVisibility,
+      requestedVisibility: request.visibility,
+      batchId,
+    });
+    const { batchPayload, storagePath, visibility } = plan;
     const encoded = encodeBatchPayload(batchPayload);
     let reservation: UploadQuotaReservation | null = null;
     let storedPayload = false;
@@ -170,7 +250,7 @@ export class IngestService {
         compressedBytes: encoded.buffer.byteLength,
         visibility,
         payload: batchPayload,
-        ownerUserIds: effectiveOwnerUserIds,
+        ownerUserIds,
         deviceName: typeof devSnap.get("name") === "string" && devSnap.get("name").trim().length > 0
           ? devSnap.get("name").trim()
           : null,
@@ -201,23 +281,6 @@ export class IngestService {
       }
       throw err;
     }
-  }
-
-  private normalizeIngestPayload(rawBody: string): IngestPayload {
-    let parsedJson: unknown;
-    try {
-      parsedJson = JSON.parse(rawBody);
-    }
-    catch {
-      throw new IngestServiceError("invalid_payload", "invalid JSON payload", 400);
-    }
-
-    const parsed = IngestPayload.safeParse(parsedJson);
-    if (!parsed.success) {
-      throw new IngestServiceError("invalid_payload", "invalid ingest payload", 400);
-    }
-
-    return parsed.data;
   }
 }
 

--- a/functions/src/services/nodePurchase.ts
+++ b/functions/src/services/nodePurchase.ts
@@ -389,22 +389,25 @@ type CreateCheckoutSessionOptions = {
   sessionData?: Record<string, unknown>;
 };
 
-async function createCheckoutSession(
-  config: CheckoutProductConfig,
-  options: CreateCheckoutSessionOptions = {},
-): Promise<NodePurchaseCheckoutSession> {
-  const catalog = await ensureCatalog(config);
-  const { successUrl, cancelUrl } = checkoutRedirectUrls(config);
+type CheckoutSessionPlan = {
+  params: CheckoutSessionCreateParams;
+  quantity: number;
+};
+
+export function buildCheckoutSessionPlan(args: {
+  config: CheckoutProductConfig;
+  catalog: PaymentCatalog;
+  urls: { successUrl: string; cancelUrl: string };
+  options?: CreateCheckoutSessionOptions;
+}): CheckoutSessionPlan {
+  const { config, catalog, urls } = args;
+  const options = args.options ?? {};
   const quantity = options.quantity ?? DEFAULT_NODE_HARDWARE_QUANTITY;
   const metadata: Record<string, string> = {
     purchaseType: config.purchaseType,
+    ...(options.userId ? { userId: options.userId } : {}),
+    ...(options.metadata ?? {}),
   };
-  if (options.userId) {
-    metadata.userId = options.userId;
-  }
-  if (options.metadata) {
-    Object.assign(metadata, options.metadata);
-  }
 
   const params: CheckoutSessionCreateParams = {
     line_items: [
@@ -420,29 +423,35 @@ async function createCheckoutSession(
     billing_address_collection: config.billingAddressCollection,
     custom_text: config.customText,
     metadata,
-    success_url: successUrl,
-    cancel_url: cancelUrl,
+    success_url: urls.successUrl,
+    cancel_url: urls.cancelUrl,
+    ...(config.allowPromotionCodes ? { allow_promotion_codes: true } : {}),
+    ...(config.shippingAddressCollection ? { shipping_address_collection: config.shippingAddressCollection } : {}),
+    ...(options.customerId
+      ? { customer: options.customerId }
+      : options.customerEmail
+        ? { customer_email: options.customerEmail }
+        : {}),
+    ...(options.userId ? { client_reference_id: options.userId } : {}),
+    ...((config.mode ?? "payment") === "subscription" && options.subscriptionMetadata
+      ? { subscription_data: { metadata: options.subscriptionMetadata } }
+      : {}),
   };
-  if (config.allowPromotionCodes) {
-    params.allow_promotion_codes = true;
-  }
-  if (config.shippingAddressCollection) {
-    params.shipping_address_collection = config.shippingAddressCollection;
-  }
-  if (options.customerId) {
-    params.customer = options.customerId;
-  }
-  else if (options.customerEmail) {
-    params.customer_email = options.customerEmail;
-  }
-  if (options.userId) {
-    params.client_reference_id = options.userId;
-  }
-  if ((config.mode ?? "payment") === "subscription" && options.subscriptionMetadata) {
-    params.subscription_data = {
-      metadata: options.subscriptionMetadata,
-    };
-  }
+
+  return { params, quantity };
+}
+
+async function createCheckoutSession(
+  config: CheckoutProductConfig,
+  options: CreateCheckoutSessionOptions = {},
+): Promise<NodePurchaseCheckoutSession> {
+  const catalog = await ensureCatalog(config);
+  const { params, quantity } = buildCheckoutSessionPlan({
+    config,
+    catalog,
+    urls: checkoutRedirectUrls(config),
+    options,
+  });
 
   let session: Stripe.Checkout.Session;
   try {

--- a/functions/test/index.test.ts
+++ b/functions/test/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildApi } from "../src/index.js";
+
+describe("buildApi", () => {
+  it("builds an injectable API with injected startup dependencies", async () => {
+    const initializeAdminApp = vi.fn();
+    const ensureLocalSuperAdmin = vi.fn(async () => {});
+
+    const app = await buildApi({
+      initializeAdminApp,
+      ensureLocalSuperAdmin,
+      logger: false,
+      rateLimitsEnabled: false,
+      routes: [],
+    });
+
+    const res = await app.inject({ method: "GET", url: "/health" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+    expect(initializeAdminApp).toHaveBeenCalledOnce();
+    expect(ensureLocalSuperAdmin).toHaveBeenCalledOnce();
+    await app.close();
+  });
+});

--- a/functions/test/services/ingestService.test.ts
+++ b/functions/test/services/ingestService.test.ts
@@ -1,6 +1,11 @@
 import { gunzipSync } from "node:zlib";
 import { describe, expect, it, vi } from "vitest";
-import { createIngestService } from "../../src/services/ingestService.js";
+import {
+  createIngestService,
+  parseIngestPayload,
+  planIngest,
+  resolveIngestDeviceId,
+} from "../../src/services/ingestService.js";
 
 function buildPayload(deviceId: string) {
   return {
@@ -19,7 +24,78 @@ function buildPayload(deviceId: string) {
   };
 }
 
+function buildSubscriptionSummary() {
+  return {
+    planId: "pro",
+    label: "Pro",
+    source: "stripe",
+    status: "active",
+    billingInterval: "month",
+    canManageBilling: true,
+    cancelAtPeriodEnd: false,
+    currentPeriodEnd: null,
+    videoDownloadAccess: "full",
+    limits: {
+      maxActiveDevices: 10,
+      maxStoredBatchesTotal: 2_000,
+      maxStoredPrivateBatches: 1_000,
+      monthlyPoints: 1_000_000,
+      maxPointsPerBatch: 10_000,
+    },
+    usage: {
+      activeDevices: 1,
+      storedBatchesTotal: 10,
+      storedPrivateBatches: 1,
+      monthlyPointsUsed: 0,
+      monthlyPointsRemaining: 1_000_000,
+      monthKey: "2024-01",
+      resetAt: "2024-02-01T00:00:00.000Z",
+    },
+  } as const;
+}
+
 describe("IngestService", () => {
+  it("plans normalized ingest work without touching storage or Firestore", () => {
+    const payload = parseIngestPayload(JSON.stringify(buildPayload("device-1")));
+    const deviceId = resolveIngestDeviceId(payload, "device-1");
+
+    const plan = planIngest({
+      payload,
+      deviceId,
+      ownerUserId: "user-1",
+      ownerUserIds: ["user-1", "user-2"],
+      ownerSubscription: buildSubscriptionSummary(),
+      ownerDefaultVisibility: "private",
+      requestedVisibility: null,
+      batchId: "batch-1",
+    });
+
+    expect(plan).toEqual({
+      deviceId: "device-1",
+      ownerUserId: "user-1",
+      ownerUserIds: ["user-1", "user-2"],
+      visibility: "private",
+      storagePath: "ingest/v2/user-1/device-1/batch-1.json.gz",
+      batchPayload: payload,
+    });
+  });
+
+  it("rejects mismatched payload and requested device ids before side effects", () => {
+    const payload = parseIngestPayload(JSON.stringify(buildPayload("device-1")));
+
+    expect(() => resolveIngestDeviceId(payload, "device-2")).toThrow("device_id mismatch between payload and request");
+    expect(() => planIngest({
+      payload,
+      deviceId: "device-2",
+      ownerUserId: "user-1",
+      ownerUserIds: ["user-1"],
+      ownerSubscription: buildSubscriptionSummary(),
+      ownerDefaultVisibility: "public",
+      requestedVisibility: "public",
+      batchId: "batch-1",
+    })).toThrow("all points must match the device_id in the request");
+  });
+
   it("stores gzipped v2 payloads and sends root batch metadata to the processor", async () => {
     const saves: Array<{ path: string; payload: Buffer; options: unknown }> = [];
     const processIngestBatch = vi.fn(async (request) => ({
@@ -67,64 +143,12 @@ describe("IngestService", () => {
       bucket: bucket as never,
       processIngestBatch: processIngestBatch as never,
       updateDeviceLastSeen: vi.fn().mockResolvedValue(undefined),
-      getSubscriptionSummary: vi.fn().mockResolvedValue({
-        planId: "pro",
-        label: "Pro",
-        source: "stripe",
-        status: "active",
-        billingInterval: "month",
-        canManageBilling: true,
-        cancelAtPeriodEnd: false,
-        currentPeriodEnd: null,
-        videoDownloadAccess: "full",
-        limits: {
-          maxActiveDevices: 10,
-          maxStoredBatchesTotal: 2_000,
-          maxStoredPrivateBatches: 1_000,
-          monthlyPoints: 1_000_000,
-          maxPointsPerBatch: 10_000,
-        },
-        usage: {
-          activeDevices: 1,
-          storedBatchesTotal: 10,
-          storedPrivateBatches: 1,
-          monthlyPointsUsed: 0,
-          monthlyPointsRemaining: 1_000_000,
-          monthKey: "2024-01",
-          resetAt: "2024-02-01T00:00:00.000Z",
-        },
-      }),
+      getSubscriptionSummary: vi.fn().mockResolvedValue(buildSubscriptionSummary()),
       reserveUploadQuota: vi.fn().mockResolvedValue({
         monthKey: "2024-01",
         pointCount: 1,
         visibility: "public",
-        subscription: {
-          planId: "pro",
-          label: "Pro",
-          source: "stripe",
-          status: "active",
-          billingInterval: "month",
-          canManageBilling: true,
-          cancelAtPeriodEnd: false,
-          currentPeriodEnd: null,
-          videoDownloadAccess: "full",
-          limits: {
-            maxActiveDevices: 10,
-            maxStoredBatchesTotal: 2_000,
-            maxStoredPrivateBatches: 1_000,
-            monthlyPoints: 1_000_000,
-            maxPointsPerBatch: 10_000,
-          },
-          usage: {
-            activeDevices: 1,
-            storedBatchesTotal: 11,
-            storedPrivateBatches: 1,
-            monthlyPointsUsed: 1,
-            monthlyPointsRemaining: 999_999,
-            monthKey: "2024-01",
-            resetAt: "2024-02-01T00:00:00.000Z",
-          },
-        },
+        subscription: buildSubscriptionSummary(),
       }),
       rollbackUploadQuotaReservation: vi.fn().mockResolvedValue(undefined),
     });

--- a/functions/test/services/nodePurchasePlanning.test.ts
+++ b/functions/test/services/nodePurchasePlanning.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { buildCheckoutSessionPlan } from "../../src/services/nodePurchase.js";
+
+describe("buildCheckoutSessionPlan", () => {
+  it("builds Stripe Checkout params from config, catalog, URLs, and caller options", () => {
+    const config = {
+      catalogDocId: "subscriptionProMonthly",
+      sessionCollection: "subscriptionCheckoutSessions",
+      purchaseType: "subscription",
+      productName: "CrowdPM Pro Monthly",
+      description: "Monthly CrowdPM Pro access.",
+      currency: "usd",
+      unitAmount: 1200,
+      taxCode: "txcd_99999999",
+      taxBehavior: "exclusive",
+      billingAddressCollection: "required",
+      successPath: "/",
+      successQueryParam: "subscriptionCheckout=success",
+      successSessionIdQueryParam: "subscriptionCheckoutSessionId",
+      cancelQueryParam: "subscriptionCheckout=cancelled",
+      customText: {
+        submit: {
+          message: "Subscription checkout",
+        },
+      },
+      mode: "subscription",
+      recurringInterval: "month",
+      allowPromotionCodes: true,
+    } satisfies Parameters<typeof buildCheckoutSessionPlan>[0]["config"];
+    const catalog = {
+      productId: "prod_123",
+      defaultPriceId: "price_123",
+      currency: "usd",
+      unitAmount: 1200,
+      taxCode: "txcd_99999999",
+      taxBehavior: "exclusive",
+      recurringInterval: "month",
+    } satisfies Parameters<typeof buildCheckoutSessionPlan>[0]["catalog"];
+
+    const plan = buildCheckoutSessionPlan({
+      config,
+      catalog,
+      urls: {
+        successUrl: "https://app.example.test/?subscriptionCheckout=success",
+        cancelUrl: "https://app.example.test/?subscriptionCheckout=cancelled",
+      },
+      options: {
+        userId: "user-123",
+        customerId: "cus_123",
+        quantity: 2,
+        metadata: {
+          offerId: "pro_monthly",
+        },
+        subscriptionMetadata: {
+          userId: "user-123",
+          offerId: "pro_monthly",
+        },
+      },
+    });
+
+    expect(plan.quantity).toBe(2);
+    expect(plan.params).toEqual({
+      line_items: [
+        {
+          price: "price_123",
+          quantity: 2,
+        },
+      ],
+      mode: "subscription",
+      automatic_tax: {
+        enabled: true,
+      },
+      billing_address_collection: "required",
+      custom_text: {
+        submit: {
+          message: "Subscription checkout",
+        },
+      },
+      metadata: {
+        purchaseType: "subscription",
+        userId: "user-123",
+        offerId: "pro_monthly",
+      },
+      success_url: "https://app.example.test/?subscriptionCheckout=success",
+      cancel_url: "https://app.example.test/?subscriptionCheckout=cancelled",
+      allow_promotion_codes: true,
+      customer: "cus_123",
+      client_reference_id: "user-123",
+      subscription_data: {
+        metadata: {
+          userId: "user-123",
+          offerId: "pro_monthly",
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- refactor functions API startup into explicit lazy initialization with request-time error handling
- move frontend URL state and several async data flows toward more derived React Query/store-based patterns
- extract map and service planning logic into purer helpers with added test coverage

## Verification
- pnpm lint
- pnpm --filter crowdpm-frontend build
- pnpm --filter crowdpm-functions test