### PR TITLE
Refactor frontend toward React 19 methodology

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,7 @@ export default [
       "eslint:recommended",
       "plugin:@typescript-eslint/recommended",
       "plugin:react/recommended",
-      "plugin:react-hooks/recommended"
+      "plugin:react-hooks/recommended-latest"
     ],
     settings: {
       react: {
@@ -50,12 +50,7 @@ export default [
       }
     },
     rules: {
-      "react/react-in-jsx-scope": "off",
-      // These rules were added to the recommended hooks preset after this codebase's
-      // existing patterns were established. Keep the prior lint contract when
-      // upgrading eslint-plugin-react-hooks instead of forcing a broad refactor here.
-      "react-hooks/refs": "off",
-      "react-hooks/set-state-in-effect": "off"
+      "react/react-in-jsx-scope": "off"
     },
     overrides: [
       {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useEffectEvent, useRef, useState } from "react";
 import type { UserThemeSettings } from "@crowdpm/types";
 import type { AuthMode } from "./components/AuthDialog";
 import { ExternalAnchor, ExternalLink } from "./components/ExternalLink";
@@ -144,24 +144,28 @@ export default function App() {
   const { settings } = useUserSettings();
   const location = useBrowserLocation();
   const userScopedKey = user?.uid ?? "anon";
-  const [tab, setTab] = useState<AppTab>(() => getDeepLinkedAppTab(location.pathname) ?? "map");
+  const [requestedTab, setRequestedTab] = useState<AppTab>(() => getDeepLinkedAppTab(location.pathname) ?? "map");
   const [authMode, setAuthMode] = useState<AuthMode>("login");
   const [isAuthDialogOpen, setAuthDialogOpen] = useState(false);
-  const [isActivationModalOpen, setActivationModalOpen] = useState(() => isActivationRoute(location.pathname));
   const [isTeamModalOpen, setTeamModalOpen] = useState(false);
-  const [isThemeModalOpen, setThemeModalOpen] = useState(() => Boolean(readThemeCheckoutNotice(location.search)));
-  const [themeCheckoutNotice, setThemeCheckoutNotice] = useState<ThemeCheckoutNotice>(() => readThemeCheckoutNotice(location.search));
-  const [themeCheckoutSessionId, setThemeCheckoutSessionId] = useState<string | null>(() => readThemeCheckoutSessionId(location.search));
-  const [subscriptionCheckoutNotice, setSubscriptionCheckoutNotice] = useState<SubscriptionCheckoutNotice>(() => readSubscriptionCheckoutNotice(location.search));
-  const [subscriptionCheckoutSessionId, setSubscriptionCheckoutSessionId] = useState<string | null>(() => readSubscriptionCheckoutSessionId(location.search));
+  const [isThemeModalRequested, setThemeModalRequested] = useState(false);
   const [themeDraft, setThemeDraft] = useState<UserThemeSettings | null>(null);
   const [dashboardRefreshToken, setDashboardRefreshToken] = useState(0);
 
+  const themeCheckoutNotice = readThemeCheckoutNotice(location.search);
+  const themeCheckoutSessionId = readThemeCheckoutSessionId(location.search);
+  const subscriptionCheckoutNotice = readSubscriptionCheckoutNotice(location.search);
+  const subscriptionCheckoutSessionId = readSubscriptionCheckoutSessionId(location.search);
+  const routeTab = getDeepLinkedAppTab(location.pathname);
+  const isActivationModalOpen = isActivationRoute(location.pathname);
   const isSignedIn = Boolean(user);
-  const activeTab = !isSignedIn && tab !== "map" && tab !== "pairing-info" && tab !== "about" && tab !== "node"
+  const tab = routeTab ?? (isDeepLinkedTab(requestedTab) ? "map" : requestedTab);
+  const preferredTab = user && subscriptionCheckoutNotice ? "dashboard" : tab;
+  const activeTab = !isSignedIn && preferredTab !== "map" && preferredTab !== "pairing-info" && preferredTab !== "about" && preferredTab !== "node"
     ? "map"
-    : (tab === "admin" && !canAccessAdmin ? "map" : tab);
-  const activeTheme = themeDraft ?? settings.theme;
+    : (preferredTab === "admin" && !canAccessAdmin ? "map" : preferredTab);
+  const isThemeModalOpen = isThemeModalRequested || Boolean(themeCheckoutNotice);
+  const activeTheme = user ? themeDraft ?? settings.theme : settings.theme;
   const isDarkTheme = activeTheme.appearance === "dark";
   const mapHeaderBackground = activeTab === "map"
     ? isDarkTheme
@@ -176,19 +180,34 @@ export default function App() {
     setAuthDialogOpen(true);
   };
 
+  const navigateToTab = useCallback((nextTab: AppTab) => {
+    const pathname = location.pathname.toLowerCase();
+    setRequestedTab(nextTab);
+
+    if (isDeepLinkedTab(nextTab)) {
+      const targetRoute = getRouteForDeepLinkedAppTab(nextTab);
+      if (!pathname.startsWith(targetRoute)) {
+        pushAppLocation(targetRoute);
+      }
+      return;
+    }
+
+    if (isActivationRoute(pathname) || isDeepLinkedAppRoute(pathname)) {
+      replaceAppLocation(APP_ROUTES.home);
+    }
+  }, [location.pathname]);
+
   const closeThemeModal = useCallback(() => {
-    setThemeModalOpen(false);
+    setThemeModalRequested(false);
     setThemeDraft(null);
     if (themeCheckoutNotice || themeCheckoutSessionId) {
-      setThemeCheckoutNotice(null);
-      setThemeCheckoutSessionId(null);
       clearThemeCheckoutNoticeFromUrl();
     }
   }, [themeCheckoutNotice, themeCheckoutSessionId]);
 
   const handleThemeModalOpenChange = useCallback((next: boolean) => {
     if (next) {
-      setThemeModalOpen(true);
+      setThemeModalRequested(true);
       return;
     }
     closeThemeModal();
@@ -199,48 +218,21 @@ export default function App() {
       closeThemeModal();
       return;
     }
-    setThemeModalOpen(true);
+    setThemeModalRequested(true);
   }, [closeThemeModal, isThemeModalOpen]);
 
   const openThemeModal = useCallback(() => {
-    setThemeModalOpen(true);
+    setThemeModalRequested(true);
   }, []);
 
   const openTeamModal = useCallback(() => {
     setTeamModalOpen(true);
   }, []);
 
-  useEffect(() => {
-    const nextThemeNotice = readThemeCheckoutNotice(location.search);
-    const nextThemeSessionId = readThemeCheckoutSessionId(location.search);
-    const nextSubscriptionNotice = readSubscriptionCheckoutNotice(location.search);
-    const nextSubscriptionSessionId = readSubscriptionCheckoutSessionId(location.search);
-
-    setThemeCheckoutNotice(nextThemeNotice);
-    setThemeCheckoutSessionId(nextThemeSessionId);
-    setSubscriptionCheckoutNotice(nextSubscriptionNotice);
-    setSubscriptionCheckoutSessionId(nextSubscriptionSessionId);
-
-    if (nextThemeNotice) {
-      setThemeModalOpen(true);
-    }
-  }, [location.search]);
-
-  useEffect(() => {
-    if (user) return;
-    setThemeDraft(null);
-  }, [user]);
-
-  useEffect(() => {
-    if (!user || !subscriptionCheckoutNotice) return;
-    setTab("dashboard");
-    setDashboardRefreshToken((prev) => prev + 1);
-  }, [subscriptionCheckoutNotice, user]);
-
   const handleProtectedTabClick = (target: "dashboard" | "admin") => {
     if (user) {
       if (target === "admin" && !canAccessAdmin) return;
-      setTab(target);
+      navigateToTab(target);
       return;
     }
     openAuthDialog("login");
@@ -249,93 +241,78 @@ export default function App() {
   const handleSignOut = async () => {
     try {
       await signOut();
-      setTab("map");
+      setRequestedTab("map");
+      setThemeDraft(null);
+      setThemeModalRequested(false);
     }
     catch (err) {
       logWarning("Sign out failed", undefined, err);
     }
   };
 
+  const handleThemeShortcut = useEffectEvent((event: KeyboardEvent) => {
+    const isModifierActive = event.altKey || event.ctrlKey || event.shiftKey || event.metaKey;
+    if (event.key?.toUpperCase() !== "T" || isModifierActive) return;
+
+    const activeElement = document.activeElement;
+    if (activeElement instanceof Element && activeElement.closest(THEME_SHORTCUT_IGNORED_SELECTOR)) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    toggleThemeModal();
+  });
+
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const handleThemeShortcut = (event: KeyboardEvent) => {
-      const isModifierActive = event.altKey || event.ctrlKey || event.shiftKey || event.metaKey;
-      if (event.key?.toUpperCase() !== "T" || isModifierActive) return;
-
-      const activeElement = document.activeElement;
-      if (activeElement instanceof Element && activeElement.closest(THEME_SHORTCUT_IGNORED_SELECTOR)) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-      toggleThemeModal();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      handleThemeShortcut(event);
     };
 
-    window.addEventListener("keydown", handleThemeShortcut, true);
-    return () => window.removeEventListener("keydown", handleThemeShortcut, true);
-  }, [toggleThemeModal]);
-
-  useEffect(() => {
-    const pathname = location.pathname.toLowerCase();
-    if (isActivationRoute(pathname)) {
-      setActivationModalOpen(true);
-      return;
-    }
-    setActivationModalOpen(false);
-
-    const deepLinkedTab = getDeepLinkedAppTab(pathname);
-    if (deepLinkedTab) {
-      setTab(deepLinkedTab);
-    }
-    else {
-      setTab((currentTab) => isDeepLinkedTab(currentTab) ? "map" : currentTab);
-    }
-  }, [location.pathname]);
-
-  useEffect(() => {
-    if (isActivationModalOpen) {
-      if (!isActivationRoute(location.pathname)) {
-        pushAppLocation(APP_ROUTES.activation);
-      }
-    }
-    else if (isActivationRoute(location.pathname)) {
-      replaceAppLocation(APP_ROUTES.home);
-    }
-  }, [isActivationModalOpen, location.pathname]);
-
-  useEffect(() => {
-    const pathname = location.pathname.toLowerCase();
-    if (isDeepLinkedTab(tab)) {
-      const targetRoute = getRouteForDeepLinkedAppTab(tab);
-      if (!pathname.startsWith(targetRoute)) {
-        pushAppLocation(targetRoute);
-      }
-    }
-    else if (isDeepLinkedAppRoute(pathname)) {
-      replaceAppLocation(APP_ROUTES.home);
-    }
-  }, [location.pathname, tab]);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, []);
 
   const openActivationModal = () => {
     if (!user) {
       openAuthDialog("login");
       return;
     }
-    setActivationModalOpen(true);
+    if (!isActivationModalOpen) {
+      pushAppLocation(APP_ROUTES.activation);
+    }
   };
 
+  const handleActivationModalOpenChange = useCallback((next: boolean) => {
+    if (next) {
+      if (!user) {
+        openAuthDialog("login");
+        return;
+      }
+      if (!isActivationModalOpen) {
+        pushAppLocation(APP_ROUTES.activation);
+      }
+      return;
+    }
+
+    if (isActivationModalOpen) {
+      replaceAppLocation(APP_ROUTES.home);
+    }
+  }, [isActivationModalOpen, user]);
+
   const handleActivationComplete = () => {
-    setActivationModalOpen(false);
-    setTab("dashboard");
+    setRequestedTab("dashboard");
     setDashboardRefreshToken((prev) => prev + 1);
+    if (isActivationModalOpen) {
+      replaceAppLocation(APP_ROUTES.home);
+    }
   };
 
   const handleSubscriptionCheckoutHandled = useCallback(() => {
     if (!subscriptionCheckoutNotice && !subscriptionCheckoutSessionId) {
       return;
     }
-    setSubscriptionCheckoutNotice(null);
-    setSubscriptionCheckoutSessionId(null);
+    setRequestedTab("dashboard");
     clearSubscriptionCheckoutNoticeFromUrl();
   }, [subscriptionCheckoutNotice, subscriptionCheckoutSessionId]);
 
@@ -362,7 +339,7 @@ export default function App() {
     >
       <ActivationModal
         open={isActivationModalOpen}
-        onOpenChange={setActivationModalOpen}
+        onOpenChange={handleActivationModalOpenChange}
         onActivationComplete={handleActivationComplete}
       />
       <TeamModal open={isTeamModalOpen} onOpenChange={setTeamModalOpen} isSignedIn={isSignedIn} />
@@ -413,12 +390,12 @@ export default function App() {
           }}
         >
           {/* Clickable logo + title — navigates back to map */}
-          <button
-            type="button"
-            onClick={() => setTab("map")}
-            style={{
-              display: "flex",
-              alignItems: "center",
+            <button
+              type="button"
+              onClick={() => navigateToTab("map")}
+              style={{
+                display: "flex",
+                alignItems: "center",
               gap: 10,
               background: "none",
               border: "none",
@@ -488,14 +465,14 @@ export default function App() {
           </DropdownMenu.Trigger>
           <DropdownMenu.Content sideOffset={8} align="start">
             <DropdownMenu.Item
-              onSelect={() => setTab("map")}
+              onSelect={() => navigateToTab("map")}
               style={activeTab === "map" ? { fontWeight: 600 } : undefined}
               disabled={isLoading}
             >
               Map
             </DropdownMenu.Item>
             <DropdownMenu.Item
-              onSelect={() => setTab("node")}
+              onSelect={() => navigateToTab("node")}
               style={activeTab === "node" ? { fontWeight: 600 } : undefined}
               disabled={isLoading}
             >
@@ -520,7 +497,7 @@ export default function App() {
                   </DropdownMenu.Item>
                 ) : null}
                 <DropdownMenu.Item
-                  onSelect={() => setTab("about")}
+                  onSelect={() => navigateToTab("about")}
                   style={activeTab === "about" ? { fontWeight: 600 } : undefined}
                   disabled={isLoading}
                 >
@@ -529,7 +506,7 @@ export default function App() {
               </>
             ) : (
               <DropdownMenu.Item
-                onSelect={() => setTab("about")}
+                onSelect={() => navigateToTab("about")}
                 style={activeTab === "about" ? { fontWeight: 600 } : undefined}
                 disabled={isLoading}
               >
@@ -655,7 +632,7 @@ export default function App() {
             mode={authMode}
             onModeChange={setAuthMode}
             onOpenChange={setAuthDialogOpen}
-            onAuthenticated={() => setTab("dashboard")}
+            onAuthenticated={() => navigateToTab("dashboard")}
           />
         ) : null}
       </Suspense>
@@ -710,41 +687,54 @@ function ThemePreferencesModal({
 }: ThemePreferencesModalProps) {
   const { user } = useAuth();
   const { settings, refresh, isLoading, isSaving, updateSettings } = useUserSettings();
-  const [message, setMessage] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isStartingCheckout, setIsStartingCheckout] = useState(false);
   const [isConfirmingCheckout, setIsConfirmingCheckout] = useState(false);
   const [openLegalDocument, setOpenLegalDocument] = useState<LegalDocumentId | null>(null);
+  const confirmationAttemptKeyRef = useRef<string | null>(null);
   const controlsDisabled = isLoading || isSaving || isStartingCheckout || isConfirmingCheckout;
   const hasUnsavedChanges = JSON.stringify(theme) !== JSON.stringify(settings.theme);
   const saveDisabled = controlsDisabled || !user || !settings.themeSaveUnlocked || !hasUnsavedChanges;
   const unlockDisabled = controlsDisabled || !user || settings.themeSaveUnlocked;
-
-  useEffect(() => {
-    if (!open) return;
-    setError(null);
-    if (checkoutNotice === "success") {
-      setMessage(settings.themeSaveUnlocked
+  const checkoutNoticeMessage = !open
+    ? null
+    : checkoutNotice === "success"
+      ? (settings.themeSaveUnlocked
         ? "Theme saving is now unlocked for this account."
-        : "Theme purchase completed. If saving is still locked, give the account a moment to refresh.");
-      return;
+        : "Theme purchase completed. If saving is still locked, give the account a moment to refresh.")
+      : checkoutNotice === "cancelled"
+        ? "Theme save unlock checkout was cancelled before payment completed."
+        : null;
+  const message = actionMessage ?? checkoutNoticeMessage;
+
+  const handleDialogOpenChange = useCallback((next: boolean) => {
+    if (!next) {
+      setActionMessage(null);
+      setError(null);
+      setIsStartingCheckout(false);
+      setIsConfirmingCheckout(false);
+      setOpenLegalDocument(null);
     }
-    if (checkoutNotice === "cancelled") {
-      setMessage("Theme save unlock checkout was cancelled before payment completed.");
-      return;
-    }
-    setMessage(null);
-  }, [checkoutNotice, open, settings.themeSaveUnlocked]);
+    onOpenChange(next);
+  }, [onOpenChange]);
 
   useEffect(() => {
     if (!open || checkoutNotice !== "success" || !user) {
-      setIsConfirmingCheckout(false);
       return;
     }
+    const confirmationKey = `${user.uid}:${checkoutSessionId ?? "none"}`;
+    if (confirmationAttemptKeyRef.current === confirmationKey) {
+      return;
+    }
+    confirmationAttemptKeyRef.current = confirmationKey;
     let isCancelled = false;
-    setIsConfirmingCheckout(true);
+
     void (async () => {
       try {
+        setActionMessage(null);
+        setError(null);
+        setIsConfirmingCheckout(true);
         if (checkoutSessionId) {
           await confirmThemeSaveCheckoutSession(checkoutSessionId);
         }
@@ -771,27 +761,27 @@ function ThemePreferencesModal({
 
   const handleSave = async () => {
     if (!user) {
-      setMessage(null);
+      setActionMessage(null);
       setError("Sign in to save theme preferences.");
       return;
     }
     if (!settings.themeSaveUnlocked) {
-      setMessage(null);
+      setActionMessage(null);
       setError("Purchase the theme save unlock to persist theme preferences.");
       return;
     }
     if (!hasUnsavedChanges) {
-      setMessage("No theme changes to save.");
+      setActionMessage("No theme changes to save.");
       setError(null);
       return;
     }
 
-    setMessage(null);
+    setActionMessage(null);
     setError(null);
     try {
       await updateSettings({ theme });
       onThemeSaved();
-      setMessage("Theme preferences saved.");
+      setActionMessage("Theme preferences saved.");
     }
     catch (err) {
       setError(err instanceof Error ? err.message : "Unable to update theme preferences.");
@@ -800,12 +790,12 @@ function ThemePreferencesModal({
 
   const handlePurchaseThemeSave = async () => {
     if (!user) {
-      setMessage(null);
+      setActionMessage(null);
       setError("Sign in to purchase and save theme preferences.");
       return;
     }
 
-    setMessage(null);
+    setActionMessage(null);
     setError(null);
     setIsStartingCheckout(true);
     try {
@@ -820,7 +810,7 @@ function ThemePreferencesModal({
   };
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root open={open} onOpenChange={handleDialogOpenChange}>
       <Dialog.Content
         size="3"
         style={{

--- a/frontend/src/components/AuthDialog.tsx
+++ b/frontend/src/components/AuthDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { FirebaseError } from "firebase/app";
 import { Button, Dialog, Flex, Text, TextField } from "@radix-ui/themes";
 import { useAuth } from "../providers/AuthProvider";
@@ -41,31 +41,23 @@ function getReadableError(error: unknown): string {
   return "Something went wrong. Please try again.";
 }
 
-export function AuthDialog({ open, mode, onModeChange, onOpenChange, onAuthenticated }: AuthDialogProps) {
+type AuthDialogFormProps = Pick<AuthDialogProps, "mode" | "onModeChange" | "onOpenChange" | "onAuthenticated"> & {
+  onOpenLegalDocument: (documentId: LegalDocumentId) => void;
+};
+
+function AuthDialogForm({
+  mode,
+  onModeChange,
+  onOpenChange,
+  onAuthenticated,
+  onOpenLegalDocument,
+}: AuthDialogFormProps) {
   const { signIn, signUp } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [openLegalDocument, setOpenLegalDocument] = useState<LegalDocumentId | null>(null);
-
-  useEffect(() => {
-    if (!open) {
-      setEmail("");
-      setPassword("");
-      setConfirmPassword("");
-      setError(null);
-      setIsSubmitting(false);
-      setOpenLegalDocument(null);
-    }
-  }, [open]);
-
-  useEffect(() => {
-    setError(null);
-    setPassword("");
-    setConfirmPassword("");
-  }, [mode]);
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -93,113 +85,127 @@ export function AuthDialog({ open, mode, onModeChange, onOpenChange, onAuthentic
     }
   }
 
-  const title = mode === "signup" ? "Sign up" : "Log in";
-  const description =
-    mode === "signup"
-      ? "Create an account with your email and password to access the user dashboard."
-      : "Enter your email and password to access the user dashboard.";
   const legalCopy = mode === "signup"
     ? "By creating an account, you agree to the "
     : "By continuing, you acknowledge the ";
 
   return (
+    <form onSubmit={handleSubmit}>
+      <Flex direction="column" gap="3" mt="4">
+        <div>
+          <Text as="label" htmlFor="auth-email" size="2" color="gray">
+            Email
+          </Text>
+          <TextField.Root
+            id="auth-email"
+            type="email"
+            autoComplete="email"
+            required
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="you@example.com"
+            mt="1"
+          />
+        </div>
+        <div>
+          <Text as="label" htmlFor="auth-password" size="2" color="gray">
+            Password
+          </Text>
+          <TextField.Root
+            id="auth-password"
+            type="password"
+            autoComplete={mode === "signup" ? "new-password" : "current-password"}
+            required
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            minLength={6}
+            mt="1"
+          />
+        </div>
+        {mode === "signup" ? (
+          <div>
+            <Text as="label" htmlFor="auth-confirm-password" size="2" color="gray">
+              Confirm password
+            </Text>
+            <TextField.Root
+              id="auth-confirm-password"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              minLength={6}
+              mt="1"
+            />
+          </div>
+        ) : null}
+        <Text size="1" color="gray" as="p">
+          {legalCopy}
+          <LegalDocumentLink documentId="terms" onOpen={onOpenLegalDocument}>
+            Terms of Service
+          </LegalDocumentLink>
+          ,{" "}
+          <LegalDocumentLink documentId="license" onOpen={onOpenLegalDocument}>
+            License
+          </LegalDocumentLink>
+          , and{" "}
+          <LegalDocumentLink documentId="privacy" onOpen={onOpenLegalDocument}>
+            Privacy Policy
+          </LegalDocumentLink>
+          .
+        </Text>
+        {error ? (
+          <Text color="red" size="2">
+            {error}
+          </Text>
+        ) : null}
+        <Flex align="center" justify="between" mt="2">
+          <Text size="2" color="gray">
+            {mode === "signup" ? "Already have an account?" : "Need an account?"}
+          </Text>
+          <Button
+            type="button"
+            onClick={() => onModeChange(mode === "signup" ? "login" : "signup")}
+            variant="ghost"
+            size="2"
+          >
+            {mode === "signup" ? "Log in" : "Sign up"}
+          </Button>
+        </Flex>
+        <Flex gap="3" justify="end">
+          <Button type="button" variant="soft" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {mode === "signup" ? (isSubmitting ? "Creating..." : "Create account") : isSubmitting ? "Signing in..." : "Log in"}
+          </Button>
+        </Flex>
+      </Flex>
+    </form>
+  );
+}
+
+export function AuthDialog({ open, mode, onModeChange, onOpenChange, onAuthenticated }: AuthDialogProps) {
+  const [openLegalDocument, setOpenLegalDocument] = useState<LegalDocumentId | null>(null);
+
+  return (
     <>
       <Dialog.Root open={open} onOpenChange={onOpenChange}>
         <Dialog.Content size="3" style={{ maxWidth: 420 }}>
-          <Dialog.Title>{title}</Dialog.Title>
-          <Dialog.Description>{description}</Dialog.Description>
-          <form onSubmit={handleSubmit}>
-            <Flex direction="column" gap="3" mt="4">
-              <div>
-                <Text as="label" htmlFor="auth-email" size="2" color="gray">
-                  Email
-                </Text>
-                <TextField.Root
-                  id="auth-email"
-                  type="email"
-                  autoComplete="email"
-                  required
-                  value={email}
-                  onChange={(event) => setEmail(event.target.value)}
-                  placeholder="you@example.com"
-                  mt="1"
-                />
-              </div>
-              <div>
-                <Text as="label" htmlFor="auth-password" size="2" color="gray">
-                  Password
-                </Text>
-                <TextField.Root
-                  id="auth-password"
-                  type="password"
-                  autoComplete={mode === "signup" ? "new-password" : "current-password"}
-                  required
-                  value={password}
-                  onChange={(event) => setPassword(event.target.value)}
-                  minLength={6}
-                  mt="1"
-                />
-              </div>
-              {mode === "signup" ? (
-                <div>
-                  <Text as="label" htmlFor="auth-confirm-password" size="2" color="gray">
-                    Confirm password
-                  </Text>
-                  <TextField.Root
-                    id="auth-confirm-password"
-                    type="password"
-                    autoComplete="new-password"
-                    required
-                    value={confirmPassword}
-                    onChange={(event) => setConfirmPassword(event.target.value)}
-                    minLength={6}
-                    mt="1"
-                  />
-                </div>
-              ) : null}
-              <Text size="1" color="gray" as="p">
-                {legalCopy}
-                <LegalDocumentLink documentId="terms" onOpen={setOpenLegalDocument}>
-                  Terms of Service
-                </LegalDocumentLink>
-                ,{" "}
-                <LegalDocumentLink documentId="license" onOpen={setOpenLegalDocument}>
-                  License
-                </LegalDocumentLink>
-                , and{" "}
-                <LegalDocumentLink documentId="privacy" onOpen={setOpenLegalDocument}>
-                  Privacy Policy
-                </LegalDocumentLink>
-                .
-              </Text>
-              {error ? (
-                <Text color="red" size="2">
-                  {error}
-                </Text>
-              ) : null}
-              <Flex align="center" justify="between" mt="2">
-                <Text size="2" color="gray">
-                  {mode === "signup" ? "Already have an account?" : "Need an account?"}
-                </Text>
-                <Button
-                  type="button"
-                  onClick={() => onModeChange(mode === "signup" ? "login" : "signup")}
-                  variant="ghost"
-                  size="2"
-                >
-                  {mode === "signup" ? "Log in" : "Sign up"}
-                </Button>
-              </Flex>
-              <Flex gap="3" justify="end">
-                <Button type="button" variant="soft" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
-                  Cancel
-                </Button>
-                <Button type="submit" disabled={isSubmitting}>
-                  {mode === "signup" ? (isSubmitting ? "Creating..." : "Create account") : isSubmitting ? "Signing in..." : "Log in"}
-                </Button>
-              </Flex>
-            </Flex>
-          </form>
+          <Dialog.Title>{mode === "signup" ? "Sign up" : "Log in"}</Dialog.Title>
+          <Dialog.Description>
+            {mode === "signup"
+              ? "Create an account with your email and password to access the user dashboard."
+              : "Enter your email and password to access the user dashboard."}
+          </Dialog.Description>
+          <AuthDialogForm
+            key={mode}
+            mode={mode}
+            onModeChange={onModeChange}
+            onOpenChange={onOpenChange}
+            onAuthenticated={onAuthenticated}
+            onOpenLegalDocument={setOpenLegalDocument}
+          />
         </Dialog.Content>
       </Dialog.Root>
       <LegalDocumentDialog

--- a/frontend/src/components/Map3D.tsx
+++ b/frontend/src/components/Map3D.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from "react";
+import { forwardRef, useCallback, useEffect, useEffectEvent, useImperativeHandle, useRef } from "react";
 import type { UserThemeAppearance } from "@crowdpm/types";
 import { GoogleMapsOverlay } from "@deck.gl/google-maps";
 import { PathLayer } from "@deck.gl/layers";
@@ -840,11 +840,6 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
   const overlayRef = useRef<GoogleMapsOverlay | null>(null);
   const latestDataRef = useRef<MeasurementPoint[]>(data);
   const selectedIndexRef = useRef<number>(selectedIndex);
-  const onSelectRef = useRef<typeof onSelectIndex>(onSelectIndex);
-  const onSelectPointRef = useRef<typeof onSelectPoint>(onSelectPoint);
-  const onZoomChangeRef = useRef<typeof onZoomChange>(onZoomChange);
-  const showAllModeRef = useRef(showAllMode);
-  const playbackPathModeRef = useRef(playbackPathMode);
   const sphereGeometryRef = useRef<SphereGeometry | null>(null);
   const cameraStateRef = useRef<MapCameraState | null>(null);
   const hasUserControlRef = useRef(typeof defaultZoom === "number");
@@ -858,11 +853,6 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
 
   useEffect(() => { latestDataRef.current = data; }, [data]);
   useEffect(() => { selectedIndexRef.current = selectedIndex; }, [selectedIndex]);
-  useEffect(() => { onSelectRef.current = onSelectIndex; }, [onSelectIndex]);
-  useEffect(() => { onSelectPointRef.current = onSelectPoint; }, [onSelectPoint]);
-  useEffect(() => { onZoomChangeRef.current = onZoomChange; }, [onZoomChange]);
-  useEffect(() => { showAllModeRef.current = showAllMode; }, [showAllMode]);
-  useEffect(() => { playbackPathModeRef.current = playbackPathMode; }, [playbackPathMode]);
   useEffect(() => {
     const sig = signature(data);
     if (dataSignatureRef.current !== sig) {
@@ -875,6 +865,18 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
     hasUserControlRef.current = !forceFollowSelection;
   }, [forceFollowSelection]);
 
+  const handleSelectIndex = useEffectEvent((index: number) => {
+    onSelectIndex?.(index);
+  });
+
+  const handleSelectPoint = useEffectEvent((point: MeasurementPoint) => {
+    onSelectPoint?.(point);
+  });
+
+  const emitZoomChange = useEffectEvent((zoom: number) => {
+    onZoomChange?.(zoom);
+  });
+
   const syncOverlay = useCallback((options?: { forceCenter?: boolean }) => {
     const overlay = overlayRef.current;
     if (!overlay) return;
@@ -886,8 +888,8 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       layers: createLayers(
         latestDataRef.current,
         selectedIndexRef.current,
-        (index) => onSelectRef.current?.(index),
-        (point) => onSelectPointRef.current?.(point),
+        handleSelectIndex,
+        handleSelectPoint,
         sphereGeometryRef.current,
         showAllMode,
         playbackPathMode
@@ -1042,16 +1044,16 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       mapRef.current = map;
 
       const markUserControl = () => { hasUserControlRef.current = true; };
-      const handleZoomChange = () => {
+      const handleMapZoomChange = () => {
         markUserControl();
         const zoom = map.getZoom();
         if (typeof zoom === "number" && Number.isFinite(zoom)) {
-          onZoomChangeRef.current?.(zoom);
+          emitZoomChange(zoom);
         }
       };
       listeners = [
         map.addListener("dragstart", markUserControl),
-        map.addListener("zoom_changed", handleZoomChange),
+        map.addListener("zoom_changed", handleMapZoomChange),
         map.addListener("tilt_changed", markUserControl),
         map.addListener("heading_changed", markUserControl)
       ];
@@ -1077,11 +1079,11 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
         layers: createLayers(
           currentSeries,
           selectedIndexRef.current,
-          (index) => onSelectRef.current?.(index),
-          (point) => onSelectPointRef.current?.(point),
+          handleSelectIndex,
+          handleSelectPoint,
           sphereGeometry,
-          showAllModeRef.current,
-          playbackPathModeRef.current
+          showAllMode,
+          playbackPathMode
         ),
         interleaved
       });
@@ -1132,7 +1134,7 @@ const Map3D = forwardRef<Map3DHandle, Map3DProps>(function Map3D({
       if (overlayRef.current === localOverlay) overlayRef.current = null;
       if (mapRef.current === localMap) mapRef.current = null;
     };
-  }, [appearance, defaultCenterLat, defaultCenterLng, interleaved]);
+  }, [appearance, defaultCenterLat, defaultCenterLng, interleaved, playbackPathMode, showAllMode]);
 
   return <div ref={divRef} style={{ width: "100%", height: "100%" }} />;
 });

--- a/frontend/src/pages/ActivationPage.tsx
+++ b/frontend/src/pages/ActivationPage.tsx
@@ -43,7 +43,7 @@ function formatDuration(ms: number): string {
 export function ActivationPage({ layout = "standalone", onActivationComplete }: ActivationPageProps = {}) {
   const { user, isLoading: isAuthLoading } = useAuth();
   const location = useBrowserLocation();
-  const [authDialogOpen, setAuthDialogOpen] = useState(false);
+  const [authDialogRequested, setAuthDialogRequested] = useState(false);
   const [authMode, setAuthMode] = useState<AuthMode>("login");
 
   const [userCode, setUserCode] = useState(() => readCodeFromSearch(location.search));
@@ -53,16 +53,10 @@ export function ActivationPage({ layout = "standalone", onActivationComplete }: 
   const [error, setError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
-  const initialCodeRef = useRef(userCode.trim());
+  const [initialCode] = useState(() => readCodeFromSearch(location.search).trim());
   const hasAutoLookupRef = useRef(false);
   const hasCompletedRef = useRef(false);
-
-  useEffect(() => {
-    if (!user && !authDialogOpen) {
-      setAuthMode("login");
-      setAuthDialogOpen(true);
-    }
-  }, [user, authDialogOpen]);
+  const isAuthDialogOpen = !user || authDialogRequested;
 
   useEffect(() => {
     if (!session) return;
@@ -100,9 +94,7 @@ export function ActivationPage({ layout = "standalone", onActivationComplete }: 
     }
   }, [userCode]);
 
-  const matchesInitialCode = useMemo(() => {
-    return initialCodeRef.current.length > 0 && initialCodeRef.current === userCode.trim();
-  }, [userCode]);
+  const matchesInitialCode = initialCode.length > 0 && initialCode === userCode.trim();
 
   useEffect(() => {
     if (!user || !matchesInitialCode || session || isLoading || hasAutoLookupRef.current) return;
@@ -237,7 +229,7 @@ export function ActivationPage({ layout = "standalone", onActivationComplete }: 
               {isLoading ? "Looking up…" : "Load device"}
             </Button>
             {!user ? (
-              <Button variant="soft" onClick={() => setAuthDialogOpen(true)} disabled={isAuthLoading}>
+              <Button variant="soft" onClick={() => setAuthDialogRequested(true)} disabled={isAuthLoading}>
                 {isAuthLoading ? "Checking account…" : "Sign in"}
               </Button>
             ) : (
@@ -339,12 +331,12 @@ export function ActivationPage({ layout = "standalone", onActivationComplete }: 
       ) : null}
 
       <AuthDialog
-        open={authDialogOpen}
+        open={isAuthDialogOpen}
         mode={authMode}
         onModeChange={setAuthMode}
-        onOpenChange={setAuthDialogOpen}
+        onOpenChange={setAuthDialogRequested}
         onAuthenticated={() => {
-          setAuthDialogOpen(false);
+          setAuthDialogRequested(false);
           setStatusMessage("Signed in. You can now authorize the device.");
         }}
       />

--- a/frontend/src/pages/AdminModerationPage.tsx
+++ b/frontend/src/pages/AdminModerationPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { timestampToMillis } from "@crowdpm/types";
 import {
@@ -146,8 +146,8 @@ export default function AdminModerationPage() {
 
   const [moderationFilter, setModerationFilter] = useState<SubmissionFilterState>("all");
   const [visibilityFilter, setVisibilityFilter] = useState<VisibilityFilterState>("all");
-  const [submissionPageIndex, setSubmissionPageIndex] = useState(0);
-  const [userPageIndex, setUserPageIndex] = useState(0);
+  const [submissionPageIndexInput, setSubmissionPageIndexInput] = useState(0);
+  const [userPageIndexInput, setUserPageIndexInput] = useState(0);
   const [pendingConfirmation, setPendingConfirmation] = useState<PendingConfirmation | null>(null);
   const [confirmationReason, setConfirmationReason] = useState("");
 
@@ -201,6 +201,8 @@ export default function AdminModerationPage() {
     ?? (demoBatchOptionsQuery.error instanceof Error ? demoBatchOptionsQuery.error.message : null);
   const userError = userActionError
     ?? (usersQuery.error instanceof Error ? usersQuery.error.message : null);
+  const submissionPageIndex = clampPageIndex(submissions.length, submissionPageIndexInput);
+  const userPageIndex = clampPageIndex(users.length, userPageIndexInput);
   const submissionPagination = useMemo(
     () => getPaginationWindow(submissions.length, submissionPageIndex),
     [submissionPageIndex, submissions.length],
@@ -236,25 +238,11 @@ export default function AdminModerationPage() {
     const nextToken = nextPageToken ?? null;
     if (nextToken !== usersPageTokenInput) {
       setUsersPageTokenInput(nextToken);
-      setUserPageIndex(0);
+      setUserPageIndexInput(0);
       return;
     }
     await usersQuery.refetch();
   }, [canManageUsers, usersPageTokenInput, usersQuery]);
-
-  useEffect(() => {
-    const nextPageIndex = clampPageIndex(submissions.length, submissionPageIndex);
-    if (nextPageIndex !== submissionPageIndex) {
-      setSubmissionPageIndex(nextPageIndex);
-    }
-  }, [submissionPageIndex, submissions.length]);
-
-  useEffect(() => {
-    const nextPageIndex = clampPageIndex(users.length, userPageIndex);
-    if (nextPageIndex !== userPageIndex) {
-      setUserPageIndex(nextPageIndex);
-    }
-  }, [userPageIndex, users.length]);
 
   const handleModerationChange = useCallback((entry: AdminSubmissionSummary, moderationState: ModerationState) => {
     if (!canAccessAdmin) return;
@@ -466,8 +454,8 @@ export default function AdminModerationPage() {
               pageStart={submissionPagination.pageStart}
               pageEnd={submissionPagination.pageEnd}
               totalCount={submissions.length}
-              onShowLess={() => setSubmissionPageIndex((current) => clampPageIndex(submissions.length, current - 1))}
-              onShowMore={() => setSubmissionPageIndex((current) => clampPageIndex(submissions.length, current + 1))}
+              onShowLess={() => setSubmissionPageIndexInput((current) => current - 1)}
+              onShowMore={() => setSubmissionPageIndexInput((current) => current + 1)}
             />
           </Flex>
           <Flex gap="3" wrap="wrap" align="end">
@@ -567,8 +555,8 @@ export default function AdminModerationPage() {
                 pageStart={userPagination.pageStart}
                 pageEnd={userPagination.pageEnd}
                 totalCount={users.length}
-                onShowLess={() => setUserPageIndex((current) => clampPageIndex(users.length, current - 1))}
-                onShowMore={() => setUserPageIndex((current) => clampPageIndex(users.length, current + 1))}
+                onShowLess={() => setUserPageIndexInput((current) => current - 1)}
+                onShowMore={() => setUserPageIndexInput((current) => current + 1)}
               />
             </Flex>
             <Flex gap="3" wrap="wrap" align="center">

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, startTransition, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { timestampToMillis, type IngestPoint, type UserThemeAppearance } from "@crowdpm/types";
 import { Button, Dialog, Flex, Select, Switch, Text } from "@radix-ui/themes";
@@ -22,10 +22,10 @@ import {
   MAX_PERSISTED_MAP_ZOOM,
   MIN_PERSISTED_MAP_ZOOM,
   normalizeStoredBatchSelection,
+  parseStoredTimelineIndexes,
   parseStoredMapZoom,
-  readStoredTimelineIndex,
   SHOW_ALL_PUBLIC_24H_KEY,
-  writeStoredTimelineIndex,
+  type StoredTimelineIndexes,
 } from "../lib/mapSelection";
 import {
   detectCanvasVideoExportSupport,
@@ -443,24 +443,43 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     () => scopedStorageKey(MAP_SELECTION_STORAGE_KEYS.lastTimelineIndex, user?.uid ?? undefined),
     [user?.uid]
   );
+  const [initialStoredSelection] = useState(() => normalizeStoredBatchSelection(safeLocalStorageGet(
+    userScopedSelectionKey,
+    null,
+    { context: "map:selected-batch:init", userId: user?.uid }
+  )));
+  const [initialStoredZoom] = useState(() => {
+    const rawValue = safeLocalStorageGet(
+      userScopedZoomKey,
+      null,
+      { context: "map:zoom:init", userId: user?.uid }
+    );
+    const parsedValue = parseStoredMapZoom(rawValue);
+    return {
+      value: parsedValue,
+      shouldClearInvalid: rawValue !== null && parsedValue === null,
+    };
+  });
 
   // Keep track of which batch is selected plus the position in the measurement timeline.
-  const [selectedBatchKey, setSelectedBatchKey] = useState<string>("");
+  const [selectedBatchKeyState, setSelectedBatchKeyState] = useState<string>(initialStoredSelection.value);
   const [isDemoBatchLoading, setDemoBatchLoading] = useState(false);
-  const [persistedMapZoom, setPersistedMapZoom] = useState<number | null>(null);
-  const [zoomHydrationKey, setZoomHydrationKey] = useState<string | null>(null);
+  const [persistedMapZoom, setPersistedMapZoom] = useState<number | null>(initialStoredZoom.value);
+  const [storedTimelineIndexes, setStoredTimelineIndexes] = useState<StoredTimelineIndexes>(() => parseStoredTimelineIndexes(
+    safeLocalStorageGet(
+      userScopedTimelineKey,
+      null,
+      { context: "map:timeline:init", userId: user?.uid }
+    )
+  ));
   const [isBatchBrowserOpen, setBatchBrowserOpen] = useState(false);
-  const [batchBrowserPageIndex, setBatchBrowserPageIndex] = useState(0);
+  const [batchBrowserPageIndexInput, setBatchBrowserPageIndexInput] = useState(0);
   const [batchBrowserTimeRange, setBatchBrowserTimeRange] = useState<BatchBrowserTimeRange>("all");
   const [showPublicBatchBrowser, setShowPublicBatchBrowser] = useState(true);
   const [showPrivateBatchBrowser, setShowPrivateBatchBrowser] = useState(true);
-  const selectionHydratedRef = useRef<string | null>(null);
-  const zoomHydratedRef = useRef<string | null>(null);
-  const timelineHydratedRef = useRef<string | null>(null);
-  const skipIndexResetRef = useRef(false);
   const map3DRef = useRef<Map3DHandle | null>(null);
   const exportAbortRef = useRef<AbortController | null>(null);
-  const [captureAvailable, setCaptureAvailable] = useState(false);
+  const [captureAvailableState, setCaptureAvailableState] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [exportProgress, setExportProgress] = useState(0);
   const [exportError, setExportError] = useState<string | null>(null);
@@ -471,7 +490,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
   const [isVideoExportSettingsOpen, setVideoExportSettingsOpen] = useState(false);
   const [videoExportSettings, setVideoExportSettings] = useState<VideoExportSettings>(DEFAULT_VIDEO_EXPORT_SETTINGS);
   const recordingSupport = useMemo(() => detectCanvasVideoExportSupport(), []);
-  const [isMapViewportActivated, setMapViewportActivated] = useState(false);
+  const [transientSelectedIndex, setTransientSelectedIndex] = useState<number | null>(null);
 
   const loadBatchSummaries = useCallback(async (ownedLimit?: number, publicLimit?: number) => {
     if (!user) {
@@ -483,6 +502,22 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     ]);
     return mergeBatchLists(owned, publicBatches);
   }, [user]);
+
+  useEffect(() => {
+    if (!initialStoredSelection.shouldClearInvalid) return;
+    safeLocalStorageRemove(
+      userScopedSelectionKey,
+      { context: "map:selected-batch:clear-invalid", userId: user?.uid }
+    );
+  }, [initialStoredSelection.shouldClearInvalid, user?.uid, userScopedSelectionKey]);
+
+  useEffect(() => {
+    if (!initialStoredZoom.shouldClearInvalid) return;
+    safeLocalStorageRemove(
+      userScopedZoomKey,
+      { context: "map:zoom:clear-invalid", userId: user?.uid }
+    );
+  }, [initialStoredZoom.shouldClearInvalid, user?.uid, userScopedZoomKey]);
 
   // Query #1: list of batches visible to the user.
   const batchesQuery = useQuery<VisibleBatchSummary[]>({
@@ -525,6 +560,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
       return processedAtMs !== null && processedAtMs >= cutoff;
     });
   }, [batchBrowserBatches, batchBrowserTimeRange, showPrivateBatchBrowser, showPublicBatchBrowser]);
+  const batchBrowserPageIndex = clampPageIndex(filteredBatchBrowserBatches.length, batchBrowserPageIndexInput);
   const batchBrowserPagination = useMemo(
     () => getPaginationWindow(filteredBatchBrowserBatches.length, batchBrowserPageIndex),
     [filteredBatchBrowserBatches.length, batchBrowserPageIndex]
@@ -534,37 +570,38 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     [batchBrowserPagination.pageEnd, batchBrowserPagination.pageStart, filteredBatchBrowserBatches]
   );
 
-  const selectedSummary = useMemo(() => {
-    if (!selectedBatchKey) return null;
-    const parsed = decodeBatchKey(selectedBatchKey);
+  const selectedBatchParsedForBrowser = useMemo(
+    () => decodeBatchKey(selectedBatchKeyState),
+    [selectedBatchKeyState]
+  );
+  const hasMissingSelectedBatch = Boolean(
+    isBatchBrowserOpen
+    && batchBrowserQuery.isSuccess
+    && !batchBrowserQuery.isFetching
+    && selectedBatchKeyState
+    && selectedBatchKeyState !== SHOW_ALL_PUBLIC_24H_KEY
+    && selectedBatchParsedForBrowser
+    && !(batchBrowserQuery.data ?? []).some((batch) => (
+      batch.deviceId === selectedBatchParsedForBrowser.deviceId
+      && batch.batchId === selectedBatchParsedForBrowser.batchId
+    ))
+  );
+  const selectedBatchKeyAfterBrowserValidation = hasMissingSelectedBatch ? "" : selectedBatchKeyState;
+  const querySelectedSummary = useMemo(() => {
+    if (!selectedBatchKeyAfterBrowserValidation) return null;
+    const parsed = decodeBatchKey(selectedBatchKeyAfterBrowserValidation);
     if (!parsed) return null;
     return batchBrowserBatches.find((batch) => batch.deviceId === parsed.deviceId && batch.batchId === parsed.batchId) ?? null;
-  }, [batchBrowserBatches, selectedBatchKey]);
-  const dropdownBatches = useMemo(() => {
-    if (!selectedSummary) return visibleBatches;
-    const exists = visibleBatches.some((batch) => (
-      batch.deviceId === selectedSummary.deviceId && batch.batchId === selectedSummary.batchId
-    ));
-    if (exists) return visibleBatches;
-    return sortBatchesByProcessedAtDesc([selectedSummary, ...visibleBatches]);
-  }, [selectedSummary, visibleBatches]);
-  const visibleDropdownBatches = useMemo(() => {
-    if (!selectedSummary) return dropdownBatches.slice(0, DROPDOWN_BATCH_LIMIT);
-    const prioritized = [
-      selectedSummary,
-      ...dropdownBatches.filter((batch) => (
-        batch.deviceId !== selectedSummary.deviceId || batch.batchId !== selectedSummary.batchId
-      )),
-    ];
-    return prioritized.slice(0, DROPDOWN_BATCH_LIMIT);
-  }, [dropdownBatches, selectedSummary]);
+  }, [batchBrowserBatches, selectedBatchKeyAfterBrowserValidation]);
 
   const batchDetailQueryKey = useMemo(
-    () => (selectedBatchKey ? BATCH_DETAIL_QUERY_KEY(user?.uid ?? "public", selectedBatchKey) : null),
-    [selectedBatchKey, user]
+    () => (selectedBatchKeyAfterBrowserValidation
+      ? BATCH_DETAIL_QUERY_KEY(user?.uid ?? "public", selectedBatchKeyAfterBrowserValidation)
+      : null),
+    [selectedBatchKeyAfterBrowserValidation, user]
   );
-  const isShowingAllPublic24h = selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY;
-  const selectedBatchAccess = selectedSummary?.access ?? "unknown";
+  const isShowingAllPublic24h = selectedBatchKeyAfterBrowserValidation === SHOW_ALL_PUBLIC_24H_KEY;
+  const selectedBatchAccess = querySelectedSummary?.access ?? "unknown";
 
   // Query #2: measurement detail for the currently selected batch.
   const measurementQuery = useQuery<MapMeasurementRecord[]>({
@@ -576,8 +613,8 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     },
     retryDelay: 1_500,
     queryFn: async () => {
-      if (!batchDetailQueryKey || !selectedBatchKey) return [];
-      if (selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY) {
+      if (!batchDetailQueryKey || !selectedBatchKeyAfterBrowserValidation) return [];
+      if (selectedBatchKeyAfterBrowserValidation === SHOW_ALL_PUBLIC_24H_KEY) {
         const cutoff = Date.now() - SHOW_ALL_PUBLIC_LOOKBACK_MS;
         const cutoffIso = new Date(Math.floor(cutoff / 60_000) * 60_000).toISOString();
         const mapResponse = await fetchPublicBatchMap({
@@ -597,7 +634,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
           .sort((a, b) => (timestampToMillis(a.timestamp) ?? 0) - (timestampToMillis(b.timestamp) ?? 0));
       }
 
-      const parsed = decodeBatchKey(selectedBatchKey);
+      const parsed = decodeBatchKey(selectedBatchKeyAfterBrowserValidation);
       if (!parsed) return [];
 
       const loadPublicDetail = () => fetchPublicBatchDetail(parsed.deviceId, parsed.batchId);
@@ -624,187 +661,105 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
 
         return loadOwnedDetail();
       })();
-      return pointsToMeasurementRecords(detail.points, detail.deviceId, detail.batchId, { batchKey: selectedBatchKey });
+      return pointsToMeasurementRecords(detail.points, detail.deviceId, detail.batchId, { batchKey: selectedBatchKeyAfterBrowserValidation });
     },
     retryOnMount: false,
     throwOnError: false,
-    placeholderData: (prev) => prev ?? [],
+    placeholderData: (prev) => selectedBatchKeyAfterBrowserValidation ? prev ?? [] : [],
   });
+  const hasTerminalSelectedBatchError = Boolean(
+    !isAuthLoading
+    && selectedBatchKeyAfterBrowserValidation
+    && selectedBatchKeyAfterBrowserValidation !== SHOW_ALL_PUBLIC_24H_KEY
+    && measurementQuery.isError
+    && !measurementQuery.isFetching
+    && !measurementQuery.isLoading
+    && isTerminalBatchError(measurementQuery.error)
+  );
+  const selectedBatchKey = hasTerminalSelectedBatchError ? "" : selectedBatchKeyAfterBrowserValidation;
+  const selectedSummary = hasTerminalSelectedBatchError ? null : querySelectedSummary;
+  const dropdownBatches = useMemo(() => {
+    if (!selectedSummary) return visibleBatches;
+    const exists = visibleBatches.some((batch) => (
+      batch.deviceId === selectedSummary.deviceId && batch.batchId === selectedSummary.batchId
+    ));
+    if (exists) return visibleBatches;
+    return sortBatchesByProcessedAtDesc([selectedSummary, ...visibleBatches]);
+  }, [selectedSummary, visibleBatches]);
+  const visibleDropdownBatches = useMemo(() => {
+    if (!selectedSummary) return dropdownBatches.slice(0, DROPDOWN_BATCH_LIMIT);
+    const prioritized = [
+      selectedSummary,
+      ...dropdownBatches.filter((batch) => (
+        batch.deviceId !== selectedSummary.deviceId || batch.batchId !== selectedSummary.batchId
+      )),
+    ];
+    return prioritized.slice(0, DROPDOWN_BATCH_LIMIT);
+  }, [dropdownBatches, selectedSummary]);
 
   const rows = useMemo(
-    () => measurementQuery.data ?? [],
-    [measurementQuery.data]
+    () => selectedBatchKey ? measurementQuery.data ?? [] : [],
+    [measurementQuery.data, selectedBatchKey]
   );
 
   const isLoadingBatch = measurementQuery.isFetching || measurementQuery.isLoading;
-  const queryError = batchesQuery.error || measurementQuery.error;
-
-  // Whenever a new batch or fresh data arrives, snap the slider to the latest point.
-  // useEffect(() => {
-  //   const newIndex = rows.length ? rows.length - 1 : 0;
-  //   setSelectedIndex(newIndex);
-  //   // This effect synchronizes state with data changes - intentional pattern
-  //   // eslint-disable-next-line react-hooks/set-state-in-effect
-  // }, [rows.length, selectedBatchKey]);
-  const [indexOverride, setIndexOverride] = useState<number | null>(null);
-
-  // Always derive the index
-  const selectedIndex = indexOverride ?? (rows.length ? rows.length - 1 : 0);
+  const queryError = batchesQuery.error || (selectedBatchKey ? measurementQuery.error : null);
+  const persistedSelectedIndex = useMemo(() => {
+    if (!rows.length) return 0;
+    if (!selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY) {
+      return rows.length - 1;
+    }
+    const storedIndex = storedTimelineIndexes[selectedBatchKey];
+    if (typeof storedIndex === "number" && Number.isFinite(storedIndex)) {
+      return clampTimelineIndex(storedIndex, rows.length - 1);
+    }
+    return rows.length - 1;
+  }, [rows.length, selectedBatchKey, storedTimelineIndexes]);
+  const selectedIndex = transientSelectedIndex === null
+    ? persistedSelectedIndex
+    : clampTimelineIndex(transientSelectedIndex, Math.max(rows.length - 1, 0));
   const [trackBall, setTrackBall] = useState(true);
 
   useEffect(() => {
-    if (skipIndexResetRef.current) {
-      skipIndexResetRef.current = false;
-      timelineHydratedRef.current = null;
-      return;
-    }
-    if (!selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY) {
-      timelineHydratedRef.current = null;
-      setIndexOverride(null);
-      return;
-    }
-    if (!rows.length) return;
-
-    const hydrationKey = `${userScopedTimelineKey}:${selectedBatchKey}:${rows.length}`;
-    if (timelineHydratedRef.current === hydrationKey) return;
-    timelineHydratedRef.current = hydrationKey;
-
-    const storedIndex = readStoredTimelineIndex(
-      safeLocalStorageGet(
-        userScopedTimelineKey,
-        null,
-        { context: "map:timeline:read", userId: user?.uid }
-      ),
-      selectedBatchKey,
-      rows.length - 1
-    );
-    if (storedIndex !== null) {
-      setIndexOverride(storedIndex);
-      return;
-    }
-
-    setIndexOverride(null);
-  }, [rows.length, selectedBatchKey, user?.uid, userScopedTimelineKey]);
-
-  useEffect(() => {
-    const nextPageIndex = clampPageIndex(filteredBatchBrowserBatches.length, batchBrowserPageIndex);
-    if (nextPageIndex !== batchBrowserPageIndex) {
-      setBatchBrowserPageIndex(nextPageIndex);
-    }
-  }, [filteredBatchBrowserBatches.length, batchBrowserPageIndex]);
-
-  useEffect(() => {
-    setBatchBrowserPageIndex(0);
-  }, [batchBrowserTimeRange, showPrivateBatchBrowser, showPublicBatchBrowser]);
-
-  useEffect(() => {
-    if (isAuthLoading) return;
-    if (selectionHydratedRef.current === userScopedSelectionKey) return;
-    selectionHydratedRef.current = userScopedSelectionKey;
-
-    const storedSelection = normalizeStoredBatchSelection(safeLocalStorageGet(
-      userScopedSelectionKey,
-      null,
-      { context: "map:selected-batch:hydrate", userId: user?.uid }
-    ));
-    setSelectedBatchKey(storedSelection.value);
-    if (storedSelection.shouldClearInvalid) {
+    if (!hasMissingSelectedBatch) return;
+    queueMicrotask(() => {
+      setSelectedBatchKeyState("");
+      setTransientSelectedIndex(null);
       safeLocalStorageRemove(
         userScopedSelectionKey,
-        { context: "map:selected-batch:clear-invalid", userId: user?.uid }
+        { context: "map:selected-batch:clear-missing", userId: user?.uid }
       );
-    }
-  }, [isAuthLoading, user?.uid, userScopedSelectionKey]);
+    });
+  }, [hasMissingSelectedBatch, user?.uid, userScopedSelectionKey]);
 
   useEffect(() => {
-    if (isAuthLoading) return;
-    if (zoomHydratedRef.current === userScopedZoomKey) return;
-    zoomHydratedRef.current = userScopedZoomKey;
-
-    const storedZoom = parseStoredMapZoom(safeLocalStorageGet(
-      userScopedZoomKey,
-      null,
-      { context: "map:zoom:hydrate", userId: user?.uid }
-    ));
-    setPersistedMapZoom(storedZoom);
-    setZoomHydrationKey(userScopedZoomKey);
-    if (storedZoom === null) {
+    if (!hasTerminalSelectedBatchError) return;
+    queueMicrotask(() => {
+      setSelectedBatchKeyState("");
+      setTransientSelectedIndex(null);
       safeLocalStorageRemove(
-        userScopedZoomKey,
-        { context: "map:zoom:clear-invalid", userId: user?.uid }
+        userScopedSelectionKey,
+        { context: "map:selected-batch:clear-terminal-error", userId: user?.uid }
       );
-    }
-  }, [isAuthLoading, user?.uid, userScopedZoomKey]);
+    });
+  }, [hasTerminalSelectedBatchError, user?.uid, userScopedSelectionKey]);
 
-  useEffect(() => {
-    if (
-      isAuthLoading
-      || !isBatchBrowserOpen
-      || !batchBrowserQuery.isSuccess
-      || batchBrowserQuery.isFetching
-    ) {
-      return;
-    }
-    if (!selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY) return;
-
-    const parsed = decodeBatchKey(selectedBatchKey);
-    const selectionExists = parsed
-      ? (batchBrowserQuery.data ?? []).some((batch) => batch.deviceId === parsed.deviceId && batch.batchId === parsed.batchId)
-      : false;
-
-    if (selectionExists) return;
-
-    setSelectedBatchKey("");
-    setIndexOverride(0);
-    safeLocalStorageRemove(
-      userScopedSelectionKey,
-      { context: "map:selected-batch:clear-missing", userId: user?.uid }
+  const persistTimelineIndex = useCallback((batchKey: string, index: number, context: string) => {
+    const nextIndexes = {
+      ...storedTimelineIndexes,
+      [batchKey]: index,
+    };
+    setStoredTimelineIndexes(nextIndexes);
+    safeLocalStorageSet(
+      userScopedTimelineKey,
+      JSON.stringify(nextIndexes),
+      { context, userId: user?.uid }
     );
-  }, [
-    batchBrowserQuery.data,
-    batchBrowserQuery.isFetching,
-    batchBrowserQuery.isSuccess,
-    isBatchBrowserOpen,
-    isAuthLoading,
-    selectedBatchKey,
-    user?.uid,
-    userScopedSelectionKey,
-  ]);
-
-  useEffect(() => {
-    if (isAuthLoading || !selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY) return;
-    if (measurementQuery.isFetching || measurementQuery.isLoading || !measurementQuery.isError) return;
-    if (!isTerminalBatchError(measurementQuery.error)) return;
-
-    setSelectedBatchKey("");
-    setIndexOverride(0);
-    safeLocalStorageRemove(
-      userScopedSelectionKey,
-      { context: "map:selected-batch:clear-terminal-error", userId: user?.uid }
-    );
-  }, [
-    isAuthLoading,
-    measurementQuery.error,
-    measurementQuery.isError,
-    measurementQuery.isFetching,
-    measurementQuery.isLoading,
-    selectedBatchKey,
-    user?.uid,
-    userScopedSelectionKey,
-  ]);
-
-  // // Reset override when data changes
-  // useEffect(() => {
-  //   setIndexOverride(null);
-  // }, [selectedBatchKey, rows.length]);
+  }, [storedTimelineIndexes, user?.uid, userScopedTimelineKey]);
 
   const handleBatchSelect = useCallback((value: string) => {
-    if (value && !isMapViewportActivated) {
-      startTransition(() => {
-        setMapViewportActivated(true);
-      });
-    }
-    setSelectedBatchKey(value);
+    setSelectedBatchKeyState(value);
+    setTransientSelectedIndex(null);
     if (value) {
       safeLocalStorageSet(
         userScopedSelectionKey,
@@ -818,7 +773,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
         { context: "map:selected-batch:clear", userId: user?.uid }
       );
     }
-  }, [isMapViewportActivated, user?.uid, userScopedSelectionKey]);
+  }, [user?.uid, userScopedSelectionKey]);
 
   const upsertBatchSummary = useCallback((summary: VisibleBatchSummary) => {
     const mergeSummaries = (prev: VisibleBatchSummary[] = []) => {
@@ -867,27 +822,29 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
   const handleTimelineIndexChange = useCallback((nextIndex: number) => {
     const maxIndex = Math.max(rows.length - 1, 0);
     const clampedIndex = clampTimelineIndex(nextIndex, maxIndex);
-    setIndexOverride(clampedIndex);
-
+    setTransientSelectedIndex(null);
     if (!selectedBatchKey || selectedBatchKey === SHOW_ALL_PUBLIC_24H_KEY || !rows.length) return;
-    safeLocalStorageSet(
-      userScopedTimelineKey,
-      writeStoredTimelineIndex(
-        safeLocalStorageGet(
-          userScopedTimelineKey,
-          null,
-          { context: "map:timeline:read", userId: user?.uid }
-        ),
-        selectedBatchKey,
-        clampedIndex
-      ),
-      { context: "map:timeline:update", userId: user?.uid }
-    );
-  }, [rows.length, selectedBatchKey, user?.uid, userScopedTimelineKey]);
+    persistTimelineIndex(selectedBatchKey, clampedIndex, "map:timeline:update");
+  }, [persistTimelineIndex, rows.length, selectedBatchKey]);
 
   const openBatchBrowser = useCallback(() => {
-    setBatchBrowserPageIndex(0);
+    setBatchBrowserPageIndexInput(0);
     setBatchBrowserOpen(true);
+  }, []);
+
+  const handleBatchBrowserTimeRangeChange = useCallback((value: string) => {
+    setBatchBrowserTimeRange(value as BatchBrowserTimeRange);
+    setBatchBrowserPageIndexInput(0);
+  }, []);
+
+  const handleShowPublicBatchBrowserChange = useCallback((checked: boolean) => {
+    setShowPublicBatchBrowser(checked);
+    setBatchBrowserPageIndexInput(0);
+  }, []);
+
+  const handleShowPrivateBatchBrowserChange = useCallback((checked: boolean) => {
+    setShowPrivateBatchBrowser(checked);
+    setBatchBrowserPageIndexInput(0);
   }, []);
 
   const handleBatchSelectValueChange = useCallback((value: string) => {
@@ -905,33 +862,18 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
   const handleMapPointSelect = useCallback((point: { batchKey?: string; batchPointIndex?: number }) => {
     if (!isShowingAllPublic24h) return;
     if (!point.batchKey) return;
-    skipIndexResetRef.current = true;
-    setSelectedBatchKey(point.batchKey);
+    setSelectedBatchKeyState(point.batchKey);
+    setTransientSelectedIndex(null);
     const pointIndex = typeof point.batchPointIndex === "number" ? point.batchPointIndex : null;
-    setIndexOverride(pointIndex);
     if (pointIndex !== null) {
-      safeLocalStorageSet(
-        userScopedTimelineKey,
-        writeStoredTimelineIndex(
-          safeLocalStorageGet(
-            userScopedTimelineKey,
-            null,
-            { context: "map:timeline:read-from-all", userId: user?.uid }
-          ),
-          point.batchKey,
-          pointIndex
-        ),
-        { context: "map:timeline:update-from-all", userId: user?.uid }
-      );
+      persistTimelineIndex(point.batchKey, pointIndex, "map:timeline:update-from-all");
     }
-    if (user) {
-      safeLocalStorageSet(
-        userScopedSelectionKey,
-        point.batchKey,
-        { context: "map:selected-batch:from-all", userId: user.uid }
-      );
-    }
-  }, [isShowingAllPublic24h, user, userScopedSelectionKey, userScopedTimelineKey]);
+    safeLocalStorageSet(
+      userScopedSelectionKey,
+      point.batchKey,
+      { context: "map:selected-batch:from-all", userId: user?.uid }
+    );
+  }, [isShowingAllPublic24h, persistTimelineIndex, user?.uid, userScopedSelectionKey]);
 
   const data = useMemo(
     () => {
@@ -979,9 +921,9 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
   // Use all-public mode by default when nothing is selected, but defer the heavy 3D viewport on the anonymous hero.
   const effectiveShowAllMode = isShowingAllPublic24h || !selectedBatchKey;
   const isAnonymousHeroState = !user && !selectedBatchKey && !rows.length;
-  const shouldRenderMapViewport = isMapViewportActivated || !isAnonymousHeroState;
-  const isMapZoomHydrated = !isAuthLoading && zoomHydrationKey === userScopedZoomKey;
+  const shouldRenderMapViewport = !isAnonymousHeroState;
   const isExportSectionVisible = Boolean(selectedBatchKey) && !isShowingAllPublic24h;
+  const captureAvailable = isExportSectionVisible && captureAvailableState;
   const isWatermarkedExport = settings.subscription.videoDownloadAccess === "preview_watermarked";
   const canExportSelection = useMemo(() => {
     if (!selectedBatchKey || isShowingAllPublic24h) return false;
@@ -1012,21 +954,11 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
   const shouldShowMeasurementSection = rows.length > 0 || Boolean(selectedBatchKey && isLoadingBatch);
 
   useEffect(() => {
-    if (isAnonymousHeroState || isMapViewportActivated) return;
-    startTransition(() => {
-      setMapViewportActivated(true);
-    });
-  }, [isAnonymousHeroState, isMapViewportActivated]);
-
-  useEffect(() => {
-    if (!isExportSectionVisible) {
-      setCaptureAvailable(false);
-      return;
-    }
+    if (!isExportSectionVisible) return;
 
     const updateCaptureAvailability = () => {
       const canvas = map3DRef.current?.getCaptureCanvas() ?? null;
-      setCaptureAvailable(Boolean(canvas));
+      setCaptureAvailableState(Boolean(canvas));
     };
 
     updateCaptureAvailability();
@@ -1064,7 +996,6 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
       return;
     }
 
-    const previousIndex = selectedIndex;
     const pointCount = rows.length;
     const lastIndex = Math.max(pointCount - 1, 0);
     const exportSettings = videoExportSettings;
@@ -1091,7 +1022,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     setExportStatus("Preparing active map capture...");
     setVideoExportSettingsOpen(false);
     setIsExporting(true);
-    setIndexOverride(0);
+    setTransientSelectedIndex(0);
     exportAbortRef.current = abortController;
 
     try {
@@ -1206,7 +1137,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
         }
 
         completedMotionMs += targetSegmentDurationMs;
-        setIndexOverride(nextIndex);
+        setTransientSelectedIndex(nextIndex);
         applyExportCameraFrame(nextIndex, nextIndex, 1, Math.min((exportSettings.holdMs + completedMotionMs) / plannedDurationMs, 1));
         requestExportFrame();
       }
@@ -1251,7 +1182,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
         exportAbortRef.current = null;
       }
       setIsExporting(false);
-      setIndexOverride(Math.min(previousIndex, lastIndex));
+      setTransientSelectedIndex(null);
     }
   }, [
     canStartExport,
@@ -1261,7 +1192,6 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
     isWatermarkedExport,
     videoExportSettings,
     selectedBatchParsed,
-    selectedIndex,
     selectedSummary?.deviceName,
   ]);
 
@@ -1277,7 +1207,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
       />
       {/* ---- Always-visible map ---- */}
       <Suspense fallback={<div style={{ width: "100%", height: "100%", background: MAP_VIEWPORT_BACKGROUND }} />}>
-        {shouldRenderMapViewport && isMapZoomHydrated ? (
+        {shouldRenderMapViewport ? (
           <Map3D
             ref={map3DRef}
             data={data}
@@ -1909,7 +1839,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
                 <Text size="1" color="gray">Time range</Text>
                 <Select.Root
                   value={batchBrowserTimeRange}
-                  onValueChange={(value) => setBatchBrowserTimeRange(value as BatchBrowserTimeRange)}
+                  onValueChange={handleBatchBrowserTimeRangeChange}
                 >
                   <Select.Trigger aria-label="Batch browser time range" />
                   <Select.Content>
@@ -1926,7 +1856,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
                   <Switch
                     id="batch-browser-public-filter"
                     checked={showPublicBatchBrowser}
-                    onCheckedChange={setShowPublicBatchBrowser}
+                    onCheckedChange={handleShowPublicBatchBrowserChange}
                   />
                   <label
                     htmlFor="batch-browser-public-filter"
@@ -1939,7 +1869,7 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
                   <Switch
                     id="batch-browser-private-filter"
                     checked={showPrivateBatchBrowser}
-                    onCheckedChange={setShowPrivateBatchBrowser}
+                    onCheckedChange={handleShowPrivateBatchBrowserChange}
                   />
                   <label
                     htmlFor="batch-browser-private-filter"
@@ -1957,8 +1887,8 @@ export default function MapPage({ mapAppearance }: MapPageProps) {
                 pageStart={batchBrowserPagination.pageStart}
                 pageEnd={batchBrowserPagination.pageEnd}
                 totalCount={filteredBatchBrowserBatches.length}
-                onShowLess={() => setBatchBrowserPageIndex((prev) => prev - 1)}
-                onShowMore={() => setBatchBrowserPageIndex((prev) => prev + 1)}
+                onShowLess={() => setBatchBrowserPageIndexInput((prev) => prev - 1)}
+                onShowMore={() => setBatchBrowserPageIndexInput((prev) => prev + 1)}
               />
               {batchBrowserQuery.isFetching ? (
                 <Text size="1" color="gray">Refreshing...</Text>

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Badge, Box, Button, Callout, Card, Flex, Heading, Link, SegmentedControl, Select, Separator, Switch, Table, Text, TextField } from "@radix-ui/themes";
 import { ReloadIcon } from "@radix-ui/react-icons";
@@ -119,11 +119,11 @@ export default function UserDashboard({
   const batchesError = batchesQuery.error instanceof Error ? batchesQuery.error.message : null;
   const receiptsError = receiptsQuery.error instanceof Error ? receiptsQuery.error.message : null;
   const [revokeError, setRevokeError] = useState<string | null>(null);
-  const [devicePageIndex, setDevicePageIndex] = useState(0);
+  const [devicePageIndexInput, setDevicePageIndexInput] = useState(0);
   const [selectedBatchDeviceId, setSelectedBatchDeviceId] = useState<string>("all");
   const [batchActionError, setBatchActionError] = useState<string | null>(null);
   const [batchActionMessage, setBatchActionMessage] = useState<string | null>(null);
-  const [batchPageIndex, setBatchPageIndex] = useState(0);
+  const [batchPageIndexInput, setBatchPageIndexInput] = useState(0);
   const [settingsMessage, setSettingsMessage] = useState<string | null>(null);
   const [settingsLocalError, setSettingsLocalError] = useState<string | null>(null);
   const [subscriptionMessage, setSubscriptionMessage] = useState<string | null>(null);
@@ -132,6 +132,7 @@ export default function UserDashboard({
   const [isOpeningBillingPortal, setOpeningBillingPortal] = useState(false);
   const activationUrl = useMemo(() => buildActivationLink(), []);
   const [activationLinkMessage, setActivationLinkMessage] = useState<string | null>(null);
+  const handledSubscriptionCheckoutRef = useRef<string | null>(null);
 
   const refreshDevices = useCallback(async () => {
     if (!user) return;
@@ -195,17 +196,21 @@ export default function UserDashboard({
     if (!user || !subscriptionCheckoutNotice) {
       return;
     }
+    const handledKey = `${user.uid}:${subscriptionCheckoutNotice}:${subscriptionCheckoutSessionId ?? "none"}`;
+    if (handledSubscriptionCheckoutRef.current === handledKey) {
+      return;
+    }
+    handledSubscriptionCheckoutRef.current = handledKey;
     let cancelled = false;
-
-    setSubscriptionError(null);
-    setSubscriptionMessage(
-      subscriptionCheckoutNotice === "cancelled"
-        ? "Subscription checkout was cancelled before it completed."
-        : "Subscription checkout completed. Refreshing account access…"
-    );
 
     void (async () => {
       try {
+        setSubscriptionError(null);
+        setSubscriptionMessage(
+          subscriptionCheckoutNotice === "cancelled"
+            ? "Subscription checkout was cancelled before it completed."
+            : "Subscription checkout completed. Refreshing account access…"
+        );
         if (subscriptionCheckoutNotice === "success" && subscriptionCheckoutSessionId) {
           await confirmSubscriptionCheckoutSession(subscriptionCheckoutSessionId);
         }
@@ -241,8 +246,8 @@ export default function UserDashboard({
     user,
   ]);
 
-  const ownedCount = useMemo(() => devices.length, [devices]);
-  const completedReceiptCount = useMemo(() => receipts.length, [receipts.length]);
+  const ownedCount = devices.length;
+  const completedReceiptCount = receipts.length;
   const activeCount = useMemo(
     () => devices.filter((device) => describeStatus(device.registryStatus ?? device.status).tone === "green").length,
     [devices],
@@ -271,16 +276,22 @@ export default function UserDashboard({
         label: deviceNameLookup.get(id) ?? batches.find((batch) => batch.deviceId === id)?.deviceName ?? id,
       }));
   }, [batches, deviceNameLookup, devices]);
+  const effectiveSelectedBatchDeviceId = selectedBatchDeviceId === "all"
+    || batchDeviceOptions.some((option) => option.id === selectedBatchDeviceId)
+    ? selectedBatchDeviceId
+    : "all";
   const filteredBatches = useMemo(() => {
-    const byDevice = selectedBatchDeviceId === "all"
+    const byDevice = effectiveSelectedBatchDeviceId === "all"
       ? batches
-      : batches.filter((batch) => batch.deviceId === selectedBatchDeviceId);
+      : batches.filter((batch) => batch.deviceId === effectiveSelectedBatchDeviceId);
     return [...byDevice].sort((a, b) => {
       const timeA = timestampToMillis(a.processedAt) ?? 0;
       const timeB = timestampToMillis(b.processedAt) ?? 0;
       return timeB - timeA;
     });
-  }, [batches, selectedBatchDeviceId]);
+  }, [batches, effectiveSelectedBatchDeviceId]);
+  const devicePageIndex = clampPageIndex(devices.length, devicePageIndexInput);
+  const batchPageIndex = clampPageIndex(filteredBatches.length, batchPageIndexInput);
   const devicePagination = useMemo(
     () => getPaginationWindow(devices.length, devicePageIndex),
     [devicePageIndex, devices.length],
@@ -297,28 +308,6 @@ export default function UserDashboard({
     () => filteredBatches.slice(batchPagination.pageStart, batchPagination.pageEnd),
     [batchPagination.pageEnd, batchPagination.pageStart, filteredBatches],
   );
-
-  useEffect(() => {
-    if (selectedBatchDeviceId === "all") return;
-    const stillExists = batchDeviceOptions.some((option) => option.id === selectedBatchDeviceId);
-    if (!stillExists) {
-      setSelectedBatchDeviceId("all");
-    }
-  }, [batchDeviceOptions, selectedBatchDeviceId]);
-
-  useEffect(() => {
-    const nextPageIndex = clampPageIndex(devices.length, devicePageIndex);
-    if (nextPageIndex !== devicePageIndex) {
-      setDevicePageIndex(nextPageIndex);
-    }
-  }, [devicePageIndex, devices.length]);
-
-  useEffect(() => {
-    const nextPageIndex = clampPageIndex(filteredBatches.length, batchPageIndex);
-    if (nextPageIndex !== batchPageIndex) {
-      setBatchPageIndex(nextPageIndex);
-    }
-  }, [batchPageIndex, filteredBatches.length]);
 
   const handleDefaultVisibilityChange = useCallback(async (nextValue: string) => {
     const next = nextValue as BatchVisibility;
@@ -434,6 +423,11 @@ export default function UserDashboard({
   const handleOpenActivation = useCallback(() => {
     onRequestActivation();
   }, [onRequestActivation]);
+
+  const handleBatchDeviceFilterChange = useCallback((nextValue: string) => {
+    setSelectedBatchDeviceId(nextValue);
+    setBatchPageIndexInput(0);
+  }, []);
 
   const handleCopyActivationLink = useCallback(async () => {
     try {
@@ -772,8 +766,8 @@ export default function UserDashboard({
               pageStart={devicePagination.pageStart}
               pageEnd={devicePagination.pageEnd}
               totalCount={devices.length}
-              onShowLess={() => setDevicePageIndex((current) => clampPageIndex(devices.length, current - 1))}
-              onShowMore={() => setDevicePageIndex((current) => clampPageIndex(devices.length, current + 1))}
+              onShowLess={() => setDevicePageIndexInput((current) => current - 1)}
+              onShowMore={() => setDevicePageIndexInput((current) => current + 1)}
             />
           </Flex>
           <Separator my="2" size="4" />
@@ -853,14 +847,14 @@ export default function UserDashboard({
             </Box>
             <Flex align="center" gap="2" wrap="wrap">
               <ResultCountControl
-                itemLabelSingular="batch"
-                itemLabelPlural="batches"
-                pageStart={batchPagination.pageStart}
-                pageEnd={batchPagination.pageEnd}
-                totalCount={filteredBatches.length}
-                onShowLess={() => setBatchPageIndex((current) => clampPageIndex(filteredBatches.length, current - 1))}
-                onShowMore={() => setBatchPageIndex((current) => clampPageIndex(filteredBatches.length, current + 1))}
-              />
+              itemLabelSingular="batch"
+              itemLabelPlural="batches"
+              pageStart={batchPagination.pageStart}
+              pageEnd={batchPagination.pageEnd}
+              totalCount={filteredBatches.length}
+              onShowLess={() => setBatchPageIndexInput((current) => current - 1)}
+              onShowMore={() => setBatchPageIndexInput((current) => current + 1)}
+            />
               <Button variant="soft" onClick={refreshBatches} disabled={isLoadingBatches}>
                 <ReloadIcon /> {isLoadingBatches ? "Refreshing" : "Refresh"}
               </Button>
@@ -872,7 +866,7 @@ export default function UserDashboard({
           <Flex direction={{ initial: "column", sm: "row" }} align={{ initial: "start", sm: "center" }} gap="2">
             <Text size="2" color="gray">Device filter</Text>
             <Box style={{ width: "min(360px, 100%)" }}>
-              <Select.Root value={selectedBatchDeviceId} onValueChange={setSelectedBatchDeviceId}>
+              <Select.Root value={effectiveSelectedBatchDeviceId} onValueChange={handleBatchDeviceFilterChange}>
                 <Select.Trigger />
                 <Select.Content>
                   <Select.Item value="all">All devices</Select.Item>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import react, { reactCompilerPreset } from "@vitejs/plugin-react";
+import babel from "@rolldown/plugin-babel";
 
 const FUNCTIONS_PROXY_TARGET = "http://127.0.0.1:5001/crowdpm-local/us-central1/crowdpmApi";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    babel({ presets: [reactCompilerPreset()] }),
+  ],
   server: {
     proxy: {
       "/api": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "deploy": "sh -c 'if [ \"${1:-}\" = \"--\" ]; then shift; fi; test -n \"${FIREBASE_PROJECT_ID:-}\" || { echo \"Set FIREBASE_PROJECT_ID to the deployed Firebase project ID.\" >&2; exit 1; }; firebase deploy --project \"$FIREBASE_PROJECT_ID\" \"$@\"; deploy_status=$?; if [ $deploy_status -ne 0 ]; then exit $deploy_status; fi; if [ -n \"${FIRST_SUPER_ADMIN_EMAIL:-}\" ]; then pnpm --filter crowdpm-functions admin:bootstrap-super-admin; else echo \"FIRST_SUPER_ADMIN_EMAIL not set; skipping super admin bootstrap.\"; fi' --"
   },
   "devDependencies": {
+    "@rolldown/plugin-babel": "0.2.3",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "9.39.4",
     "@typescript-eslint/eslint-plugin": "8.59.0",
     "@typescript-eslint/parser": "8.59.0",
+    "babel-plugin-react-compiler": "1.0.0",
     "concurrently": "9.2.1",
     "eslint": "9.39.4",
     "eslint-plugin-react": "7.37.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,18 @@ importers:
       '@eslint/js':
         specifier: 9.39.4
         version: 9.39.4
+      '@rolldown/plugin-babel':
+        specifier: 0.2.3
+        version: 0.2.3(@babel/core@7.29.0)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))
       '@typescript-eslint/eslint-plugin':
         specifier: 8.59.0
         version: 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: 8.59.0
         version: 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      babel-plugin-react-compiler:
+        specifier: 1.0.0
+        version: 1.0.0
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -101,7 +107,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))
+        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))
       autoprefixer:
         specifier: 10.5.0
         version: 10.5.0(postcss@8.5.10)
@@ -2031,6 +2037,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/plugin-babel@0.2.3':
+    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.16':
     resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
 
@@ -2497,6 +2520,9 @@ packages:
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
+
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -7886,6 +7912,14 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
     optional: true
 
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      picomatch: 4.0.4
+      rolldown: 1.0.0-rc.16
+    optionalDependencies:
+      vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
+
   '@rolldown/pluginutils@1.0.0-rc.16': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
@@ -8140,10 +8174,13 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))
+      babel-plugin-react-compiler: 1.0.0
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -8426,6 +8463,10 @@ snapshots:
       fastq: 1.20.1
 
   b4a@1.8.1: {}
+
+  babel-plugin-react-compiler@1.0.0:
+    dependencies:
+      '@babel/types': 7.29.0
 
   balanced-match@1.0.2: {}
 


### PR DESCRIPTION
## Summary
- refactor frontend state flow away from effect-driven repair patterns to align with React 19 hook/compiler guidance
- enable the stricter `react-hooks/recommended-latest` lint baseline and update callback/ref patterns
- wire the React Compiler through the supported Vite plugin-react + rolldown Babel integration

## Verification
- pnpm lint
- pnpm --filter crowdpm-frontend exec tsc --noEmit
- pnpm --filter crowdpm-frontend build