### PR TITLE
Publish Swagger UI docs and sync OpenAPI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  validate:
+  lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Pull Request Checks
 
 permissions:
   contents: read
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  lint:
+  validate:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,3 +32,9 @@ jobs:
 
       - name: Run lint
         run: pnpm lint
+
+      - name: Run functions tests
+        run: pnpm --filter crowdpm-functions test
+
+      - name: Build workspace
+        run: pnpm build

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ CrowdPM documentation is organized by audience and environment. Avoid copying th
 | `development.md` | Contributors | Local emulator setup, env files, device checks, daily workflow. |
 | `deployment.md` | Maintainers | Deployed Firebase release checklist and rollback process. |
 | `hardware-builder.md` | Hardware builders | Device pairing, DPoP, access tokens, ingest payload contract. |
-| `openapi-swagger-ui.md` | API users | View `functions/src/openapi.yaml` in Swagger UI locally. |
+| `openapi-swagger-ui.md` | API users | View `functions/src/openapi.yaml` in hosted or local Swagger UI. |
 | `test-plan.txt` | Capstone team | Sprint test scope, methods, ownership, and Kanban evidence. |
 | `INSTALL-openjdk25-linux.md` | Linux contributors | JDK 25 setup notes for Firebase emulators. |
 | `INSTALL-openjdk25-mac.md` | macOS contributors | JDK 25 setup notes for Firebase emulators. |

--- a/docs/openapi-swagger-ui.md
+++ b/docs/openapi-swagger-ui.md
@@ -1,12 +1,18 @@
 # OpenAPI In Swagger UI
 
-Use Swagger UI locally to inspect `functions/src/openapi.yaml`.
+Use Swagger UI to inspect `functions/src/openapi.yaml`.
+
+## Hosted
+
+Deployed frontend builds publish a live Swagger UI page at `/api-docs` on the
+main app origin. The page bundles the OpenAPI file from `functions/src/openapi.yaml`
+at build time, so it stays aligned with the shipped frontend artifact.
 
 ## Prerequisite
 
 - Docker installed and running.
 
-## Run
+## Local Run
 
 From the repository root:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,8 @@
     "@tanstack/react-query": "5.100.9",
     "firebase": "12.13.0",
     "react": "19.2.5",
-    "react-dom": "19.2.5"
+    "react-dom": "19.2.5",
+    "swagger-ui-dist": "5.30.2"
   },
   "devDependencies": {
     "@tanstack/react-query-devtools": "5.100.9",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,6 +92,7 @@ const ActivationPage = lazy(async () => {
 const PairingInfoPage = lazy(() => import("./pages/PairingInfoPage"));
 const AboutPage = lazy(() => import("./pages/AboutPage"));
 const NodePage = lazy(() => import("./pages/NodePage"));
+const ApiDocsPage = lazy(() => import("./pages/ApiDocsPage"));
 const ThemeSettingsControls = lazy(async () => {
   const module = await import("./components/ThemeSettingsControls");
   return { default: module.ThemeSettingsControls };
@@ -151,7 +152,13 @@ export default function App() {
   const isSignedIn = Boolean(user);
   const tab = routeTab ?? requestedTab;
   const preferredTab = user && subscriptionCheckoutNotice ? "dashboard" : tab;
-  const activeTab = !isSignedIn && preferredTab !== "home" && preferredTab !== "map" && preferredTab !== "pairing-info" && preferredTab !== "about" && preferredTab !== "node"
+  const activeTab = !isSignedIn
+    && preferredTab !== "home"
+    && preferredTab !== "map"
+    && preferredTab !== "pairing-info"
+    && preferredTab !== "about"
+    && preferredTab !== "node"
+    && preferredTab !== "api-docs"
     ? "home"
     : (preferredTab === "admin" && !canAccessAdmin ? "home" : preferredTab);
   const isThemeModalOpen = isThemeModalRequested || Boolean(themeCheckoutNotice);
@@ -604,6 +611,8 @@ export default function App() {
                     <AboutPage onOpenTeamModal={openTeamModal} />
                   ) : activeTab === "node" ? (
                     <NodePage />
+                  ) : activeTab === "api-docs" ? (
+                    <ApiDocsPage />
                   ) : (
                     <Flex
                       direction="column"

--- a/frontend/src/lib/appRoutes.ts
+++ b/frontend/src/lib/appRoutes.ts
@@ -7,9 +7,10 @@ export const APP_ROUTES = {
   pairingGuide: "/pairing-guide",
   about: "/about",
   node: "/node",
+  apiDocs: "/api-docs",
 } as const;
 
-export type DeepLinkedAppTab = "pairing-info" | "about" | "node";
+export type DeepLinkedAppTab = "pairing-info" | "about" | "node" | "api-docs";
 export type RoutedAppTab = "home" | "map" | "dashboard" | "admin" | DeepLinkedAppTab;
 
 const ROUTED_TAB_ROUTES: Record<RoutedAppTab, string> = {
@@ -20,6 +21,7 @@ const ROUTED_TAB_ROUTES: Record<RoutedAppTab, string> = {
   "pairing-info": APP_ROUTES.pairingGuide,
   about: APP_ROUTES.about,
   node: APP_ROUTES.node,
+  "api-docs": APP_ROUTES.apiDocs,
 };
 
 const ROUTED_TAB_ROUTE_ENTRIES = [
@@ -29,6 +31,7 @@ const ROUTED_TAB_ROUTE_ENTRIES = [
   ["pairing-info", APP_ROUTES.pairingGuide],
   ["about", APP_ROUTES.about],
   ["node", APP_ROUTES.node],
+  ["api-docs", APP_ROUTES.apiDocs],
   ["home", APP_ROUTES.home],
 ] as const satisfies readonly [RoutedAppTab, string][];
 
@@ -53,7 +56,7 @@ export function getAppTabFromPath(pathname: string): RoutedAppTab | null {
 
 export function getDeepLinkedAppTab(pathname: string): DeepLinkedAppTab | null {
   const tab = getAppTabFromPath(pathname);
-  return tab === "pairing-info" || tab === "about" || tab === "node" ? tab : null;
+  return tab === "pairing-info" || tab === "about" || tab === "node" || tab === "api-docs" ? tab : null;
 }
 
 export function getRouteForAppTab(tab: RoutedAppTab): string {

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -14,6 +14,7 @@ import {
   type LegalDocumentId,
 } from "../components/LegalDocumentDialog";
 import { ExternalLink } from "../components/ExternalLink";
+import { APP_ROUTES } from "../lib/appRoutes";
 import { PROJECT_LINKS } from "../lib/projectLinks";
 
 type AboutPageProps = {
@@ -207,6 +208,12 @@ export default function AboutPage({ onOpenTeamModal }: AboutPageProps) {
             <ExternalLink href={PROJECT_LINKS.repository} color="iris" highContrast>
               GitHub
             </ExternalLink>.
+          </Text>
+          <Text size="2" color="gray" as="p" mt="3">
+            The live REST contract is available in the{" "}
+            <Link href={APP_ROUTES.apiDocs} color="iris" highContrast>
+              Swagger API reference
+            </Link>.
           </Text>
         </Box>
       </Flex>

--- a/frontend/src/pages/ApiDocsPage.css
+++ b/frontend/src/pages/ApiDocsPage.css
@@ -1,0 +1,38 @@
+.api-docs-page .swagger-ui {
+  font-family: inherit;
+  color: var(--gray-12);
+}
+
+.api-docs-page .swagger-ui .topbar {
+  display: none;
+}
+
+.api-docs-page .swagger-ui .scheme-container {
+  background: color-mix(in srgb, var(--color-panel-solid) 92%, white);
+  box-shadow: none;
+  border-block: 1px solid var(--gray-5);
+}
+
+.api-docs-page .swagger-ui .information-container,
+.api-docs-page .swagger-ui .wrapper {
+  padding-inline: 0;
+}
+
+.api-docs-page .swagger-ui .info {
+  margin: 0 0 var(--space-4);
+}
+
+.api-docs-page .swagger-ui .info .title,
+.api-docs-page .swagger-ui .opblock-tag,
+.api-docs-page .swagger-ui .opblock-summary-path {
+  color: var(--gray-12);
+}
+
+.api-docs-page .swagger-ui .btn.authorize,
+.api-docs-page .swagger-ui .btn.execute {
+  border-radius: 8px;
+}
+
+.api-docs-page .swagger-ui .opblock {
+  border-radius: 8px;
+}

--- a/frontend/src/pages/ApiDocsPage.tsx
+++ b/frontend/src/pages/ApiDocsPage.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react";
+import { Box, Card, Flex, Heading, Link, Text } from "@radix-ui/themes";
+import SwaggerUIBundle from "swagger-ui-dist/swagger-ui-bundle.js";
+import SwaggerUIStandalonePreset from "swagger-ui-dist/swagger-ui-standalone-preset.js";
+import "swagger-ui-dist/swagger-ui.css";
+import openapiSpecUrl from "../../../functions/src/openapi.yaml?url";
+import "./ApiDocsPage.css";
+
+const SWAGGER_LAYOUT = "BaseLayout";
+
+export default function ApiDocsPage() {
+  const swaggerContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = swaggerContainerRef.current;
+    if (!container) return;
+
+    const swaggerUi = SwaggerUIBundle({
+      url: openapiSpecUrl,
+      domNode: container,
+      deepLinking: true,
+      displayRequestDuration: true,
+      docExpansion: "list",
+      filter: true,
+      persistAuthorization: true,
+      defaultModelsExpandDepth: 1,
+      defaultModelExpandDepth: 1,
+      presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+      layout: SWAGGER_LAYOUT,
+    });
+
+    return () => {
+      swaggerUi.destroy?.();
+      container.replaceChildren();
+    };
+  }, []);
+
+  return (
+    <Flex className="api-docs-page" direction="column" gap="4">
+      <Box>
+        <Heading as="h1" size="5">API Reference</Heading>
+        <Text as="p" size="2" color="gray" mt="2">
+          Live Swagger UI for the CrowdPM REST API, bundled from the repository OpenAPI document.
+        </Text>
+      </Box>
+
+      <Card>
+        <Flex direction="column" gap="2">
+          <Text as="p" size="2">
+            Authentication and admin endpoints are documented here because they are part of the shipped contract.
+            Publishing this page is appropriate when that discoverability is intentional and authorization remains the
+            real access boundary.
+          </Text>
+          <Text as="p" size="2">
+            The raw OpenAPI file is also available at{" "}
+            <Link href={openapiSpecUrl} highContrast>
+              this generated spec URL
+            </Link>.
+          </Text>
+        </Flex>
+      </Card>
+
+      <Box
+        ref={swaggerContainerRef}
+        style={{
+          minHeight: 720,
+          overflow: "hidden",
+        }}
+      />
+    </Flex>
+  );
+}

--- a/frontend/src/types/swagger-ui.d.ts
+++ b/frontend/src/types/swagger-ui.d.ts
@@ -1,0 +1,34 @@
+declare module "swagger-ui-dist/swagger-ui-bundle.js" {
+  export type SwaggerUiInstance = {
+    destroy?: () => void;
+  };
+
+  export type SwaggerUiOptions = {
+    url?: string;
+    domNode: Element;
+    deepLinking?: boolean;
+    displayRequestDuration?: boolean;
+    docExpansion?: "list" | "full" | "none";
+    filter?: boolean;
+    persistAuthorization?: boolean;
+    defaultModelsExpandDepth?: number;
+    defaultModelExpandDepth?: number;
+    presets?: unknown[];
+    layout?: string;
+  };
+
+  type SwaggerUiBundle = {
+    (options: SwaggerUiOptions): SwaggerUiInstance;
+    presets: {
+      apis: unknown;
+    };
+  };
+
+  const swaggerUiBundle: SwaggerUiBundle;
+  export default swaggerUiBundle;
+}
+
+declare module "swagger-ui-dist/swagger-ui-standalone-preset.js" {
+  const swaggerUiStandalonePreset: unknown;
+  export default swaggerUiStandalonePreset;
+}

--- a/functions/src/openapi.yaml
+++ b/functions/src/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.1
 info:
   title: CrowdPM API
   version: 1.0.0
@@ -110,6 +110,40 @@ paths:
           description: Rate limited.
         '500':
           description: Stripe or application configuration is missing.
+        '502':
+          description: Stripe returned an upstream error.
+  /v1/theme-purchase/confirm:
+    post:
+      operationId: confirmThemeSaveCheckoutSession
+      summary: Confirm a completed theme save checkout
+      description: >
+        Retrieves a completed Stripe Checkout session, verifies that it belongs
+        to the signed-in account, and grants the one-time theme save unlock.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmCheckoutRequest'
+      responses:
+        '200':
+          description: Theme save unlock granted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfirmThemeSaveCheckoutResponse'
+        '400':
+          description: Invalid request payload or checkout session type.
+        '401':
+          description: Missing or invalid bearer token.
+        '403':
+          description: Checkout session belongs to another user.
+        '409':
+          description: Checkout session is still pending.
+        '429':
+          description: Rate limited.
         '502':
           description: Stripe returned an upstream error.
   /v1/subscription/checkout-session:
@@ -460,6 +494,8 @@ paths:
                   $ref: '#/components/schemas/Device'
         '401':
           description: Authentication required.
+        '429':
+          description: Rate limited.
     post:
       summary: Register a device
       description: >
@@ -469,7 +505,7 @@ paths:
       security:
         - BearerAuth: []
       requestBody:
-        required: true
+        required: false
         content:
           application/json:
             schema:
@@ -485,7 +521,11 @@ paths:
           description: Invalid request payload.
         '401':
           description: Missing or invalid bearer token.
-  /v1/devices/{id}/revoke:
+        '403':
+          description: Device quota exceeded for the current account plan.
+        '429':
+          description: Rate limited.
+  /v1/devices/{deviceId}/revoke:
     post:
       operationId: revokeDevice
       summary: Revoke a device
@@ -495,7 +535,7 @@ paths:
       security:
         - BearerAuth: []
       parameters:
-        - name: id
+        - name: deviceId
           in: path
           required: true
           schema:
@@ -503,12 +543,16 @@ paths:
       responses:
         '200':
           description: Device revoked.
+        '400':
+          description: Invalid device id.
         '401':
           description: Missing or invalid bearer token.
         '403':
           description: Caller does not own the device.
         '404':
           description: Device not found.
+        '429':
+          description: Rate limited.
   /v1/device-activation:
     get:
       operationId: getActivationSession
@@ -531,10 +575,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ActivationSession'
+        '400':
+          description: Invalid activation query.
         '401':
           description: Missing or invalid bearer token.
         '404':
           description: Session not found.
+        '429':
+          description: Rate limited.
   /v1/device-activation/authorize:
     post:
       operationId: authorizeActivationSession
@@ -561,10 +609,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ActivationSession'
+        '400':
+          description: Invalid authorization payload.
         '401':
           description: Missing credentials or MFA requirement not satisfied.
         '404':
           description: Session not found.
+        '429':
+          description: Rate limited.
   /v1/admin/devices/{id}/suspend:
     post:
       operationId: suspendDevice
@@ -598,6 +650,58 @@ paths:
           description: Caller lacks permission to suspend the device.
         '404':
           description: Device not found.
+        '429':
+          description: Rate limited.
+  /v1/admin/demo-batch:
+    get:
+      operationId: getAdminDemoBatch
+      summary: Retrieve the configured demo batch
+      description: >
+        Returns the public approved batch selected for the demo map experience,
+        or null when no valid demo batch is configured.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Demo batch setting returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DemoBatchSetting'
+        '401':
+          description: Missing or invalid bearer token.
+        '403':
+          description: Caller lacks permission to view submissions.
+        '429':
+          description: Rate limited.
+    put:
+      operationId: setAdminDemoBatch
+      summary: Configure the demo batch
+      description: >
+        Sets the public approved batch used as the demo map entry point.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DemoBatchUpdateRequest'
+      responses:
+        '200':
+          description: Demo batch setting updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DemoBatch'
+        '400':
+          description: Invalid request payload or batch is not public and approved.
+        '401':
+          description: Missing or invalid bearer token.
+        '403':
+          description: Caller lacks permission to moderate submissions.
+        '404':
+          description: Batch not found.
         '429':
           description: Rate limited.
   /v1/admin/submissions:
@@ -637,6 +741,8 @@ paths:
           description: Missing or invalid bearer token.
         '403':
           description: Caller lacks permission to view submissions.
+        '429':
+          description: Rate limited.
   /v1/admin/submissions/{deviceId}/{batchId}:
     patch:
       operationId: moderateSubmission
@@ -669,12 +775,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AdminSubmissionSummary'
+        '400':
+          description: Invalid request payload, device id, or batch id.
         '401':
           description: Missing or invalid bearer token.
         '403':
           description: Caller lacks permission to moderate submissions.
         '404':
           description: Submission not found.
+        '429':
+          description: Rate limited.
   /v1/admin/users:
     get:
       operationId: listAdminUsers
@@ -707,6 +817,8 @@ paths:
           description: Missing or invalid bearer token.
         '403':
           description: Caller lacks permission to manage users.
+        '429':
+          description: Rate limited.
   /v1/admin/users/{uid}:
     patch:
       operationId: updateAdminUser
@@ -738,6 +850,25 @@ paths:
           description: Missing or invalid bearer token.
         '403':
           description: Caller lacks permission to manage users.
+        '429':
+          description: Rate limited.
+  /v1/public/demo-batch:
+    get:
+      operationId: getPublicDemoBatch
+      summary: Retrieve the public demo batch
+      description: >
+        Returns the public approved batch selected for anonymous demo map use,
+        or null when no valid demo batch is configured.
+      security: []
+      responses:
+        '200':
+          description: Public demo batch returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicDemoBatchSetting'
+        '429':
+          description: Rate limited.
   /v1/public/batches:
     get:
       operationId: listPublicBatches
@@ -762,6 +893,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PublicBatchSummary'
+        '400':
+          description: Invalid query parameters.
+        '429':
+          description: Rate limited.
   /v1/public/batches/map:
     get:
       operationId: getPublicBatchMap
@@ -790,6 +925,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PublicBatchMapResponse'
+        '400':
+          description: Invalid query parameters.
+        '429':
+          description: Rate limited.
   /v1/public/batches/{deviceId}/{batchId}:
     get:
       operationId: getPublicBatchDetail
@@ -815,8 +954,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PublicBatchDetail'
+        '400':
+          description: Invalid device id or batch id.
         '404':
           description: Batch not found or not publicly visible.
+        '429':
+          description: Rate limited.
+        '500':
+          description: Batch payload could not be read from storage.
   /v1/batches:
     get:
       operationId: listBatches
@@ -825,6 +970,14 @@ paths:
         Returns the most recent batches owned by the authenticated caller.
       security:
         - BearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
       responses:
         '200':
           description: Batch summaries returned.
@@ -834,8 +987,12 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/BatchSummary'
+        '400':
+          description: Invalid query parameters.
         '401':
           description: Missing or invalid bearer token.
+        '429':
+          description: Rate limited.
   /v1/batches/{deviceId}/{batchId}:
     get:
       operationId: getBatchDetail
@@ -864,12 +1021,101 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BatchDetail'
+        '400':
+          description: Invalid device id or batch id.
         '401':
           description: Missing or invalid bearer token.
         '403':
           description: Caller does not own the referenced batch.
         '404':
           description: Device or batch not found, or payload unavailable.
+        '429':
+          description: Rate limited.
+        '500':
+          description: Batch payload could not be read from storage.
+    patch:
+      operationId: updateBatchVisibility
+      summary: Update batch visibility
+      description: >
+        Updates visibility for a stored ingest batch belonging to a device the
+        caller owns.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: deviceId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Device identifier associated with the batch.
+        - name: batchId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Ingest batch identifier.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchVisibilityUpdateRequest'
+      responses:
+        '200':
+          description: Updated batch summary returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchSummary'
+        '400':
+          description: Invalid request payload, device id, or batch id.
+        '401':
+          description: Missing or invalid bearer token.
+        '403':
+          description: Caller does not own the referenced batch.
+        '404':
+          description: Device or batch not found.
+        '429':
+          description: Rate limited.
+    delete:
+      operationId: deleteBatch
+      summary: Delete a stored batch
+      description: >
+        Deletes a stored ingest batch and its payload for a device the caller owns.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: deviceId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Device identifier associated with the batch.
+        - name: batchId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Ingest batch identifier.
+      responses:
+        '200':
+          description: Batch deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteBatchResponse'
+        '400':
+          description: Invalid device id or batch id.
+        '401':
+          description: Missing or invalid bearer token.
+        '403':
+          description: Caller does not own the referenced batch.
+        '404':
+          description: Device or batch not found.
+        '429':
+          description: Rate limited.
+        '500':
+          description: Batch payload could not be deleted from storage.
   /v1/user/settings:
     get:
       operationId: getUserSettings
@@ -886,6 +1132,8 @@ paths:
                 $ref: '#/components/schemas/UserSettings'
         '401':
           description: Missing or invalid bearer token.
+        '429':
+          description: Rate limited.
     put:
       operationId: updateUserSettings
       summary: Update user settings
@@ -913,6 +1161,8 @@ paths:
           description: Theme saving is not unlocked for the account.
         '401':
           description: Missing or invalid bearer token.
+        '429':
+          description: Rate limited.
 components:
   securitySchemes:
     BearerAuth:
@@ -950,6 +1200,31 @@ components:
           type: string
           format: uri
           description: Hosted Stripe Checkout URL to open in the browser.
+    ConfirmCheckoutRequest:
+      type: object
+      required:
+        - sessionId
+      properties:
+        sessionId:
+          type: string
+          minLength: 1
+          description: Stripe Checkout session identifier to confirm.
+      additionalProperties: false
+    ConfirmThemeSaveCheckoutResponse:
+      type: object
+      required:
+        - confirmed
+        - sessionId
+        - unlockGranted
+      properties:
+        confirmed:
+          type: boolean
+          example: true
+        sessionId:
+          type: string
+        unlockGranted:
+          type: boolean
+          example: true
     NodePurchaseCheckoutRequest:
       type: object
       additionalProperties: false
@@ -987,19 +1262,17 @@ components:
           type: string
           enum: [completed]
         paymentStatus:
-          type: string
-          nullable: true
+          type: [string, 'null']
         variantId:
-          type: string
-          nullable: true
+          type: [string, 'null']
           enum:
             - standard
             - no2
             - co2
             - co2_no2
+            - null
         variantLabel:
-          type: string
-          nullable: true
+          type: [string, 'null']
         quantity:
           type: integer
           minimum: 1
@@ -1008,45 +1281,42 @@ components:
           type: string
           example: usd
         unitAmount:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
           description: Per-device pre-tax price in the smallest currency unit.
         amountSubtotal:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
         amountTax:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
         amountShipping:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
         amountDiscount:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
         amountTotal:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
         completedAt:
-          type: string
+          type: [string, 'null']
           format: date-time
-          nullable: true
         customerEmail:
-          type: string
-          nullable: true
+          type: [string, 'null']
         shippingName:
-          type: string
-          nullable: true
+          type: [string, 'null']
         shippingAddress:
-          type: object
-          nullable: true
+          type: [object, 'null']
           additionalProperties:
-            type: string
-            nullable: true
+            type: [string, 'null']
     DeviceStatus:
       type: string
       enum:
         - ACTIVE
         - SUSPENDED
+        - REVOKED
+    DeviceRegistryStatus:
+      type: [string, 'null']
+      enum:
+        - active
+        - suspended
+        - revoked
+        - null
     Device:
       type: object
       description: A registered CrowdPM device.
@@ -1055,34 +1325,45 @@ components:
           type: string
           description: Device identifier.
         name:
-          type: string
+          type: [string, 'null']
           description: Friendly name supplied by the owner.
+        status:
+          oneOf:
+            - $ref: '#/components/schemas/DeviceStatus'
+            - type: 'null'
+          description: Moderation status applied to the device.
+        registryStatus:
+          $ref: '#/components/schemas/DeviceRegistryStatus'
         ownerUserIds:
-          type: array
+          type: [array, 'null']
           description: All Firebase UIDs that can access the device.
           items:
             type: string
           minItems: 1
         publicDeviceId:
-          type: string
+          type: [string, 'null']
           description: Raw device identifier provided by the owner (before namespacing).
         ownerScope:
-          type: string
+          type: [string, 'null']
           description: Slugged segment derived from the owner UID that is prepended to device IDs for uniqueness.
-        status:
-          $ref: '#/components/schemas/DeviceStatus'
         createdAt:
-          type: string
+          type: [string, 'null']
           format: date-time
           description: Timestamp when the device record was created.
+        fingerprint:
+          type: [string, 'null']
+          description: Human-verifiable device key fingerprint when registered through pairing.
+        lastSeenAt:
+          type: [string, 'null']
+          format: date-time
+          description: Timestamp when the device last used an access token or ingested data.
         location:
           $ref: '#/components/schemas/Location'
+      additionalProperties: true
       required:
         - id
-        - name
-        - ownerUserIds
-        - status
         - createdAt
+        - lastSeenAt
     ActivationSession:
       type: object
       description: Metadata about a pending pairing session.
@@ -1108,22 +1389,17 @@ components:
           type: string
           format: date-time
         requester_ip:
-          type: string
-          nullable: true
+          type: [string, 'null']
         requester_asn:
-          type: string
-          nullable: true
+          type: [string, 'null']
         poll_interval:
           type: integer
         device_id:
-          type: string
-          nullable: true
+          type: [string, 'null']
         authorized_account:
-          type: string
-          nullable: true
+          type: [string, 'null']
         viewer_account:
-          type: string
-          nullable: true
+          type: [string, 'null']
       required:
         - device_code
         - user_code
@@ -1151,8 +1427,6 @@ components:
         - longitude
     RegisterDeviceRequest:
       type: object
-      required:
-        - name
       properties:
         name:
           type: string
@@ -1192,18 +1466,15 @@ components:
           type: number
           format: double
         altitude:
-          type: number
+          type: [number, 'null']
           format: double
-          nullable: true
         precision:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
         timestamp:
           type: string
           format: date-time
         flags:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
     IngestBody:
       type: object
       properties:
@@ -1236,16 +1507,14 @@ components:
           type: string
           description: Device associated with the batch.
         deviceName:
-          type: string
-          nullable: true
+          type: [string, 'null']
           description: Friendly device name, if one is set.
         count:
           type: integer
           description: Number of points recorded in the batch.
         processedAt:
-          type: string
+          type: [string, 'null']
           format: date-time
-          nullable: true
           description: Timestamp when the batch was processed.
         visibility:
           $ref: '#/components/schemas/BatchVisibility'
@@ -1286,21 +1555,74 @@ components:
             $ref: '#/components/schemas/PublicBatchDetail'
       required:
         - batches
+    PublicDemoBatchSetting:
+      oneOf:
+        - $ref: '#/components/schemas/PublicBatchSummary'
+        - type: 'null'
+    DemoBatch:
+      type: object
+      required:
+        - deviceId
+        - batchId
+        - summary
+      properties:
+        deviceId:
+          type: string
+        batchId:
+          type: string
+        summary:
+          $ref: '#/components/schemas/AdminSubmissionSummary'
+    DemoBatchSetting:
+      oneOf:
+        - $ref: '#/components/schemas/DemoBatch'
+        - type: 'null'
+    DemoBatchUpdateRequest:
+      type: object
+      required:
+        - deviceId
+        - batchId
+      properties:
+        deviceId:
+          type: string
+          minLength: 1
+        batchId:
+          type: string
+          minLength: 1
+      additionalProperties: false
+    BatchVisibilityUpdateRequest:
+      type: object
+      required:
+        - visibility
+      properties:
+        visibility:
+          $ref: '#/components/schemas/BatchVisibility'
+      additionalProperties: false
+    DeleteBatchResponse:
+      type: object
+      required:
+        - status
+        - deviceId
+        - batchId
+      properties:
+        status:
+          type: string
+          enum: [deleted]
+        deviceId:
+          type: string
+        batchId:
+          type: string
     AdminSubmissionSummary:
       allOf:
         - $ref: '#/components/schemas/BatchSummary'
         - type: object
           properties:
             moderationReason:
-              type: string
-              nullable: true
+              type: [string, 'null']
             moderatedBy:
-              type: string
-              nullable: true
+              type: [string, 'null']
             moderatedAt:
-              type: string
+              type: [string, 'null']
               format: date-time
-              nullable: true
     AdminSubmissionListResponse:
       type: object
       properties:
@@ -1318,15 +1640,13 @@ components:
         moderationState:
           $ref: '#/components/schemas/ModerationState'
         reason:
-          type: string
-          nullable: true
+          type: [string, 'null']
           maxLength: 500
     AdminDeviceSuspendRequest:
       type: object
       properties:
         reason:
-          type: string
-          nullable: true
+          type: [string, 'null']
           maxLength: 500
     AdminRole:
       type: string
@@ -1339,8 +1659,7 @@ components:
         uid:
           type: string
         email:
-          type: string
-          nullable: true
+          type: [string, 'null']
         disabled:
           type: boolean
         roles:
@@ -1348,13 +1667,11 @@ components:
           items:
             $ref: '#/components/schemas/AdminRole'
         createdAt:
-          type: string
+          type: [string, 'null']
           format: date-time
-          nullable: true
         lastSignInAt:
-          type: string
+          type: [string, 'null']
           format: date-time
-          nullable: true
       required:
         - uid
         - disabled
@@ -1367,8 +1684,7 @@ components:
           items:
             $ref: '#/components/schemas/AdminUserSummary'
         nextPageToken:
-          type: string
-          nullable: true
+          type: [string, 'null']
       required:
         - users
         - nextPageToken
@@ -1425,17 +1741,15 @@ components:
           type: string
           enum: [active, inactive, trialing, past_due, canceled]
         billingInterval:
-          type: string
-          nullable: true
-          enum: [month, year]
+          type: [string, 'null']
+          enum: [month, year, null]
         canManageBilling:
           type: boolean
         cancelAtPeriodEnd:
           type: boolean
         currentPeriodEnd:
-          type: string
+          type: [string, 'null']
           format: date-time
-          nullable: true
         videoDownloadAccess:
           type: string
           enum: [preview_watermarked, full]
@@ -1514,21 +1828,17 @@ components:
         description:
           type: string
         currency:
-          type: string
-          nullable: true
+          type: [string, 'null']
         unitAmount:
-          type: integer
-          nullable: true
+          type: [integer, 'null']
         billingInterval:
-          type: string
-          nullable: true
-          enum: [month, year]
+          type: [string, 'null']
+          enum: [month, year, null]
         action:
           type: string
           enum: [checkout, contact]
         contactEmail:
-          type: string
-          nullable: true
+          type: [string, 'null']
       required:
         - offerId
         - planId

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
+      swagger-ui-dist:
+        specifier: 5.30.2
+        version: 5.30.2
     devDependencies:
       '@tanstack/react-query-devtools':
         specifier: 5.100.9
@@ -2059,6 +2062,9 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -5238,6 +5244,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-ui-dist@5.30.2:
+    resolution: {integrity: sha512-HWCg1DTNE/Nmapt+0m2EPXFwNKNeKK4PwMjkwveN/zn1cV2Kxi9SURd+m0SpdcSgWEK/O64sf8bzXdtUhigtHA==}
+
   table-layout@4.1.1:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
     engines: {node: '>=12.17'}
@@ -7923,6 +7932,8 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.16': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -11753,6 +11764,10 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swagger-ui-dist@5.30.2:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   table-layout@4.1.1:
     dependencies:


### PR DESCRIPTION
## Summary

Publish a live Swagger UI route at `/api-docs` from the existing frontend/Firebase deploy path, add a link to it near the bottom of the About page, and keep the shipped OpenAPI document aligned with the live REST surface.

This also makes the PR checks more production-appropriate by running lint, Functions tests, and a full workspace build before merge.

Because the docs page is public, this PR intentionally makes the full authenticated API contract discoverable, including admin and device lifecycle endpoints already present in the shipped spec. Authorization remains the access boundary.

## Checks

- [x] I have read CONTRIBUTING.md and this contribution is submitted under the applicable repository license terms.
- [x] If I am not already covered by a Denuo Web LLC contributor agreement, I agree to CLA.md for this contribution.
- [x] I have the right to submit this contribution, including any third-party materials identified in this pull request.
- [x] I ran the relevant lint, build, or test commands, or explained why they were not run.

Commands run:
- `pnpm lint`
- `pnpm --filter crowdpm-functions test`
- `pnpm build`
