### PR TITLE
Add Stripe payment catalog seeding script

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -11,6 +11,7 @@ pnpm --filter crowdpm-functions build
 pnpm --filter crowdpm-functions build:watch
 pnpm --filter crowdpm-functions test
 pnpm --filter crowdpm-functions emulate
+pnpm --filter crowdpm-functions payments:seed-catalog
 ```
 
 `pnpm dev` at the repository root builds functions once, starts the Firebase Emulator Suite, and watches TypeScript output into `functions/lib/`.
@@ -38,6 +39,37 @@ The code reads these values from `process.env`. In deployed Firebase Functions, 
 The node purchase flow now relies on Stripe Checkout shipping-address collection plus Stripe Tax. Configure Stripe Tax in the Stripe Dashboard so the physical-goods product can add US sales tax on top of the `$375` base node price after the buyer enters a US shipping address. Single-sensor variants are `$420`, and the combined CO2 + NO2 variant is `$480`, before tax.
 
 Stripe Checkout can still show `$0.00` tax for a valid US address when the Stripe account is not registered to collect tax in that jurisdiction. In Stripe's tax breakdown, that appears as `taxability_reason=not_collecting`. This is expected account configuration behavior, not a missing `automatic_tax` integration parameter.
+
+## Stripe Catalog Seeding
+
+Production checkout expects Firestore `paymentCatalog` documents to exist for each live Stripe product + default price. Seed them with:
+
+```bash
+pnpm --filter crowdpm-functions payments:seed-catalog
+```
+
+By default the seeding script loads `functions/.env.local` when present and syncs all known Stripe-backed products:
+
+- `nodeHardware`
+- `nodeHardwareNo2`
+- `nodeHardwareCo2`
+- `nodeHardwareCo2No2`
+- `themeSaveUnlock`
+- `subscriptionProMonthly`
+- `subscriptionProYearly`
+
+To seed only specific entries:
+
+```bash
+pnpm --filter crowdpm-functions payments:seed-catalog -- --only nodeHardware,nodeHardwareCo2
+```
+
+To seed a deployed Firebase project, provide credentials with Firestore access plus a live `STRIPE_SECRET_KEY`. Cloud Function Secret Manager bindings are not visible to this local script, so export the live key or load it from an env file explicitly:
+
+```bash
+FIREBASE_PROJECT_ID=crowdpmplatform STRIPE_SECRET_KEY=sk_live_... \
+pnpm --filter crowdpm-functions payments:seed-catalog -- --project crowdpmplatform
+```
 
 ## API Surface
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,6 +12,7 @@
     "emulate": "firebase emulators:start --project crowdpm-local",
     "pretest": "node ../scripts/prepare-functions-deps.mjs",
     "test": "vitest",
+    "payments:seed-catalog": "pnpm run build && node ./scripts/seed-payment-catalog.mjs",
     "admin:bootstrap-super-admin": "node ./scripts/bootstrap-super-admin.mjs",
     "admin:grant-role": "node ./scripts/grant-role.mjs"
   },

--- a/functions/scripts/seed-payment-catalog.mjs
+++ b/functions/scripts/seed-payment-catalog.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import admin from "firebase-admin";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const functionsDir = path.resolve(__dirname, "..");
+
+function parseArg(name) {
+  const args = process.argv.slice(2);
+  const direct = args.find((entry) => entry.startsWith(`--${name}=`));
+  if (direct) return direct.slice(name.length + 3);
+  const index = args.indexOf(`--${name}`);
+  if (index >= 0) return args[index + 1];
+  return undefined;
+}
+
+function parseCsvArg(name) {
+  const value = parseArg(name);
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function usage() {
+  console.log("Usage:");
+  console.log("  pnpm --filter crowdpm-functions payments:seed-catalog");
+  console.log("  pnpm --filter crowdpm-functions payments:seed-catalog -- --only nodeHardware,nodeHardwareCo2");
+  console.log("  pnpm --filter crowdpm-functions payments:seed-catalog -- --env-file functions/.env.live --project crowdpmplatform");
+  console.log("");
+  console.log("Options:");
+  console.log("  --only       Comma-separated list of paymentCatalog document ids to seed.");
+  console.log("  --env-file   Optional dotenv-style file to load before seeding.");
+  console.log("  --project    Optional Firebase project id override.");
+}
+
+function normalizeEnvValue(raw) {
+  const trimmed = raw.trim();
+  const unquoted = (trimmed.startsWith("\"") && trimmed.endsWith("\""))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    ? trimmed.slice(1, -1)
+    : trimmed;
+  return unquoted.replace(/\\n/g, "\n");
+}
+
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Env file not found: ${filePath}`);
+  }
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = normalizeEnvValue(trimmed.slice(eq + 1));
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+async function run() {
+  if (process.argv.includes("--help") || process.argv.includes("-h")) {
+    usage();
+    return;
+  }
+
+  const hadStripeSecretKey = typeof process.env.STRIPE_SECRET_KEY === "string" && process.env.STRIPE_SECRET_KEY.trim().length > 0;
+  const envFileArg = parseArg("env-file");
+  const envFile = envFileArg
+    ? path.resolve(process.cwd(), envFileArg)
+    : path.resolve(functionsDir, ".env.local");
+  const loadedDefaultLocalEnv = !envFileArg && envFile.endsWith(`${path.sep}.env.local`) && fs.existsSync(envFile);
+  if (fs.existsSync(envFile)) {
+    loadEnvFile(envFile);
+  }
+
+  const projectId = (parseArg("project") || process.env.FIREBASE_PROJECT_ID || "").trim();
+  if (projectId) {
+    process.env.FIREBASE_PROJECT_ID = projectId;
+  }
+  if (loadedDefaultLocalEnv && projectId && projectId !== "crowdpm-local" && !hadStripeSecretKey) {
+    throw new Error("Refusing to seed a non-local Firebase project with credentials from functions/.env.local. Export a live STRIPE_SECRET_KEY or provide --env-file explicitly.");
+  }
+
+  if (!admin.apps.length) {
+    admin.initializeApp(projectId ? { projectId } : undefined);
+  }
+
+  const { listStripeCatalogSeedConfigs, synchronizeStripeCatalog } = await import("../lib/services/nodePurchase.js");
+  const configs = listStripeCatalogSeedConfigs();
+  const only = parseCsvArg("only");
+  const availableIds = new Set(configs.map((config) => config.catalogDocId));
+
+  for (const catalogDocId of only) {
+    if (!availableIds.has(catalogDocId)) {
+      usage();
+      throw new Error(`Unknown catalog id "${catalogDocId}". Available ids: ${Array.from(availableIds).sort().join(", ")}`);
+    }
+  }
+
+  const selectedConfigs = only.length > 0
+    ? configs.filter((config) => only.includes(config.catalogDocId))
+    : configs;
+
+  const results = [];
+  for (const config of selectedConfigs) {
+    const result = await synchronizeStripeCatalog(config, { allowCreate: true });
+    results.push({
+      catalogDocId: result.catalogDocId,
+      productName: result.productName,
+      state: result.state,
+      productId: result.catalog.productId,
+      defaultPriceId: result.catalog.defaultPriceId,
+      unitAmount: result.catalog.unitAmount,
+      currency: result.catalog.currency,
+      recurringInterval: result.catalog.recurringInterval ?? null,
+    });
+  }
+
+  console.log(JSON.stringify({
+    projectId: projectId || null,
+    envFile: fs.existsSync(envFile) ? envFile : null,
+    results,
+  }, null, 2));
+}
+
+run().catch((err) => {
+  console.error("[seed-payment-catalog] failed", err.message || err);
+  process.exitCode = 1;
+});

--- a/functions/src/lib/fire.ts
+++ b/functions/src/lib/fire.ts
@@ -1,6 +1,20 @@
 import admin from "firebase-admin";
 let inited = false;
-export function app() { if (!inited) { admin.initializeApp(); inited = true; } return admin; }
+
+function initOptions() {
+  const projectId = process.env.FIREBASE_PROJECT_ID?.trim();
+  return projectId ? { projectId } : undefined;
+}
+
+export function app() {
+  if (!inited) {
+    if (!admin.apps.length) {
+      admin.initializeApp(initOptions());
+    }
+    inited = true;
+  }
+  return admin;
+}
 export const db = () => app().firestore();
 export const bucket = () => app().storage().bucket();
 export function hourBucket(ts: Date) {

--- a/functions/src/services/nodePurchase.ts
+++ b/functions/src/services/nodePurchase.ts
@@ -24,7 +24,7 @@ const DEFAULT_NODE_HARDWARE_QUANTITY = 1;
 const MAX_NODE_HARDWARE_QUANTITY = 10;
 const SUBSCRIPTION_SESSION_COLLECTION = "subscriptionCheckoutSessions";
 
-type PaymentCatalog = {
+export type PaymentCatalog = {
   productId: string;
   defaultPriceId: string;
   currency: string;
@@ -37,7 +37,7 @@ type PaymentCatalog = {
 type PurchaseType = "node_hardware" | "theme_save_unlock" | "subscription";
 type CheckoutSessionCreateParams = NonNullable<Parameters<Stripe["checkout"]["sessions"]["create"]>[0]>;
 
-type CheckoutProductConfig = {
+export type CheckoutProductConfig = {
   catalogDocId: string;
   sessionCollection: string;
   purchaseType: PurchaseType;
@@ -57,6 +57,13 @@ type CheckoutProductConfig = {
   allowPromotionCodes?: boolean;
   successSessionIdQueryParam?: string;
   shippingAddressCollection?: CheckoutSessionCreateParams["shipping_address_collection"];
+};
+
+export type StripeCatalogSyncResult = {
+  catalogDocId: string;
+  productName: string;
+  state: "current" | "seeded";
+  catalog: PaymentCatalog;
 };
 
 export type NodePurchaseCheckoutSession = {
@@ -319,20 +326,10 @@ function normalizeStripeAddress(address: Stripe.Address | null | undefined): Rec
 }
 
 async function ensureCatalog(config: CheckoutProductConfig): Promise<PaymentCatalog> {
-  const ref = db().collection(CATALOG_COLLECTION).doc(config.catalogDocId);
-  const snap = await ref.get();
-  const stored = readStoredCatalog(snap.exists ? (snap.data() as Record<string, unknown>) : undefined);
-  if (stored && isCurrentCatalog(stored, config)) {
-    return stored;
-  }
-  if (!allowStripeCatalogAutoCreate()) {
-    throw httpError(
-      500,
-      "stripe_catalog_not_seeded",
-      `Stripe catalog for ${config.productName} is missing or stale. Seed paymentCatalog before enabling checkout.`
-    );
-  }
+  return (await synchronizeStripeCatalog(config, { allowCreate: allowStripeCatalogAutoCreate() })).catalog;
+}
 
+async function createStripeCatalog(config: CheckoutProductConfig): Promise<PaymentCatalog> {
   let product: Stripe.Product;
   try {
     product = await getStripeClient().products.create({
@@ -361,7 +358,7 @@ async function ensureCatalog(config: CheckoutProductConfig): Promise<PaymentCata
     throw httpError(502, "stripe_error", `Stripe did not return a default price for ${config.productName}.`);
   }
 
-  const catalog: PaymentCatalog = {
+  return {
     productId: product.id,
     defaultPriceId,
     currency: config.currency,
@@ -370,13 +367,44 @@ async function ensureCatalog(config: CheckoutProductConfig): Promise<PaymentCata
     taxBehavior: config.taxBehavior,
     recurringInterval: config.recurringInterval ?? null,
   };
+}
+
+export async function synchronizeStripeCatalog(
+  config: CheckoutProductConfig,
+  options: { allowCreate: boolean },
+): Promise<StripeCatalogSyncResult> {
+  const ref = db().collection(CATALOG_COLLECTION).doc(config.catalogDocId);
+  const snap = await ref.get();
+  const stored = readStoredCatalog(snap.exists ? (snap.data() as Record<string, unknown>) : undefined);
+  if (stored && isCurrentCatalog(stored, config)) {
+    return {
+      catalogDocId: config.catalogDocId,
+      productName: config.productName,
+      state: "current",
+      catalog: stored,
+    };
+  }
+  if (!options.allowCreate) {
+    throw httpError(
+      500,
+      "stripe_catalog_not_seeded",
+      `Stripe catalog for ${config.productName} is missing or stale. Seed paymentCatalog before enabling checkout.`
+    );
+  }
+
+  const catalog = await createStripeCatalog(config);
 
   await ref.set({
     ...catalog,
     updatedAt: new Date().toISOString(),
   }, { merge: true });
 
-  return catalog;
+  return {
+    catalogDocId: config.catalogDocId,
+    productName: config.productName,
+    state: "seeded",
+    catalog,
+  };
 }
 
 type CreateCheckoutSessionOptions = {
@@ -530,6 +558,18 @@ function subscriptionConfigForOffer(offerId: "pro_monthly" | "pro_yearly"): Chec
     recurringInterval: offer.billingInterval,
     allowPromotionCodes: true,
   };
+}
+
+export function listStripeCatalogSeedConfigs(): CheckoutProductConfig[] {
+  return [
+    nodeHardwareConfigForVariant("standard"),
+    nodeHardwareConfigForVariant("no2"),
+    nodeHardwareConfigForVariant("co2"),
+    nodeHardwareConfigForVariant("co2_no2"),
+    THEME_SAVE_UNLOCK_CONFIG,
+    subscriptionConfigForOffer("pro_monthly"),
+    subscriptionConfigForOffer("pro_yearly"),
+  ];
 }
 
 export async function createNodePurchaseCheckoutSession(args: {

--- a/functions/test/services/nodePurchasePlanning.test.ts
+++ b/functions/test/services/nodePurchasePlanning.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCheckoutSessionPlan } from "../../src/services/nodePurchase.js";
+import { buildCheckoutSessionPlan, listStripeCatalogSeedConfigs } from "../../src/services/nodePurchase.js";
 
 describe("buildCheckoutSessionPlan", () => {
   it("builds Stripe Checkout params from config, catalog, URLs, and caller options", () => {
@@ -93,5 +93,19 @@ describe("buildCheckoutSessionPlan", () => {
         },
       },
     });
+  });
+});
+
+describe("listStripeCatalogSeedConfigs", () => {
+  it("returns all live Stripe-backed catalog definitions", () => {
+    expect(listStripeCatalogSeedConfigs().map((config) => config.catalogDocId)).toEqual([
+      "nodeHardware",
+      "nodeHardwareNo2",
+      "nodeHardwareCo2",
+      "nodeHardwareCo2No2",
+      "themeSaveUnlock",
+      "subscriptionProMonthly",
+      "subscriptionProYearly",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add a reusable Stripe catalog sync helper and a CLI seed script for paymentCatalog entries
- make Admin SDK initialization usable for project-targeted seeding scripts
- document how to seed live checkout catalog records and cover the seed list in tests

## Verification
- pnpm --filter crowdpm-functions build
- pnpm --filter crowdpm-functions test -- --run test/routes/nodePurchase.test.ts test/services/nodePurchasePlanning.test.ts
- node functions/scripts/seed-payment-catalog.mjs --help