### PR TITLE
Defer map loading behind explicit route

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,6 @@
       name="description"
       content="CrowdPM Platform visualizes crowd-sourced PM2.5 air quality data and device insights."
     />
-    <link rel="preconnect" href="https://us-central1-crowdpmplatform.cloudfunctions.net" crossorigin />
     <link rel="canonical" href="https://crowdpmplatform.web.app/" />
     <meta name="robots" content="index,follow" />
     <title>CrowdPM</title>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import type { UserThemeSettings } from "@crowdpm/types";
 import type { AuthMode } from "./components/AuthDialog";
 import { ExternalAnchor, ExternalLink } from "./components/ExternalLink";
 import { LegalDocumentDialog, LegalDocumentLink, type LegalDocumentId } from "./components/LegalDocumentDialog";
-import { APP_ROUTES, getDeepLinkedAppTab, getRouteForDeepLinkedAppTab, isActivationRoute, isDeepLinkedAppRoute, type DeepLinkedAppTab } from "./lib/appRoutes";
+import { APP_ROUTES, getAppTabFromPath, getRouteForAppTab, isActivationRoute, type RoutedAppTab } from "./lib/appRoutes";
 import { PROJECT_LINKS, PROJECT_RESOURCE_LINKS } from "./lib/projectLinks";
 import { logWarning } from "./lib/logger";
 import { pushAppLocation, replaceAppLocation, replaceCurrentUrl, useBrowserLocation } from "./lib/locationStore";
@@ -29,6 +29,7 @@ import {
   Dialog,
 } from "@radix-ui/themes";
 import { GitHubLogoIcon, HamburgerMenuIcon, LinkedInLogoIcon } from "@radix-ui/react-icons";
+import HomePage from "./pages/HomePage";
 
 const TEAM_MEMBERS: Array<{
   name: string;
@@ -97,13 +98,9 @@ const ThemeSettingsControls = lazy(async () => {
 });
 const MAP_VIEWPORT_BOTTOM_INSET = "max(12px, env(safe-area-inset-bottom, 0px))";
 
-type AppTab = "map" | "dashboard" | "admin" | DeepLinkedAppTab;
+type AppTab = RoutedAppTab;
 type ThemeCheckoutNotice = "success" | "cancelled" | null;
 type SubscriptionCheckoutNotice = "success" | "cancelled" | null;
-
-function isDeepLinkedTab(tab: AppTab): tab is DeepLinkedAppTab {
-  return tab === "pairing-info" || tab === "about" || tab === "node";
-}
 
 function readThemeCheckoutNotice(search: string): ThemeCheckoutNotice {
   const status = new URLSearchParams(search).get("themeCheckout");
@@ -132,19 +129,12 @@ function readSubscriptionCheckoutSessionId(search: string): string | null {
   return typeof sessionId === "string" && sessionId.trim().length > 0 ? sessionId : null;
 }
 
-function clearSubscriptionCheckoutNoticeFromUrl() {
-  replaceCurrentUrl((nextUrl) => {
-    nextUrl.searchParams.delete("subscriptionCheckout");
-    nextUrl.searchParams.delete("subscriptionCheckoutSessionId");
-  });
-}
-
 export default function App() {
   const { user, isLoading, signOut, canAccessAdmin } = useAuth();
   const { settings } = useUserSettings();
   const location = useBrowserLocation();
   const userScopedKey = user?.uid ?? "anon";
-  const [requestedTab, setRequestedTab] = useState<AppTab>(() => getDeepLinkedAppTab(location.pathname) ?? "map");
+  const [requestedTab, setRequestedTab] = useState<AppTab>(() => getAppTabFromPath(location.pathname) ?? "home");
   const [authMode, setAuthMode] = useState<AuthMode>("login");
   const [isAuthDialogOpen, setAuthDialogOpen] = useState(false);
   const [isTeamModalOpen, setTeamModalOpen] = useState(false);
@@ -156,14 +146,14 @@ export default function App() {
   const themeCheckoutSessionId = readThemeCheckoutSessionId(location.search);
   const subscriptionCheckoutNotice = readSubscriptionCheckoutNotice(location.search);
   const subscriptionCheckoutSessionId = readSubscriptionCheckoutSessionId(location.search);
-  const routeTab = getDeepLinkedAppTab(location.pathname);
+  const routeTab = getAppTabFromPath(location.pathname);
   const isActivationModalOpen = isActivationRoute(location.pathname);
   const isSignedIn = Boolean(user);
-  const tab = routeTab ?? (isDeepLinkedTab(requestedTab) ? "map" : requestedTab);
+  const tab = routeTab ?? requestedTab;
   const preferredTab = user && subscriptionCheckoutNotice ? "dashboard" : tab;
-  const activeTab = !isSignedIn && preferredTab !== "map" && preferredTab !== "pairing-info" && preferredTab !== "about" && preferredTab !== "node"
-    ? "map"
-    : (preferredTab === "admin" && !canAccessAdmin ? "map" : preferredTab);
+  const activeTab = !isSignedIn && preferredTab !== "home" && preferredTab !== "map" && preferredTab !== "pairing-info" && preferredTab !== "about" && preferredTab !== "node"
+    ? "home"
+    : (preferredTab === "admin" && !canAccessAdmin ? "home" : preferredTab);
   const isThemeModalOpen = isThemeModalRequested || Boolean(themeCheckoutNotice);
   const activeTheme = user ? themeDraft ?? settings.theme : settings.theme;
   const isDarkTheme = activeTheme.appearance === "dark";
@@ -181,19 +171,10 @@ export default function App() {
   };
 
   const navigateToTab = useCallback((nextTab: AppTab) => {
-    const pathname = location.pathname.toLowerCase();
     setRequestedTab(nextTab);
-
-    if (isDeepLinkedTab(nextTab)) {
-      const targetRoute = getRouteForDeepLinkedAppTab(nextTab);
-      if (!pathname.startsWith(targetRoute)) {
-        pushAppLocation(targetRoute);
-      }
-      return;
-    }
-
-    if (isActivationRoute(pathname) || isDeepLinkedAppRoute(pathname)) {
-      replaceAppLocation(APP_ROUTES.home);
+    const targetRoute = getRouteForAppTab(nextTab);
+    if (location.pathname.toLowerCase() !== targetRoute.toLowerCase()) {
+      pushAppLocation(targetRoute);
     }
   }, [location.pathname]);
 
@@ -241,9 +222,10 @@ export default function App() {
   const handleSignOut = async () => {
     try {
       await signOut();
-      setRequestedTab("map");
+      setRequestedTab("home");
       setThemeDraft(null);
       setThemeModalRequested(false);
+      replaceAppLocation(APP_ROUTES.home);
     }
     catch (err) {
       logWarning("Sign out failed", undefined, err);
@@ -296,15 +278,15 @@ export default function App() {
     }
 
     if (isActivationModalOpen) {
-      replaceAppLocation(APP_ROUTES.home);
+      replaceAppLocation(getRouteForAppTab(requestedTab));
     }
-  }, [isActivationModalOpen, user]);
+  }, [isActivationModalOpen, requestedTab, user]);
 
   const handleActivationComplete = () => {
     setRequestedTab("dashboard");
     setDashboardRefreshToken((prev) => prev + 1);
     if (isActivationModalOpen) {
-      replaceAppLocation(APP_ROUTES.home);
+      replaceAppLocation(APP_ROUTES.dashboard);
     }
   };
 
@@ -313,7 +295,7 @@ export default function App() {
       return;
     }
     setRequestedTab("dashboard");
-    clearSubscriptionCheckoutNoticeFromUrl();
+    replaceAppLocation(APP_ROUTES.dashboard);
   }, [subscriptionCheckoutNotice, subscriptionCheckoutSessionId]);
 
   const tabPanelFallback = (
@@ -389,10 +371,10 @@ export default function App() {
             pointerEvents: "auto",
           }}
         >
-          {/* Clickable logo + title — navigates back to map */}
+          {/* Clickable logo + title — navigates back to the lightweight landing page */}
             <button
               type="button"
-              onClick={() => navigateToTab("map")}
+              onClick={() => navigateToTab("home")}
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -403,7 +385,7 @@ export default function App() {
               cursor: "pointer",
               color: "inherit",
             }}
-            aria-label="Return to map"
+            aria-label="Return to home"
           >
             <svg width="36" height="36" viewBox="0 0 28 28" fill="none" aria-hidden>
               <circle cx="14" cy="14" r="13" stroke="var(--accent-9)" strokeWidth="1.5" fill="none" opacity="0.7" />
@@ -465,11 +447,18 @@ export default function App() {
           </DropdownMenu.Trigger>
           <DropdownMenu.Content sideOffset={8} align="start">
             <DropdownMenu.Item
+              onSelect={() => navigateToTab("home")}
+              style={activeTab === "home" ? { fontWeight: 600 } : undefined}
+              disabled={isLoading}
+            >
+              Home
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
               onSelect={() => navigateToTab("map")}
               style={activeTab === "map" ? { fontWeight: 600 } : undefined}
               disabled={isLoading}
             >
-              Map
+              Explore Map
             </DropdownMenu.Item>
             <DropdownMenu.Item
               onSelect={() => navigateToTab("node")}
@@ -587,7 +576,17 @@ export default function App() {
                 }}
               >
                 <Suspense fallback={tabPanelFallback}>
-                  {activeTab === "dashboard" && user ? (
+                  {activeTab === "home" ? (
+                    <HomePage
+                      isSignedIn={isSignedIn}
+                      onExploreMap={() => navigateToTab("map")}
+                      onOpenDashboard={() => handleProtectedTabClick("dashboard")}
+                      onOpenActivation={openActivationModal}
+                      onOpenAbout={() => navigateToTab("about")}
+                      onOpenProducts={() => navigateToTab("node")}
+                      onOpenAuth={openAuthDialog}
+                    />
+                  ) : activeTab === "dashboard" && user ? (
                     <UserDashboard
                       key={`dashboard:${userScopedKey}`}
                       onRequestActivation={openActivationModal}
@@ -632,7 +631,7 @@ export default function App() {
             mode={authMode}
             onModeChange={setAuthMode}
             onOpenChange={setAuthDialogOpen}
-            onAuthenticated={() => navigateToTab("dashboard")}
+            onAuthenticated={() => navigateToTab(routeTab === "admin" ? "admin" : "dashboard")}
           />
         ) : null}
       </Suspense>

--- a/frontend/src/lib/appRoutes.ts
+++ b/frontend/src/lib/appRoutes.ts
@@ -1,5 +1,8 @@
 export const APP_ROUTES = {
   home: "/",
+  map: "/map",
+  dashboard: "/dashboard",
+  admin: "/admin",
   activation: "/activate",
   pairingGuide: "/pairing-guide",
   about: "/about",
@@ -7,31 +10,58 @@ export const APP_ROUTES = {
 } as const;
 
 export type DeepLinkedAppTab = "pairing-info" | "about" | "node";
+export type RoutedAppTab = "home" | "map" | "dashboard" | "admin" | DeepLinkedAppTab;
 
-const DEEP_LINKED_TAB_ROUTES: Record<DeepLinkedAppTab, string> = {
+const ROUTED_TAB_ROUTES: Record<RoutedAppTab, string> = {
+  home: APP_ROUTES.home,
+  map: APP_ROUTES.map,
+  dashboard: APP_ROUTES.dashboard,
+  admin: APP_ROUTES.admin,
   "pairing-info": APP_ROUTES.pairingGuide,
   about: APP_ROUTES.about,
   node: APP_ROUTES.node,
 };
 
-const DEEP_LINKED_TAB_ROUTE_ENTRIES = Object.entries(DEEP_LINKED_TAB_ROUTES) as Array<[DeepLinkedAppTab, string]>;
+const ROUTED_TAB_ROUTE_ENTRIES = [
+  ["map", APP_ROUTES.map],
+  ["dashboard", APP_ROUTES.dashboard],
+  ["admin", APP_ROUTES.admin],
+  ["pairing-info", APP_ROUTES.pairingGuide],
+  ["about", APP_ROUTES.about],
+  ["node", APP_ROUTES.node],
+  ["home", APP_ROUTES.home],
+] as const satisfies readonly [RoutedAppTab, string][];
 
 function normalizeAppPathname(pathname: string): string {
-  return pathname.toLowerCase();
+  const normalized = pathname.toLowerCase().replace(/\/+$/, "");
+  return normalized || "/";
 }
 
 export function matchesAppRoute(pathname: string, route: string): boolean {
-  return normalizeAppPathname(pathname).startsWith(normalizeAppPathname(route));
+  const normalizedPathname = normalizeAppPathname(pathname);
+  const normalizedRoute = normalizeAppPathname(route);
+  if (normalizedRoute === APP_ROUTES.home) {
+    return normalizedPathname === normalizedRoute;
+  }
+  return normalizedPathname === normalizedRoute || normalizedPathname.startsWith(`${normalizedRoute}/`);
 }
 
-export function getDeepLinkedAppTab(pathname: string): DeepLinkedAppTab | null {
-  const normalizedPathname = normalizeAppPathname(pathname);
-  const match = DEEP_LINKED_TAB_ROUTE_ENTRIES.find((entry) => normalizedPathname.startsWith(entry[1]));
+export function getAppTabFromPath(pathname: string): RoutedAppTab | null {
+  const match = ROUTED_TAB_ROUTE_ENTRIES.find((entry) => matchesAppRoute(pathname, entry[1]));
   return match?.[0] ?? null;
 }
 
+export function getDeepLinkedAppTab(pathname: string): DeepLinkedAppTab | null {
+  const tab = getAppTabFromPath(pathname);
+  return tab === "pairing-info" || tab === "about" || tab === "node" ? tab : null;
+}
+
+export function getRouteForAppTab(tab: RoutedAppTab): string {
+  return ROUTED_TAB_ROUTES[tab];
+}
+
 export function getRouteForDeepLinkedAppTab(tab: DeepLinkedAppTab): string {
-  return DEEP_LINKED_TAB_ROUTES[tab];
+  return ROUTED_TAB_ROUTES[tab];
 }
 
 export function isActivationRoute(pathname: string): boolean {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,191 @@
+import { Box, Button, Card, Flex, Heading, Separator, Text } from "@radix-ui/themes";
+import { ExternalLink } from "../components/ExternalLink";
+import { PROJECT_LINKS } from "../lib/projectLinks";
+
+type HomePageProps = {
+  isSignedIn: boolean;
+  onExploreMap: () => void;
+  onOpenDashboard: () => void;
+  onOpenActivation: () => void;
+  onOpenAbout: () => void;
+  onOpenProducts: () => void;
+  onOpenAuth: (mode: "login" | "signup") => void;
+};
+
+const HIGHLIGHTS = [
+  {
+    title: "Public 3D map",
+    description: "Browse shared PM2.5 measurements on demand instead of paying the Google Maps WebGL cost on every first paint.",
+  },
+  {
+    title: "Node pairing",
+    description: "Register hardware securely with short-lived activation codes and account-scoped device authorization.",
+  },
+  {
+    title: "Batch exports",
+    description: "Review historical runs, select measurement timelines, and render flythrough videos when you need them.",
+  },
+  {
+    title: "Open source stack",
+    description: "React, Firebase, and ESP32-based hardware with public source, license, and contributor attribution.",
+  },
+] as const;
+
+const WORKFLOW_STEPS = [
+  {
+    title: "Collect local data",
+    description: "Deploy a compatible node to sample PM2.5, GPS, and supporting environmental telemetry in the places you actually care about.",
+  },
+  {
+    title: "Review and publish",
+    description: "Inspect device batches in your dashboard, keep sensitive runs private, and choose which measurements should appear publicly.",
+  },
+  {
+    title: "Share context",
+    description: "Open the live map, compare public batches, and export movement traces that are easier to explain than raw coordinates alone.",
+  },
+] as const;
+
+export default function HomePage({
+  isSignedIn,
+  onExploreMap,
+  onOpenDashboard,
+  onOpenActivation,
+  onOpenAbout,
+  onOpenProducts,
+  onOpenAuth,
+}: HomePageProps) {
+  return (
+    <Flex direction="column" gap="6">
+      <Card
+        style={{
+          overflow: "hidden",
+          background:
+            "radial-gradient(120% 120% at 0% 0%, color-mix(in srgb, var(--accent-9) 22%, transparent), transparent 52%), "
+            + "radial-gradient(90% 120% at 100% 0%, color-mix(in srgb, var(--gray-8) 18%, transparent), transparent 60%), "
+            + "linear-gradient(180deg, color-mix(in srgb, var(--color-panel-solid) 98%, transparent), color-mix(in srgb, var(--color-panel-solid) 94%, var(--gray-2)))",
+          border: "1px solid var(--gray-a5)",
+        }}
+      >
+        <Flex direction="column" gap="5" style={{ padding: "var(--space-6)" }}>
+          <Flex direction="column" gap="3" style={{ maxWidth: 760 }}>
+            <Text
+              size="1"
+              weight="bold"
+              style={{
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                color: "var(--accent-11)",
+              }}
+            >
+              Community air quality intelligence
+            </Text>
+            <Heading as="h1" size="8" style={{ lineHeight: 1.02, maxWidth: 720 }}>
+              Hyper-local PM2.5 mapping without forcing the live map onto every first visit.
+            </Heading>
+            <Text size="3" color="gray" as="p" style={{ maxWidth: 680 }}>
+              CrowdPM combines open hardware, account-scoped device activation, public measurement publishing,
+              and on-demand 3D mapping so the expensive map stack only loads when someone explicitly wants it.
+            </Text>
+          </Flex>
+
+          <Flex gap="3" wrap="wrap">
+            <Button size="4" onClick={onExploreMap}>
+              Explore live map
+            </Button>
+            {isSignedIn ? (
+              <>
+                <Button size="4" variant="soft" onClick={onOpenDashboard}>
+                  Open dashboard
+                </Button>
+                <Button size="4" variant="outline" onClick={onOpenActivation}>
+                  Activate a node
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button size="4" variant="soft" onClick={() => onOpenAuth("signup")}>
+                  Create account
+                </Button>
+                <Button size="4" variant="outline" onClick={() => onOpenAuth("login")}>
+                  Log in
+                </Button>
+              </>
+            )}
+          </Flex>
+
+          <Flex gap="3" wrap="wrap">
+            <Button variant="ghost" onClick={onOpenProducts}>
+              Browse hardware
+            </Button>
+            <Button variant="ghost" onClick={onOpenAbout}>
+              Learn about the project
+            </Button>
+            <Text size="2" color="gray" as="p">
+              Source on{" "}
+              <ExternalLink href={PROJECT_LINKS.repository} color="iris" highContrast>
+                GitHub
+              </ExternalLink>
+              {" "}and community support on{" "}
+              <ExternalLink href={PROJECT_LINKS.discord} color="iris" highContrast>
+                Discord
+              </ExternalLink>
+              .
+            </Text>
+          </Flex>
+        </Flex>
+      </Card>
+
+      <Flex gap="4" wrap="wrap">
+        {HIGHLIGHTS.map((highlight) => (
+          <Card key={highlight.title} style={{ flex: "1 1 240px", minWidth: 0 }}>
+            <Flex direction="column" gap="2">
+              <Heading as="h2" size="4">{highlight.title}</Heading>
+              <Text size="2" color="gray" as="p">{highlight.description}</Text>
+            </Flex>
+          </Card>
+        ))}
+      </Flex>
+
+      <Separator size="4" />
+
+      <Box>
+        <Heading as="h2" size="5" mb="3">How CrowdPM works</Heading>
+        <Flex gap="4" wrap="wrap">
+          {WORKFLOW_STEPS.map((step, index) => (
+            <Card key={step.title} style={{ flex: "1 1 280px", minWidth: 0 }}>
+              <Flex direction="column" gap="3">
+                <Text
+                  size="1"
+                  weight="bold"
+                  style={{
+                    letterSpacing: "0.08em",
+                    textTransform: "uppercase",
+                    color: "var(--accent-11)",
+                  }}
+                >
+                  Step {index + 1}
+                </Text>
+                <Heading as="h3" size="4">{step.title}</Heading>
+                <Text size="2" color="gray" as="p">{step.description}</Text>
+              </Flex>
+            </Card>
+          ))}
+        </Flex>
+      </Box>
+
+      <Card>
+        <Flex direction="column" gap="3">
+          <Heading as="h2" size="4">Why the landing page is lighter now</Heading>
+          <Text size="2" color="gray" as="p">
+            The live Google Maps WebGL stack is intentionally deferred behind the map route, so home-page users see
+            project context, account entry points, and hardware guidance before any heavy map runtime is initialized.
+          </Text>
+          <Text size="2" color="gray" as="p">
+            That keeps the first view fast while preserving the existing 3D map experience for people who actually want it.
+          </Text>
+        </Flex>
+      </Card>
+    </Flex>
+  );
+}


### PR DESCRIPTION
## Summary
- move the public landing experience to a static home route and push the live map behind `/map`
- add explicit app routes for home, map, dashboard, and admin so activation and checkout flows return to the right surface
- remove the unconditional Cloud Functions preconnect from the initial HTML shell

## Verification
- pnpm lint
- pnpm --filter crowdpm-frontend exec tsc --noEmit
- pnpm --filter crowdpm-frontend build