### PR TITLE
Fix cached browser location snapshots

### DIFF
--- a/frontend/src/lib/locationStore.ts
+++ b/frontend/src/lib/locationStore.ts
@@ -15,10 +15,21 @@ const SERVER_LOCATION: BrowserLocationSnapshot = {
   hash: "",
 };
 
+let cachedBrowserLocation: BrowserLocationSnapshot = SERVER_LOCATION;
+
 function readBrowserLocation(): BrowserLocationSnapshot {
   if (typeof window === "undefined") return SERVER_LOCATION;
   const { href, pathname, search, hash } = window.location;
-  return { href, pathname, search, hash };
+  if (
+    cachedBrowserLocation.href === href
+    && cachedBrowserLocation.pathname === pathname
+    && cachedBrowserLocation.search === search
+    && cachedBrowserLocation.hash === hash
+  ) {
+    return cachedBrowserLocation;
+  }
+  cachedBrowserLocation = { href, pathname, search, hash };
+  return cachedBrowserLocation;
 }
 
 function emitLocationChange(): void {


### PR DESCRIPTION
## Summary
- cache the last browser location snapshot returned by `useBrowserLocation`
- only publish a new snapshot object when the URL fields actually change
- prevent the React external-store infinite update loop behind production error #185

## Verification
- pnpm --filter crowdpm-frontend build
- pnpm lint