### PR TITLE
Refactor node checkout for FCC campaign reservations

### DIFF
--- a/docs/test-plan.txt
+++ b/docs/test-plan.txt
@@ -11,7 +11,7 @@ Repository - GitHub Repo: https://github.com/Denuo-Web/CrowdPMPlatform/
 Website - CrowdPM Platform: https://crowdpmplatform.web.app/
 
 Testing Scope and Needs
-This sprint focuses on the highest-risk CrowdPM features: map/public pages, sign in and sign out, device activation and pairing, the user dashboard, admin moderation, node purchase, and the ingest pipeline.
+This sprint focuses on the highest-risk CrowdPM features: map/public pages, sign in and sign out, device activation and pairing, the user dashboard, admin moderation, node campaign checkout, and the ingest pipeline.
 
 - Public map and data visibility: public batches should appear, while private and quarantined data stays hidden.
 - Authentication and access: protected routes should only work for the correct users.
@@ -32,7 +32,7 @@ The Kanban board includes testing tasks for the areas above and assigns them as 
 
 - Mark: device end-to-end ingest flow from pair to visibility
 - Skylar: frontend smoke and regression testing
-- Jaron: node purchase and Stripe testing
+- Jaron: node campaign checkout and Stripe testing
 - Jack: role, access, and moderation testing
 
 Evidence

--- a/frontend/src/components/AppNavigation.tsx
+++ b/frontend/src/components/AppNavigation.tsx
@@ -157,7 +157,7 @@ export function AppNavigation({
               style={activeTab === "node" ? { fontWeight: 600 } : undefined}
               disabled={isLoading}
             >
-              Products
+              Reservations
             </DropdownMenu.Item>
             {isSignedIn ? (
               <>

--- a/frontend/src/components/LegalDocumentDialog.tsx
+++ b/frontend/src/components/LegalDocumentDialog.tsx
@@ -16,7 +16,7 @@ type LegalDocumentLinkProps = {
   onOpen: (documentId: LegalDocumentId) => void;
 };
 
-const LAST_UPDATED = "May 14, 2026";
+const LAST_UPDATED = "May 25, 2026";
 const COMPANY_NAME = "Denuo Web LLC";
 const COMPANY_CONTACT_EMAIL = "info@denuoweb.com";
 const COMPANY_LICENSE_EMAIL = "license@denuoweb.com";
@@ -126,7 +126,8 @@ function TermsOfService() {
       <P>
         These Terms of Service govern your access to and use of CrowdPM, a crowd-sourced PM2.5 air
         quality monitoring platform operated by {COMPANY_NAME}. By creating an account, using the
-        hosted service, or purchasing CrowdPM node hardware, you agree to these terms.
+        hosted service, reserving CrowdPM node hardware, or making a certification support
+        contribution, you agree to these terms.
       </P>
 
       <Section title="1. Service">
@@ -155,23 +156,31 @@ function TermsOfService() {
         </P>
       </Section>
 
-      <Section title="3. Paid Products and Digital Expansions">
+      <Section title="3. Paid Products, Reservations, and Support">
         <P>
-          CrowdPM node hardware is sold by {COMPANY_NAME}. Node purchases are one-time hardware
-          purchases processed through Stripe Checkout. The base node price is $375 with standard US
-          shipping included, before applicable sales tax. Applicable sales tax is calculated during
-          checkout from the shipping address.
+          CrowdPM founding node reservations and certification support contributions are processed
+          through Stripe Checkout for {COMPANY_NAME}. A founding node reservation is a conditional
+          preorder for planned physical CrowdPM node hardware. It is not immediate delivery and no
+          node will be shipped, delivered, transferred, or released to an end user before required
+          FCC equipment authorization is complete.
         </P>
         <P>
-          You are purchasing physical CrowdPM node hardware and any expressly listed related services
-          from {COMPANY_NAME}. Power source and USB-A-to-micro-USB cable are not included. CrowdPM
-          Platform software is open-source software maintained by {COMPANY_NAME} and contributors.
-          Purchase of hardware does not restrict your rights under the applicable open-source
-          software license.
+          The founding node reservation price is $375 per reserved node with standard US shipping
+          included after authorization, before applicable sales tax. Applicable tax is calculated
+          during checkout. We currently accept node reservations only for shipping addresses in the
+          United States. Power source and USB-A-to-micro-USB cable are not included.
         </P>
         <P>
-          Purchase of a node does not transfer ownership of {COMPANY_NAME} trademarks, branding,
-          hosted infrastructure, customer accounts, or proprietary business materials.
+          The current reservation refund checkpoint is December 31, 2026. If required FCC
+          authorization is not complete by that date, reservation holders may request cancellation
+          and refund of the unshipped reservation or choose to continue waiting. We may also cancel
+          and refund reservations if authorization, production, supply, compliance, safety, or
+          fulfillment issues make shipment impractical.
+        </P>
+        <P>
+          Certification support is a support-only contribution toward FCC testing and launch costs.
+          It does not reserve hardware, include shipment, create equity or debt, grant a service
+          entitlement, or qualify as a charitable tax-deductible donation.
         </P>
         <P>
           CrowdPM may also offer one-time digital expansion purchases processed through Stripe
@@ -181,29 +190,24 @@ function TermsOfService() {
           checkout from the billing location.
         </P>
         <P>
-          We currently accept node orders only for shipping addresses in the United States. You are
-          responsible for providing accurate contact, billing, and shipping information and for any
-          local requirements that apply to deploying, powering, mounting, or operating the hardware.
+          You are responsible for providing accurate contact, billing, and shipping information and
+          for any local requirements that apply to deploying, powering, mounting, or operating the
+          hardware. After authorized shipment and delivery, contact us within 30 days if a node
+          arrives damaged, defective, or materially different from what you ordered. We may ask for
+          reasonable troubleshooting details, photographs, diagnostic information, or return of the
+          hardware before issuing a replacement, repair, or refund.
         </P>
         <P>
-          Unless a different shipping estimate is stated at checkout or in an order confirmation, we
-          expect to ship node hardware within 30 days after completed payment. If we cannot ship
-          within the stated time or, if no time was stated, within 30 days, we will contact you with
-          a revised shipping date and the option to cancel the unshipped order for a prompt refund.
+          CrowdPM Platform software is open-source software maintained by {COMPANY_NAME} and
+          contributors. Purchase, reservation, or support does not restrict your rights under the
+          applicable open-source software license and does not transfer ownership of {COMPANY_NAME}
+          trademarks, branding, hosted infrastructure, customer accounts, or proprietary business
+          materials.
         </P>
         <P>
-          Contact us within 30 days after delivery if a node arrives damaged, defective, or
-          materially different from what you ordered. We may ask for reasonable troubleshooting
-          details, photographs, diagnostic information, or return of the hardware before issuing a
-          replacement, repair, or refund. Shipping charges included in the node price are not
-          separately refundable except where required by law or where the entire unshipped order is
-          cancelled. This policy does not limit rights that cannot be waived under applicable law.
-        </P>
-        <P>
-          Node hardware, firmware, sensors, GPS, wireless networking, and environmental
-          measurements are provided for community, research, and educational use. They are not
-          certified safety, medical, emergency, industrial hygiene, or regulatory monitoring
-          equipment.
+          Node hardware, firmware, sensors, GPS, wireless networking, and environmental measurements
+          are provided for community, research, and educational use. They are not certified safety,
+          medical, emergency, industrial hygiene, or regulatory monitoring equipment.
         </P>
       </Section>
 
@@ -328,7 +332,7 @@ function PrivacyPolicy() {
           <Bullet>User settings, including default batch visibility, map/rendering preferences, and theme preferences.</Bullet>
           <Bullet>Device records, including device IDs, optional device names, owner IDs, model/version, status, fingerprints, public key material, pairing codes, token records, and last-seen timestamps.</Bullet>
           <Bullet>Measurement and batch data, including PM2.5 readings, pollutant/unit, latitude, longitude, altitude, precision, timestamp, flags, batch IDs, visibility, moderation state, storage paths, and related metadata.</Bullet>
-          <Bullet>Paid product records, including Stripe Checkout session IDs, payment status, customer contact details, billing and shipping addresses where applicable, order totals, tax amounts, shipping details for hardware, receipts, refunds, support messages, and related fulfillment or entitlement records.</Bullet>
+          <Bullet>Paid product records, including Stripe Checkout session IDs, payment status, campaign tier, reservation or support quantity, customer contact details, billing and shipping addresses where applicable, order totals, tax amounts, shipping details for hardware reservations, receipts, refunds, support messages, and related fulfillment or entitlement records.</Bullet>
           <Bullet>Moderation and administration records, including moderator user IDs, role changes, disabled account status, moderation reasons, and audit records.</Bullet>
           <Bullet>Technical and security data, including IP address or network hints, request headers, logs, rate-limit keys, browser/device information available to the service, and error diagnostics.</Bullet>
           <Bullet>Local browser storage, including recent map zoom, timeline position, and selected batch data used to keep the interface responsive.</Bullet>
@@ -346,7 +350,7 @@ function PrivacyPolicy() {
         <BulletList>
           <Bullet>Provide authentication, device pairing, ingest, map display, dashboards, moderation, and administration features.</Bullet>
           <Bullet>Store and process sensor measurements, enforce visibility choices, and show public batches on the map and public API.</Bullet>
-          <Bullet>Process paid product purchases, calculate tax, ship hardware orders, grant digital entitlements, send receipts, handle refunds or replacements, and respond to order support requests.</Bullet>
+          <Bullet>Process paid product purchases, node reservations, certification support contributions, tax calculation, authorized hardware shipments, digital entitlements, receipts, refunds or replacements, and order support requests.</Bullet>
           <Bullet>Protect the service through rate limiting, abuse detection, access controls, logging, audits, token revocation, and troubleshooting.</Bullet>
           <Bullet>Save preferences and improve reliability, usability, and performance.</Bullet>
           <Bullet>Respond to support, licensing, security, or legal requests.</Bullet>
@@ -376,7 +380,7 @@ function PrivacyPolicy() {
         <BulletList>
           <Bullet>With Google Firebase and Google Cloud services used for authentication, hosting, functions, Firestore, storage, and operational logs.</Bullet>
           <Bullet>With Stripe for payment processing, sales tax calculation, checkout, receipts, fraud prevention, refunds, and related payment operations.</Bullet>
-          <Bullet>With shipping, fulfillment, repair, or customer-support providers where needed to deliver or support node hardware orders.</Bullet>
+          <Bullet>With shipping, fulfillment, repair, or customer-support providers where needed to deliver or support authorized node hardware reservations.</Bullet>
           <Bullet>With the public, when you or a device under your account submits public approved batch data.</Bullet>
           <Bullet>With authorized moderators and administrators who need access to operate, secure, moderate, or support CrowdPM.</Bullet>
           <Bullet>When required to comply with law, protect rights and safety, investigate abuse, or enforce terms.</Bullet>
@@ -534,12 +538,12 @@ function LicenseTerms() {
 
       <Section title="4. Hardware and Embedded Software">
         <P>
-          Buying CrowdPM node hardware transfers ownership of the physical device only. Purchase of
-          hardware does not restrict your rights under the applicable open-source software license,
-          and it does not transfer ownership of CrowdPM source code, firmware, {COMPANY_NAME}
-          trademarks or branding, hosted infrastructure, customer accounts, proprietary business
-          materials, datasets, hosted service features, or third-party software included with or used
-          by the device.
+          Reserving or buying CrowdPM node hardware transfers ownership of the physical device only
+          after authorized fulfillment. Reservation, purchase, or support does not restrict your
+          rights under the applicable open-source software license, and it does not transfer
+          ownership of CrowdPM source code, firmware, {COMPANY_NAME} trademarks or branding, hosted
+          infrastructure, customer accounts, proprietary business materials, datasets, hosted service
+          features, or third-party software included with or used by the device.
         </P>
         <P>
           Any CrowdPM firmware, setup scripts, examples, or application code included with a node are

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   FirestoreTimestampLike,
   MeasurementRecord,
   ModerationState,
+  NodeCampaignTierId,
   NodePurchaseReceipt,
   NodePurchaseVariantId,
   PublicBatchDetail,
@@ -121,6 +122,7 @@ export type {
   FirestoreTimestampLike,
   MeasurementRecord,
   ModerationState,
+  NodeCampaignTierId,
   NodePurchaseReceipt,
   NodePurchaseVariantId,
   PublicBatchDetail,
@@ -150,6 +152,19 @@ export async function createNodePurchaseCheckoutSession(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ variantId, quantity }),
+  });
+}
+
+export async function createNodeCampaignCheckoutSession(
+  tierId: NodeCampaignTierId,
+  quantity = 1,
+): Promise<CheckoutRedirectSession> {
+  return requestJson<CheckoutRedirectSession>("/v1/node-purchase/checkout-session", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ tierId, quantity }),
   });
 }
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -18,8 +18,8 @@ const HIGHLIGHTS = [
     description: "Browse shared PM2.5 measurements from the dedicated live map experience.",
   },
   {
-    title: "Node pairing",
-    description: "Register hardware securely with short-lived activation codes and account-scoped device authorization.",
+    title: "Conditional node launch",
+    description: "Reserve first-run hardware or support FCC testing without implying immediate shipment.",
   },
   {
     title: "Batch exports",
@@ -81,11 +81,12 @@ export default function HomePage({
               Community air quality intelligence
             </Text>
             <Heading as="h1" size="8" style={{ lineHeight: 1.02, maxWidth: 720 }}>
-              Hyper-local PM2.5 mapping for public and account-scoped air quality data.
+              Hyper-local PM2.5 mapping, now funding the first authorized node run.
             </Heading>
             <Text size="3" color="gray" as="p" style={{ maxWidth: 680 }}>
-              CrowdPM combines open hardware, account-scoped device activation, public measurement publishing,
-              and a 3D map for exploring community air quality data.
+              CrowdPM combines open hardware, account-scoped activation, public measurement publishing,
+              and a 3D map for community air quality data. Expo payments are structured as certification
+              support or conditional reservations that ship only after FCC authorization.
             </Text>
           </Flex>
 
@@ -116,7 +117,7 @@ export default function HomePage({
 
           <Flex gap="3" wrap="wrap">
             <Button variant="ghost" onClick={onOpenProducts}>
-              Browse hardware
+              Reserve or support
             </Button>
             <Button variant="ghost" onClick={onOpenAbout}>
               Learn about the project

--- a/frontend/src/pages/NodePage.tsx
+++ b/frontend/src/pages/NodePage.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 import {
   Box,
+  Badge,
   Button,
   Callout,
   Card,
@@ -19,7 +20,7 @@ import {
   type LegalDocumentId,
 } from "../components/LegalDocumentDialog";
 import { APP_ROUTES } from "../lib/appRoutes";
-import { createNodePurchaseCheckoutSession } from "../lib/api";
+import { createNodeCampaignCheckoutSession, type NodeCampaignTierId } from "../lib/api";
 import { useBrowserLocation } from "../lib/locationStore";
 
 type SectionProps = {
@@ -33,7 +34,10 @@ type TableProps = {
 };
 
 const BASE_NODE_PRICE_CENTS = 37_500;
+const CERTIFICATION_SUPPORT_UNIT_CENTS = 2_500;
 const NODE_QUANTITY_OPTIONS = Array.from({ length: 10 }, (_, index) => index + 1);
+const SUPPORT_QUANTITY_OPTIONS = Array.from({ length: 10 }, (_, index) => index + 1);
+const FCC_REFUND_CHECKPOINT_LABEL = "December 31, 2026";
 
 const ZERO_2_W_URL = "https://www.amazon.com/Raspberry-Heatsink-Adapter-Quad-core-Bluetooth/dp/B0DRRDJKDV?crid=3VRASN6F43J3I&dib=eyJ2IjoiMSJ9.t-BTW30Tluhki6lWlHIi2rulYzLQMAGFk2OvRz-XBQTYgqnJ_G_aL00we8CvIVnKwG2Qc75itVV_M0bpyBUc5YG3r7ovACXMTrtlMTUUnZBffQIiEHNn3Yqk-Chei1tyWsoAB2tTea-NTY83Z_QJUq5-3JfgkUiz0PjutePcLmnkuMuu_IWzavyrhKUNrUjTEI8BgTUNhwVf1epqDu2ahFmxjLDI5xaFLi5SgdjHoeg.dYFNm35Nc1V43vvTuZ8pC5dQ-abvmafEYOYXJh8E5Ss&dib_tag=se&keywords=raspberry%2Bpi%2Bzero%2B2%2Bw&qid=1778398787&sprefix=Raspberry%2BPi%2BZero%2B2%2BW%2Caps%2C178&sr=8-2-spons&sp_csd=d2lkZ2V0TmFtZT1zcF9hdGY&th=1&linkCode=ll2&tag=lipbalm01-20&linkId=35363b709757db3d01baa6b973c52a01&language=en_US&ref_=as_li_ss_tl";
 const PMS5003_URL = "https://www.amazon.com/BestParts-Digital-Particle-Concentration-PMS5003/dp/B0B1DQKV4N?crid=2CSK1VIYBL9LN&dib=eyJ2IjoiMSJ9.98U0BdlWh4vmYk-feCR0PmZpSTwOza-Io1F0J5aEYxt-Atifz_ulAtN2MSfswsFSwZAY5G94uyuiJwZQ1pJEgEFX1HBloSTDsFit2N07xKk13LTq4uwQ5LAGvFMMuUeWH2nLcVwe2SqFNb96Kn75VRFoIWku34vnGX3ryzbO4xgpcNSnNDH7QmqgRqu-KYCsnv1gNizUAnlnmoc22RpGTvxNFB4H45LOk2Hf_kqlcO8.l0Rt1mD9IbbwGvgp5ZFUzZgF46xGdPN76S6jbwz8CLE&dib_tag=se&keywords=Plantower+PMS5003&qid=1778398886&sprefix=plantower+pms5003%2Caps%2C225&sr=8-4&linkCode=ll2&tag=lipbalm01-20&linkId=7eb62de9f07d2cf0f66b47bb7349e0db&language=en_US&ref_=as_li_ss_tl";
@@ -43,8 +47,8 @@ const SD_CARD_URL = "https://www.amazon.com/SanDisk-Ultra-microSDHC-Memory-Adapt
 const USB_TO_TTL_URL = "https://www.amazon.com/dp/B0G61569JG?th=1&linkCode=ll2&tag=lipbalm01-20&linkId=5e49b7bc297b33e721e671312e45f1a1&language=en_US&ref_=as_li_ss_tl";
 const OTG_ADAPTER_URL = "https://www.amazon.com/dp/B015GZLG8I?th=1&linkCode=ll2&tag=lipbalm01-20&linkId=d31fc458d54c90c0e3a7ef69edccad08&language=en_US&ref_=as_li_ss_tl";
 const LINE_CABLES_URL = "https://www.amazon.com/dp/B08YRGVYPV?th=1&linkCode=ll2&tag=lipbalm01-20&linkId=0e64e274f6524982c4806f74982744e0&language=en_US&ref_=as_li_ss_tl";
-const NODE_PRODUCT_LABEL = "PM2.5 standard node";
-const NODE_PRODUCT_SUMMARY = "Current shipped build with PMS5003, GPS, temperature/humidity, local storage, and USB micro power input.";
+const NODE_PRODUCT_LABEL = "Founding node reservation";
+const NODE_PRODUCT_SUMMARY = "Conditional reservation for the standard PM2.5 node with PMS5003, GPS, temperature/humidity, local storage, and USB micro power input.";
 
 const USD_FORMATTER = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -290,18 +294,21 @@ function readCheckoutNotice(search: string): CheckoutNotice {
 
 export default function NodePage() {
   const location = useBrowserLocation();
-  const [isStartingCheckout, setIsStartingCheckout] = useState(false);
+  const [activeCheckoutTier, setActiveCheckoutTier] = useState<NodeCampaignTierId | null>(null);
   const [checkoutError, setCheckoutError] = useState("");
   const checkoutNotice = readCheckoutNotice(location.search);
   const [openLegalDocument, setOpenLegalDocument] = useState<LegalDocumentId | null>(null);
-  const [quantity, setQuantity] = useState(1);
-  const orderSubtotalCents = BASE_NODE_PRICE_CENTS * quantity;
+  const [reservationQuantity, setReservationQuantity] = useState(1);
+  const [supportUnits, setSupportUnits] = useState(1);
+  const reservationSubtotalCents = BASE_NODE_PRICE_CENTS * reservationQuantity;
+  const supportSubtotalCents = CERTIFICATION_SUPPORT_UNIT_CENTS * supportUnits;
 
-  const handlePurchaseNode = async () => {
+  const handleCampaignCheckout = async (tierId: NodeCampaignTierId) => {
     setCheckoutError("");
-    setIsStartingCheckout(true);
+    setActiveCheckoutTier(tierId);
     try {
-      const session = await createNodePurchaseCheckoutSession("standard", quantity);
+      const quantity = tierId === "certification_support" ? supportUnits : reservationQuantity;
+      const session = await createNodeCampaignCheckoutSession(tierId, quantity);
       window.location.assign(session.url);
       return;
     }
@@ -310,7 +317,7 @@ export default function NodePage() {
         ? err.message
         : "Unable to open checkout right now.";
       setCheckoutError(message);
-      setIsStartingCheckout(false);
+      setActiveCheckoutTier(null);
     }
   };
 
@@ -320,148 +327,215 @@ export default function NodePage() {
       <Box>
         <Flex direction={{ initial: "column", md: "row" }} align="start" gap="5">
           <Box style={{ flex: "1 1 34rem", minWidth: 0 }}>
-            <Heading as="h1" size="5">
-              Products - CrowdPM Node Hardware
-            </Heading>
-            <Text size="3" color="gray" mt="2" as="p">
-              A CrowdPM node is a small air-quality computer that measures PM2.5,
-              records where and when the measurement happened, stores the reading
-              locally, and uploads the data to CrowdPM when internet is available.
-            </Text>
-            <Text size="2" mt="3" as="p">
-              The base model is the only current production configuration. US
-              shipping is included; sales tax is calculated at checkout.
-            </Text>
+            <Flex direction="column" gap="3">
+              <Badge color="amber" variant="soft" style={{ alignSelf: "start" }}>
+                FCC authorization pending
+              </Badge>
+              <Heading as="h1" size="6">
+                Reserve a founding CrowdPM node, shipping only after authorization.
+              </Heading>
+              <Text size="3" color="gray" as="p">
+                CrowdPM is collecting conditional reservations and certification support for the expo launch.
+                Node hardware is not available for immediate delivery; reservations convert to shipment only after
+                FCC equipment authorization is complete.
+              </Text>
+              <Text size="2" color="gray" as="p">
+                The base model is the only planned first-run configuration. It measures PM2.5, GPS,
+                temperature/humidity, and local storage telemetry, then uploads to CrowdPM when internet is available.
+              </Text>
+            </Flex>
             <Box mt="4">
               <ProductGallery />
             </Box>
           </Box>
 
-          <Card
-            style={{
-              width: "100%",
-              maxWidth: "28rem",
-              minWidth: 0,
-            }}
-          >
-            <Flex direction="column" gap="4">
-              <Box>
-                <Text size="1" color="gray" as="div" style={{ textTransform: "uppercase", fontWeight: 600 }}>
-                  Standard configuration
-                </Text>
-                <Heading as="h2" size="4" mt="1">
-                  CrowdPM Node
-                </Heading>
-                <Flex align="baseline" gap="2" mt="2" wrap="wrap">
-                  <Text as="div" size="6" weight="bold">
-                    {formatUsd(BASE_NODE_PRICE_CENTS)}
-                  </Text>
-                  <Text size="2" color="gray">per device</Text>
-                </Flex>
-                <Text size="2" color="gray" as="p" mt="2">
-                  {NODE_PRODUCT_SUMMARY}
-                </Text>
-              </Box>
-
-              <Separator size="4" />
-
-              <Box>
-                <Text size="2" weight="bold" as="div" mb="2">
-                  Included
-                </Text>
-                <BulletList>
-                  <ListItem>PM2.5 sensing, GPS, temperature/humidity, local storage, and USB micro power input.</ListItem>
-                  <ListItem>Power source and USB-A-to-micro-USB cable are supplied by the customer.</ListItem>
-                  <ListItem>US shipping and first-time setup documentation.</ListItem>
-                </BulletList>
-              </Box>
-
-              <Flex align="center" justify="between" gap="3">
+          <Flex direction="column" gap="4" style={{ width: "100%", maxWidth: "30rem", minWidth: 0 }}>
+            <Card>
+              <Flex direction="column" gap="4">
                 <Box>
-                  <Text size="2" weight="bold" as="div">
-                    Quantity
+                  <Text size="1" color="gray" as="div" style={{ textTransform: "uppercase", fontWeight: 600 }}>
+                    Conditional preorder
                   </Text>
-                  <Text size="1" color="gray">Up to 10 devices per checkout</Text>
+                  <Heading as="h2" size="4" mt="1">
+                    Founding node reservation
+                  </Heading>
+                  <Flex align="baseline" gap="2" mt="2" wrap="wrap">
+                    <Text as="div" size="6" weight="bold">
+                      {formatUsd(BASE_NODE_PRICE_CENTS)}
+                    </Text>
+                    <Text size="2" color="gray">per reserved device</Text>
+                  </Flex>
+                  <Text size="2" color="gray" as="p" mt="2">
+                    {NODE_PRODUCT_SUMMARY}
+                  </Text>
                 </Box>
-                <Box style={{ width: "7rem" }}>
-                  <Select.Root
-                    value={String(quantity)}
-                    onValueChange={(value) => setQuantity(Number(value))}
-                  >
-                    <Select.Trigger aria-label="Quantity" />
-                    <Select.Content>
-                      {NODE_QUANTITY_OPTIONS.map((option) => (
-                        <Select.Item key={option} value={String(option)}>
-                          {option}
-                        </Select.Item>
-                      ))}
-                    </Select.Content>
-                  </Select.Root>
+
+                <Callout.Root color="amber" variant="surface">
+                  <Callout.Text>
+                    No node will be shipped, delivered, or released to an end user before FCC equipment authorization is complete.
+                  </Callout.Text>
+                </Callout.Root>
+
+                <Box>
+                  <Text size="2" weight="bold" as="div" mb="2">
+                    Reservation terms
+                  </Text>
+                  <BulletList>
+                    <ListItem>US shipping is included after authorization; sales tax is calculated at checkout.</ListItem>
+                    <ListItem>Power source and USB-A-to-micro-USB cable are supplied by the customer.</ListItem>
+                    <ListItem>If authorization is not complete by {FCC_REFUND_CHECKPOINT_LABEL}, reservation holders can request a refund or continue waiting.</ListItem>
+                  </BulletList>
                 </Box>
+
+                <Flex align="center" justify="between" gap="3">
+                  <Box>
+                    <Text size="2" weight="bold" as="div">
+                      Reserved quantity
+                    </Text>
+                    <Text size="1" color="gray">Up to 10 devices per checkout</Text>
+                  </Box>
+                  <Box style={{ width: "7rem" }}>
+                    <Select.Root
+                      value={String(reservationQuantity)}
+                      onValueChange={(value) => setReservationQuantity(Number(value))}
+                    >
+                      <Select.Trigger aria-label="Reserved quantity" />
+                      <Select.Content>
+                        {NODE_QUANTITY_OPTIONS.map((option) => (
+                          <Select.Item key={option} value={String(option)}>
+                            {option}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select.Root>
+                  </Box>
+                </Flex>
+
+                <Box
+                  style={{
+                    borderTop: "1px solid var(--gray-a5)",
+                    paddingTop: "var(--space-3)",
+                  }}
+                >
+                  <Flex justify="between" gap="3">
+                    <Text size="2" color="gray">Reservation</Text>
+                    <Text size="2">{formatUsd(BASE_NODE_PRICE_CENTS)}</Text>
+                  </Flex>
+                  <Flex justify="between" gap="3" mt="1">
+                    <Text size="2" color="gray">Tier</Text>
+                    <Text size="2">{NODE_PRODUCT_LABEL}</Text>
+                  </Flex>
+                  <Flex justify="between" gap="3" mt="1">
+                    <Text size="2" color="gray">Quantity</Text>
+                    <Text size="2">x {reservationQuantity}</Text>
+                  </Flex>
+                  <Separator size="4" my="3" />
+                  <Flex justify="between" align="center" gap="3">
+                    <Text size="3" weight="bold">Subtotal</Text>
+                    <Text as="div" size="5" weight="bold">{formatUsd(reservationSubtotalCents)}</Text>
+                  </Flex>
+                  <Text size="1" color="gray" as="p" mt="1">
+                    Applicable tax is calculated in Stripe Checkout.
+                  </Text>
+                </Box>
+
+                <Button
+                  size="3"
+                  onClick={() => { void handleCampaignCheckout("founding_node_reservation"); }}
+                  disabled={Boolean(activeCheckoutTier)}
+                >
+                  {activeCheckoutTier === "founding_node_reservation"
+                    ? "Opening Checkout..."
+                    : `Reserve - ${formatUsd(reservationSubtotalCents)}`}
+                </Button>
               </Flex>
+            </Card>
 
-              <Box
-                style={{
-                  borderTop: "1px solid var(--gray-a5)",
-                  paddingTop: "var(--space-3)",
-                }}
-              >
-                <Flex justify="between" gap="3">
-                  <Text size="2" color="gray">Base node</Text>
-                  <Text size="2">{formatUsd(BASE_NODE_PRICE_CENTS)}</Text>
+            <Card>
+              <Flex direction="column" gap="4">
+                <Box>
+                  <Text size="1" color="gray" as="div" style={{ textTransform: "uppercase", fontWeight: 600 }}>
+                    No hardware reward
+                  </Text>
+                  <Heading as="h2" size="4" mt="1">
+                    Certification support
+                  </Heading>
+                  <Flex align="baseline" gap="2" mt="2" wrap="wrap">
+                    <Text as="div" size="6" weight="bold">
+                      {formatUsd(CERTIFICATION_SUPPORT_UNIT_CENTS)}
+                    </Text>
+                    <Text size="2" color="gray">per support unit</Text>
+                  </Flex>
+                  <Text size="2" color="gray" as="p" mt="2">
+                    Helps fund FCC testing and launch costs. This tier does not reserve hardware, equity,
+                    charitable tax treatment, or service access.
+                  </Text>
+                </Box>
+
+                <Flex align="center" justify="between" gap="3">
+                  <Box>
+                    <Text size="2" weight="bold" as="div">
+                      Support units
+                    </Text>
+                    <Text size="1" color="gray">Choose 1 to 10 units</Text>
+                  </Box>
+                  <Box style={{ width: "7rem" }}>
+                    <Select.Root
+                      value={String(supportUnits)}
+                      onValueChange={(value) => setSupportUnits(Number(value))}
+                    >
+                      <Select.Trigger aria-label="Support units" />
+                      <Select.Content>
+                        {SUPPORT_QUANTITY_OPTIONS.map((option) => (
+                          <Select.Item key={option} value={String(option)}>
+                            {option}
+                          </Select.Item>
+                        ))}
+                      </Select.Content>
+                    </Select.Root>
+                  </Box>
                 </Flex>
-                <Flex justify="between" gap="3" mt="1">
-                  <Text size="2" color="gray">Configuration</Text>
-                  <Text size="2">{NODE_PRODUCT_LABEL}</Text>
-                </Flex>
-                <Flex justify="between" gap="3" mt="1">
-                  <Text size="2" color="gray">Quantity</Text>
-                  <Text size="2">x {quantity}</Text>
-                </Flex>
-                <Separator size="4" my="3" />
+
                 <Flex justify="between" align="center" gap="3">
-                  <Text size="3" weight="bold">Subtotal</Text>
-                  <Text as="div" size="5" weight="bold">{formatUsd(orderSubtotalCents)}</Text>
+                  <Text size="3" weight="bold">Support total</Text>
+                  <Text as="div" size="5" weight="bold">{formatUsd(supportSubtotalCents)}</Text>
                 </Flex>
-                <Text size="1" color="gray" as="p" mt="1">
-                  Sales tax is calculated in Stripe Checkout.
-                </Text>
-              </Box>
 
-              <Button
-                size="3"
-                onClick={() => { void handlePurchaseNode(); }}
-                disabled={isStartingCheckout}
-              >
-                {isStartingCheckout
-                  ? "Opening Checkout..."
-                  : `Checkout - ${formatUsd(orderSubtotalCents)}`}
-              </Button>
+                <Button
+                  size="3"
+                  variant="soft"
+                  onClick={() => { void handleCampaignCheckout("certification_support"); }}
+                  disabled={Boolean(activeCheckoutTier)}
+                >
+                  {activeCheckoutTier === "certification_support"
+                    ? "Opening Checkout..."
+                    : `Support certification - ${formatUsd(supportSubtotalCents)}`}
+                </Button>
+              </Flex>
+            </Card>
 
-              <Text size="1" color="gray" as="p">
-                Sold by Denuo Web LLC as a one-time hardware purchase. Orders are
-                subject to the{" "}
-                <LegalDocumentLink documentId="terms" onOpen={setOpenLegalDocument}>
-                  Terms
-                </LegalDocumentLink>
-                ,{" "}
-                <LegalDocumentLink documentId="license" onOpen={setOpenLegalDocument}>
-                  License
-                </LegalDocumentLink>
-                , and{" "}
-                <LegalDocumentLink documentId="privacy" onOpen={setOpenLegalDocument}>
-                  Privacy Policy
-                </LegalDocumentLink>
-                .
-              </Text>
-            </Flex>
-          </Card>
+            <Text size="1" color="gray" as="p">
+              Campaign payments are processed by Stripe for Denuo Web LLC and are subject to the{" "}
+              <LegalDocumentLink documentId="terms" onOpen={setOpenLegalDocument}>
+                Terms
+              </LegalDocumentLink>
+              ,{" "}
+              <LegalDocumentLink documentId="license" onOpen={setOpenLegalDocument}>
+                License
+              </LegalDocumentLink>
+              , and{" "}
+              <LegalDocumentLink documentId="privacy" onOpen={setOpenLegalDocument}>
+                Privacy Policy
+              </LegalDocumentLink>
+              .
+            </Text>
+          </Flex>
         </Flex>
 
         {checkoutNotice === "success" ? (
           <Callout.Root color="green" variant="surface" mt="4">
             <Callout.Text>
-              Checkout completed. Stripe will email a receipt. Signed-in purchases also appear in the dashboard.
+              Checkout completed. Stripe will email a receipt. Signed-in campaign payments also appear in the dashboard.
             </Callout.Text>
           </Callout.Root>
         ) : null}
@@ -483,17 +557,18 @@ export default function NodePage() {
 
       <Separator size="4" />
 
-      <Section title="Configuration Options">
+      <Section title="Campaign Options">
         <Text size="2" color="gray" as="p">
-          Each order is for the standard PM2.5 node. The selected quantity
-          applies to identical base-model devices.
+          Expo payments are either conditional reservations for the first standard node build
+          or support-only contributions toward certification costs.
         </Text>
 
         <InfoTable
-          headers={["Configuration", "What it adds", "Price"]}
+          headers={["Option", "What it includes", "Price"]}
           rows={[
-            [NODE_PRODUCT_LABEL, "PM2.5 sensing, GPS, temperature/humidity, local storage, and USB micro power input", formatUsd(BASE_NODE_PRICE_CENTS)],
-            ["Quantity", "1 to 10 devices per checkout", "Applied at checkout"],
+            [NODE_PRODUCT_LABEL, "Conditional reservation for PM2.5 sensing, GPS, temperature/humidity, local storage, USB micro power input, US shipping after authorization, and setup documentation", formatUsd(BASE_NODE_PRICE_CENTS)],
+            ["Certification support", "Support-only contribution toward FCC testing and launch costs; no hardware reward or service entitlement", `${formatUsd(CERTIFICATION_SUPPORT_UNIT_CENTS)} units`],
+            ["Refund checkpoint", `Reservation holders may request a refund or keep waiting if FCC authorization is not complete by ${FCC_REFUND_CHECKPOINT_LABEL}`, "Applies to reservations"],
           ]}
         />
       </Section>
@@ -508,7 +583,7 @@ export default function NodePage() {
           <Flex direction="column" gap="5" style={{ paddingTop: "var(--space-4)" }}>
             <Section title="Setup Your Node">
               <Text size="2" color="gray" as="p">
-                These are the first-time setup steps for a shipped CrowdPM node.
+                These are the first-time setup steps for an authorized shipped node or compatible self-built node.
                 Start near the Wi-Fi network you want the node to use most often.
                 Once setup is complete, the node should reconnect to that saved
                 network automatically on future startups.

--- a/frontend/src/pages/UserDashboard.tsx
+++ b/frontend/src/pages/UserDashboard.tsx
@@ -69,11 +69,20 @@ function formatReceiptDate(value: string | null): string {
 }
 
 function formatShippingLocation(receipt: NodePurchaseReceipt): string {
+  if (receipt.purchaseType === "certification_support") {
+    return "No shipment";
+  }
   const address = receipt.shippingAddress;
   const city = address?.city?.trim();
   const state = address?.state?.trim();
   if (city && state) return `${city}, ${state}`;
-  return city || state || "—";
+  return city || state || "Pending authorization";
+}
+
+function formatReceiptTier(receipt: NodePurchaseReceipt): string {
+  return receipt.tierLabel ?? receipt.variantLabel ?? (
+    receipt.purchaseType === "certification_support" ? "Certification support" : "Founding node reservation"
+  );
 }
 
 export default function UserDashboard({
@@ -613,7 +622,7 @@ export default function UserDashboard({
               <Heading size="6">{activeCount}</Heading>
             </Flex>
             <Flex direction="column" gap="1">
-              <Text size="2" color="gray">Hardware orders</Text>
+              <Text size="2" color="gray">Campaign payments</Text>
               <Heading size="6">{completedReceiptCount}</Heading>
             </Flex>
           </Flex>
@@ -634,8 +643,8 @@ export default function UserDashboard({
         <Flex direction="column" gap="3">
           <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">
             <Box>
-              <Heading as="h3" size="4">Hardware receipts</Heading>
-              <Text color="gray">Completed node purchases tied to this signed-in account.</Text>
+              <Heading as="h3" size="4">Campaign receipts</Heading>
+              <Text color="gray">Completed node reservations and certification support tied to this signed-in account.</Text>
             </Box>
             <Button variant="soft" onClick={refreshReceipts} disabled={isLoadingReceipts}>
               <ReloadIcon /> {isLoadingReceipts ? "Refreshing" : "Refresh"}
@@ -649,17 +658,17 @@ export default function UserDashboard({
           ) : null}
           {receipts.length === 0 ? (
             <Text color="gray" style={{ fontStyle: "italic" }}>
-              {isLoadingReceipts ? "Loading receipts…" : "No completed hardware purchases for this account."}
+              {isLoadingReceipts ? "Loading receipts…" : "No completed campaign payments for this account."}
             </Text>
           ) : (
             <Table.Root>
               <Table.Header>
                 <Table.Row>
                   <Table.ColumnHeaderCell>Date</Table.ColumnHeaderCell>
-                  <Table.ColumnHeaderCell>Configuration</Table.ColumnHeaderCell>
-                  <Table.ColumnHeaderCell>Qty</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Tier</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Units</Table.ColumnHeaderCell>
                   <Table.ColumnHeaderCell>Total</Table.ColumnHeaderCell>
-                  <Table.ColumnHeaderCell>Ship to</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>Fulfillment</Table.ColumnHeaderCell>
                   <Table.ColumnHeaderCell>Payment</Table.ColumnHeaderCell>
                 </Table.Row>
               </Table.Header>
@@ -674,7 +683,14 @@ export default function UserDashboard({
                         </Text>
                       </Flex>
                     </Table.Cell>
-                    <Table.Cell>{receipt.variantLabel ?? "CrowdPM Node Hardware"}</Table.Cell>
+                    <Table.Cell>
+                      <Flex direction="column" gap="1">
+                        <Text>{formatReceiptTier(receipt)}</Text>
+                        <Badge color={receipt.purchaseType === "certification_support" ? "blue" : "amber"} variant="soft">
+                          {receipt.purchaseType === "certification_support" ? "Support only" : "Conditional reservation"}
+                        </Badge>
+                      </Flex>
+                    </Table.Cell>
                     <Table.Cell>{receipt.quantity}</Table.Cell>
                     <Table.Cell>
                       <Flex direction="column" gap="1">

--- a/functions/src/openapi.yaml
+++ b/functions/src/openapi.yaml
@@ -30,18 +30,22 @@ paths:
   /v1/node-purchase/checkout-session:
     post:
       operationId: createNodePurchaseCheckoutSession
-      summary: Create a Stripe Checkout session for node hardware
+      summary: Create a Stripe Checkout session for the node campaign
       description: >
-        Creates a Stripe Checkout session for the one-time CrowdPM node hardware
-        purchase. Checkout collects a US shipping address, applies Stripe Tax
-        based on that destination, and charges the standard PM2.5 hardware
-        product. The standard PM2.5 node is $375 with shipping included before
-        tax. Power source and USB-A-to-micro-USB cable are not included. The
-        selected quantity can be 1 through 10 devices. If a valid bearer token is
-        supplied, the completed hardware receipt is tied to that account. The
-        backing live Stripe product + price must be seeded in Firestore
-        `paymentCatalog` before public checkout is enabled; local and test
-        environments may opt into automatic catalog creation.
+        Creates a Stripe Checkout session for a CrowdPM founding node
+        reservation or a support-only certification contribution. A founding
+        node reservation is a conditional preorder: checkout collects a US
+        shipping address, applies Stripe Tax, and no node is shipped or
+        delivered before FCC equipment authorization is complete. The founding
+        node reservation is $375 with shipping included after authorization,
+        before tax. The certification support tier is $25 per support unit and
+        does not reserve hardware, grant service access, create equity, or
+        qualify as a charitable tax-deductible donation. The selected quantity
+        can be 1 through 10 units. If a valid bearer token is supplied, the
+        completed campaign receipt is tied to that account. The backing live
+        Stripe product + price must be seeded in Firestore `paymentCatalog`
+        before public checkout is enabled; local and test environments may opt
+        into automatic catalog creation.
       security: []
       requestBody:
         required: false
@@ -67,13 +71,13 @@ paths:
   /v1/node-purchase/receipts:
     get:
       operationId: listNodePurchaseReceipts
-      summary: List signed-in user's node hardware receipts
-      description: Returns completed CrowdPM node hardware purchase receipts tied to the signed-in account.
+      summary: List signed-in user's node campaign receipts
+      description: Returns completed CrowdPM node reservations and certification support receipts tied to the signed-in account.
       security:
         - BearerAuth: []
       responses:
         '200':
-          description: Completed node hardware receipts.
+          description: Completed node campaign receipts.
           content:
             application/json:
               schema:
@@ -258,7 +262,7 @@ paths:
       operationId: handleStripeWebhook
       summary: Receive Stripe webhook events
       description: >
-        Accepts Stripe webhook callbacks and records successful node hardware,
+        Accepts Stripe webhook callbacks and records successful node campaign,
         theme save unlock, and recurring subscription events, including shipping
         details where applicable, calculated tax, and account entitlements after
         verifying the
@@ -1229,17 +1233,24 @@ components:
       type: object
       additionalProperties: false
       properties:
+        tierId:
+          type: string
+          enum:
+            - founding_node_reservation
+            - certification_support
+          default: founding_node_reservation
+          description: Campaign tier to check out.
         variantId:
           type: string
           enum:
             - standard
-          description: Selected CrowdPM hardware product variant.
+          description: Backward-compatible hardware variant field for founding node reservations.
         quantity:
           type: integer
           minimum: 1
           maximum: 10
           default: 1
-          description: Number of devices to purchase in this checkout.
+          description: Number of reserved nodes or support units to check out.
     NodePurchaseReceipt:
       type: object
       required:
@@ -1254,11 +1265,19 @@ components:
           description: Stripe Checkout session identifier.
         purchaseType:
           type: string
-          enum: [node_hardware]
+          enum: [node_hardware, certification_support]
         status:
           type: string
           enum: [completed]
         paymentStatus:
+          type: [string, 'null']
+        tierId:
+          type: [string, 'null']
+          enum:
+            - founding_node_reservation
+            - certification_support
+            - null
+        tierLabel:
           type: [string, 'null']
         variantId:
           type: [string, 'null']
@@ -1276,7 +1295,7 @@ components:
           example: usd
         unitAmount:
           type: [integer, 'null']
-          description: Per-device pre-tax price in the smallest currency unit.
+          description: Per-unit pre-tax price in the smallest currency unit.
         amountSubtotal:
           type: [integer, 'null']
         amountTax:

--- a/functions/src/routes/nodePurchase.ts
+++ b/functions/src/routes/nodePurchase.ts
@@ -14,7 +14,7 @@ import {
   confirmSubscriptionCheckoutSession,
   confirmThemeSaveCheckoutSession,
   createBillingPortalSession,
-  createNodePurchaseCheckoutSession,
+  createNodeCampaignCheckoutSession,
   createSubscriptionCheckoutSession,
   createThemeSaveCheckoutSession,
   handleStripeWebhook,
@@ -26,6 +26,7 @@ type RequestWithRawBody = {
 };
 
 const nodeCheckoutBodySchema = z.object({
+  tierId: z.enum(["founding_node_reservation", "certification_support"]).optional(),
   variantId: z.enum(["standard"]).optional(),
   quantity: z.number().int().min(1).max(10).optional(),
 }).strict();
@@ -66,7 +67,8 @@ export const nodePurchaseRoutes: FastifyPluginAsync = async (app) => {
       throw httpError(400, "invalid_request", "invalid request", { details: parsed.error.flatten() });
     }
     const user = getOptionalRequestUser(req);
-    return createNodePurchaseCheckoutSession({
+    return createNodeCampaignCheckoutSession({
+      tierId: parsed.data.tierId,
       variantId: parsed.data.variantId,
       quantity: parsed.data.quantity,
       userId: user?.uid,

--- a/functions/src/services/nodePurchase.ts
+++ b/functions/src/services/nodePurchase.ts
@@ -15,13 +15,16 @@ const STRIPE_API_VERSION = "2026-04-22.dahlia";
 const DEFAULT_PRODUCT_TAX_CODE = "txcd_99999999";
 
 const NODE_HARDWARE_ALLOWED_SHIPPING_COUNTRIES: Array<"US"> = ["US"];
-const NODE_HARDWARE_CHECKOUT_SUBMIT_MESSAGE = "You are purchasing physical CrowdPM node hardware and any expressly listed related services from Denuo Web LLC. Power source and USB-A-to-micro-USB cable are not included. Purchase does not transfer proprietary rights in CrowdPM Platform software or restrict rights under applicable open-source licenses. Price includes US shipping. Applicable sales tax is calculated at checkout.";
-const NODE_HARDWARE_SHIPPING_ADDRESS_MESSAGE = "We currently ship CrowdPM nodes only to addresses in the United States.";
+const NODE_RESERVATION_CHECKOUT_SUBMIT_MESSAGE = "Conditional preorder: no CrowdPM node will be shipped or delivered until FCC equipment authorization is complete. If authorization is not complete by the stated refund checkpoint, you may request a refund or continue waiting. Price includes US shipping after authorization; applicable sales tax is calculated at checkout.";
+const NODE_RESERVATION_SHIPPING_ADDRESS_MESSAGE = "Shipping is available only to US addresses and will occur only after FCC equipment authorization is complete.";
+const CERTIFICATION_SUPPORT_CHECKOUT_SUBMIT_MESSAGE = "Support-only contribution toward FCC testing and launch costs. No hardware, service entitlement, equity, or charitable tax deduction is provided. Applicable tax, if any, is calculated at checkout.";
 const THEME_SAVE_UNLOCK_CHECKOUT_SUBMIT_MESSAGE = "One-time digital expansion purchase that permanently unlocks theme preference saving for the purchasing account. Applicable sales tax is calculated at checkout.";
 const SUBSCRIPTION_CHECKOUT_SUBMIT_MESSAGE = "Recurring CrowdPM account subscription. Applicable taxes are calculated in Stripe Checkout. Cancel any time from the billing portal.";
 const DEFAULT_NODE_HARDWARE_VARIANT_ID = "standard";
+const DEFAULT_NODE_CAMPAIGN_TIER_ID = "founding_node_reservation";
 const DEFAULT_NODE_HARDWARE_QUANTITY = 1;
 const MAX_NODE_HARDWARE_QUANTITY = 10;
+const FCC_REFUND_CHECKPOINT_DATE = "2026-12-31";
 const SUBSCRIPTION_SESSION_COLLECTION = "subscriptionCheckoutSessions";
 
 export type PaymentCatalog = {
@@ -34,7 +37,7 @@ export type PaymentCatalog = {
   recurringInterval?: Stripe.Price.Recurring.Interval | null;
 };
 
-type PurchaseType = "node_hardware" | "theme_save_unlock" | "subscription";
+type PurchaseType = "node_hardware" | "certification_support" | "theme_save_unlock" | "subscription";
 type CheckoutSessionCreateParams = NonNullable<Parameters<Stripe["checkout"]["sessions"]["create"]>[0]>;
 
 export type CheckoutProductConfig = {
@@ -78,12 +81,15 @@ export type ConfirmSubscriptionCheckoutSessionResult = {
 };
 
 export type NodePurchaseVariantId = "standard";
+export type NodeCampaignTierId = "founding_node_reservation" | "certification_support";
 
 export type NodePurchaseReceipt = {
   sessionId: string;
-  purchaseType: "node_hardware";
+  purchaseType: "node_hardware" | "certification_support";
   status: "completed";
   paymentStatus: string | null;
+  tierId: NodeCampaignTierId | null;
+  tierLabel: string | null;
   variantId: NodePurchaseVariantId | null;
   variantLabel: string | null;
   quantity: number;
@@ -116,10 +122,10 @@ const NODE_HARDWARE_BASE_CONFIG: Omit<CheckoutProductConfig, "catalogDocId" | "p
   cancelQueryParam: "checkout=cancelled",
   customText: {
     shipping_address: {
-      message: NODE_HARDWARE_SHIPPING_ADDRESS_MESSAGE,
+      message: NODE_RESERVATION_SHIPPING_ADDRESS_MESSAGE,
     },
     submit: {
-      message: NODE_HARDWARE_CHECKOUT_SUBMIT_MESSAGE,
+      message: NODE_RESERVATION_CHECKOUT_SUBMIT_MESSAGE,
     },
   },
   shippingAddressCollection: {
@@ -129,10 +135,10 @@ const NODE_HARDWARE_BASE_CONFIG: Omit<CheckoutProductConfig, "catalogDocId" | "p
 
 const NODE_HARDWARE_VARIANTS: Record<NodePurchaseVariantId, NodeHardwareVariantConfig> = {
   standard: {
-    catalogDocId: "nodeHardware",
-    label: "PM2.5 standard node",
-    productName: "CrowdPM Node Hardware",
-    description: "Physical node hardware purchase with US shipping included.",
+    catalogDocId: "nodeReservation",
+    label: "Founding node reservation",
+    productName: "CrowdPM Founding Node Reservation",
+    description: "Conditional CrowdPM node preorder; ships only after FCC equipment authorization.",
     unitAmount: 37_500,
   },
 };
@@ -143,6 +149,27 @@ function nodeHardwareConfigForVariant(variantId: NodePurchaseVariantId): Checkou
     ...NODE_HARDWARE_VARIANTS[variantId],
   };
 }
+
+const CERTIFICATION_SUPPORT_CONFIG: CheckoutProductConfig = {
+  catalogDocId: "certificationSupport",
+  sessionCollection: NODE_HARDWARE_BASE_CONFIG.sessionCollection,
+  purchaseType: "certification_support",
+  productName: "CrowdPM Certification Support",
+  description: "Support-only contribution toward FCC testing and launch costs. No hardware reward.",
+  currency: "usd",
+  unitAmount: 2_500,
+  taxCode: DEFAULT_PRODUCT_TAX_CODE,
+  taxBehavior: "exclusive",
+  billingAddressCollection: "required",
+  successPath: "/node",
+  successQueryParam: "checkout=success",
+  cancelQueryParam: "checkout=cancelled",
+  customText: {
+    submit: {
+      message: CERTIFICATION_SUPPORT_CHECKOUT_SUBMIT_MESSAGE,
+    },
+  },
+};
 
 const THEME_SAVE_UNLOCK_CONFIG: CheckoutProductConfig = {
   catalogDocId: "themeSaveUnlock",
@@ -189,6 +216,13 @@ function readNonEmptyString(value: unknown): string | null {
 
 function readNodeVariantId(value: unknown): NodePurchaseVariantId | null {
   if (value === "standard") {
+    return value;
+  }
+  return null;
+}
+
+function readNodeCampaignTierId(value: unknown): NodeCampaignTierId | null {
+  if (value === "founding_node_reservation" || value === "certification_support") {
     return value;
   }
   return null;
@@ -542,18 +576,44 @@ function subscriptionConfigForOffer(offerId: "pro_monthly" | "pro_yearly"): Chec
 export function listStripeCatalogSeedConfigs(): CheckoutProductConfig[] {
   return [
     nodeHardwareConfigForVariant("standard"),
+    CERTIFICATION_SUPPORT_CONFIG,
     THEME_SAVE_UNLOCK_CONFIG,
     subscriptionConfigForOffer("pro_monthly"),
     subscriptionConfigForOffer("pro_yearly"),
   ];
 }
 
-export async function createNodePurchaseCheckoutSession(args: {
+export async function createNodeCampaignCheckoutSession(args: {
+  tierId?: NodeCampaignTierId;
   variantId?: NodePurchaseVariantId;
   quantity?: number;
   userId?: string;
   customerEmail?: string | null;
 } = {}): Promise<NodePurchaseCheckoutSession> {
+  const tierId = args.tierId ?? DEFAULT_NODE_CAMPAIGN_TIER_ID;
+  if (tierId === "certification_support") {
+    const quantity = args.quantity ?? DEFAULT_NODE_HARDWARE_QUANTITY;
+    return createCheckoutSession(CERTIFICATION_SUPPORT_CONFIG, {
+      userId: args.userId,
+      customerEmail: args.customerEmail,
+      quantity,
+      metadata: {
+        tierId,
+        tierLabel: "Certification support",
+        quantity: String(quantity),
+        hardwareReward: "false",
+        charitableDonation: "false",
+      },
+      sessionData: {
+        tierId,
+        tierLabel: "Certification support",
+        quantity,
+        hardwareReward: false,
+        charitableDonation: false,
+      },
+    });
+  }
+
   const variantId = args.variantId ?? DEFAULT_NODE_HARDWARE_VARIANT_ID;
   const quantity = args.quantity ?? DEFAULT_NODE_HARDWARE_QUANTITY;
   const variant = NODE_HARDWARE_VARIANTS[variantId];
@@ -562,15 +622,40 @@ export async function createNodePurchaseCheckoutSession(args: {
     customerEmail: args.customerEmail,
     quantity,
     metadata: {
+      tierId,
+      tierLabel: "Founding node reservation",
       variantId,
       variantLabel: variant.label,
       quantity: String(quantity),
+      fccAuthorizationRequired: "true",
+      noDeliveryBeforeAuthorization: "true",
+      refundCheckpointDate: FCC_REFUND_CHECKPOINT_DATE,
     },
     sessionData: {
+      tierId,
+      tierLabel: "Founding node reservation",
       variantId,
       variantLabel: variant.label,
       quantity,
+      fccAuthorizationRequired: true,
+      noDeliveryBeforeAuthorization: true,
+      refundCheckpointDate: FCC_REFUND_CHECKPOINT_DATE,
     },
+  });
+}
+
+export async function createNodePurchaseCheckoutSession(args: {
+  variantId?: NodePurchaseVariantId;
+  quantity?: number;
+  userId?: string;
+  customerEmail?: string | null;
+} = {}): Promise<NodePurchaseCheckoutSession> {
+  return createNodeCampaignCheckoutSession({
+    tierId: "founding_node_reservation",
+    variantId: args.variantId,
+    quantity: args.quantity,
+    userId: args.userId,
+    customerEmail: args.customerEmail,
   });
 }
 
@@ -847,6 +932,14 @@ async function resolvePurchase(session: Stripe.Checkout.Session): Promise<Resolv
 
   const nodeSnap = await db().collection(NODE_HARDWARE_BASE_CONFIG.sessionCollection).doc(session.id).get();
   const storedSession = nodeSnap.exists ? (nodeSnap.data() as Record<string, unknown>) : null;
+  const storedPurchaseType = readNonEmptyString(storedSession?.purchaseType);
+  if (metadataPurchaseType === CERTIFICATION_SUPPORT_CONFIG.purchaseType || storedPurchaseType === CERTIFICATION_SUPPORT_CONFIG.purchaseType) {
+    return {
+      config: CERTIFICATION_SUPPORT_CONFIG,
+      storedSession,
+    };
+  }
+
   const variantId = readNodeVariantId(session.metadata?.variantId)
     ?? readNodeVariantId(storedSession?.variantId)
     ?? DEFAULT_NODE_HARDWARE_VARIANT_ID;
@@ -945,12 +1038,20 @@ async function recordCompletedSession(
     return;
   }
 
+  const tierId = readNodeCampaignTierId(session.metadata?.tierId) ?? readNodeCampaignTierId(storedSession?.tierId);
+  const tierLabel = readNonEmptyString(session.metadata?.tierLabel) ?? readNonEmptyString(storedSession?.tierLabel);
   const variantId = readNodeVariantId(session.metadata?.variantId) ?? readNodeVariantId(storedSession?.variantId);
   const variantLabel = readNonEmptyString(session.metadata?.variantLabel) ?? readNonEmptyString(storedSession?.variantLabel);
   const quantity = readNodeQuantity(session.metadata?.quantity)
     ?? readNodeQuantity(storedSession?.quantity)
     ?? DEFAULT_NODE_HARDWARE_QUANTITY;
   const userId = resolveNodePurchaseUserId(session, storedSession);
+  if (tierId) {
+    payload.tierId = tierId;
+  }
+  if (tierLabel) {
+    payload.tierLabel = tierLabel;
+  }
   if (variantId) {
     payload.variantId = variantId;
   }
@@ -958,6 +1059,15 @@ async function recordCompletedSession(
     payload.variantLabel = variantLabel;
   }
   payload.quantity = quantity;
+  if (config.purchaseType === NODE_HARDWARE_BASE_CONFIG.purchaseType) {
+    payload.fccAuthorizationRequired = true;
+    payload.noDeliveryBeforeAuthorization = true;
+    payload.refundCheckpointDate = FCC_REFUND_CHECKPOINT_DATE;
+  }
+  if (config.purchaseType === CERTIFICATION_SUPPORT_CONFIG.purchaseType) {
+    payload.hardwareReward = false;
+    payload.charitableDonation = false;
+  }
   if (userId) {
     payload.userId = userId;
   }
@@ -966,7 +1076,10 @@ async function recordCompletedSession(
 }
 
 function receiptFromSession(data: Record<string, unknown>): NodePurchaseReceipt | null {
-  if (data.purchaseType !== NODE_HARDWARE_BASE_CONFIG.purchaseType || data.status !== "completed") {
+  if (
+    (data.purchaseType !== NODE_HARDWARE_BASE_CONFIG.purchaseType && data.purchaseType !== CERTIFICATION_SUPPORT_CONFIG.purchaseType)
+    || data.status !== "completed"
+  ) {
     return null;
   }
   const sessionId = readNonEmptyString(data.sessionId);
@@ -982,9 +1095,11 @@ function receiptFromSession(data: Record<string, unknown>): NodePurchaseReceipt 
 
   return {
     sessionId,
-    purchaseType: "node_hardware",
+    purchaseType: data.purchaseType === CERTIFICATION_SUPPORT_CONFIG.purchaseType ? "certification_support" : "node_hardware",
     status: "completed",
     paymentStatus: readNonEmptyString(data.paymentStatus),
+    tierId: readNodeCampaignTierId(data.tierId),
+    tierLabel: readNonEmptyString(data.tierLabel),
     variantId: readNodeVariantId(data.variantId),
     variantLabel: readNonEmptyString(data.variantLabel),
     quantity: readNodeQuantity(data.quantity) ?? DEFAULT_NODE_HARDWARE_QUANTITY,

--- a/functions/test/routes/nodePurchase.test.ts
+++ b/functions/test/routes/nodePurchase.test.ts
@@ -172,8 +172,8 @@ describe("POST /v1/node-purchase/checkout-session", () => {
     });
 
     expect(mocks.productsCreate).toHaveBeenCalledWith({
-      name: "CrowdPM Node Hardware",
-      description: "Physical node hardware purchase with US shipping included.",
+      name: "CrowdPM Founding Node Reservation",
+      description: "Conditional CrowdPM node preorder; ships only after FCC equipment authorization.",
       tax_code: "txcd_99999999",
       default_price_data: {
         currency: "usd",
@@ -198,22 +198,27 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       },
       custom_text: {
         shipping_address: {
-          message: "We currently ship CrowdPM nodes only to addresses in the United States.",
+          message: "Shipping is available only to US addresses and will occur only after FCC equipment authorization is complete.",
         },
         submit: {
-          message: "You are purchasing physical CrowdPM node hardware and any expressly listed related services from Denuo Web LLC. Power source and USB-A-to-micro-USB cable are not included. Purchase does not transfer proprietary rights in CrowdPM Platform software or restrict rights under applicable open-source licenses. Price includes US shipping. Applicable sales tax is calculated at checkout.",
+          message: "Conditional preorder: no CrowdPM node will be shipped or delivered until FCC equipment authorization is complete. If authorization is not complete by the stated refund checkpoint, you may request a refund or continue waiting. Price includes US shipping after authorization; applicable sales tax is calculated at checkout.",
         },
       },
       metadata: {
         purchaseType: "node_hardware",
+        tierId: "founding_node_reservation",
+        tierLabel: "Founding node reservation",
         variantId: "standard",
-        variantLabel: "PM2.5 standard node",
+        variantLabel: "Founding node reservation",
         quantity: "1",
+        fccAuthorizationRequired: "true",
+        noDeliveryBeforeAuthorization: "true",
+        refundCheckpointDate: "2026-12-31",
       },
       success_url: "https://crowdpmplatform.web.app/node?checkout=success",
       cancel_url: "https://crowdpmplatform.web.app/node?checkout=cancelled",
     });
-    expect(dbStore.get("paymentCatalog/nodeHardware")).toMatchObject({
+    expect(dbStore.get("paymentCatalog/nodeReservation")).toMatchObject({
       productId: "prod_node_123",
       defaultPriceId: "price_node_123",
       currency: "usd",
@@ -235,8 +240,13 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       amountSubtotal: 37500,
       amountTotal: 37500,
       purchaseType: "node_hardware",
+      tierId: "founding_node_reservation",
+      tierLabel: "Founding node reservation",
       variantId: "standard",
-      variantLabel: "PM2.5 standard node",
+      variantLabel: "Founding node reservation",
+      fccAuthorizationRequired: true,
+      noDeliveryBeforeAuthorization: true,
+      refundCheckpointDate: "2026-12-31",
     });
     await app.close();
   });
@@ -278,16 +288,23 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       metadata: {
         purchaseType: "node_hardware",
         userId: "user-123",
+        tierId: "founding_node_reservation",
+        tierLabel: "Founding node reservation",
         variantId: "standard",
-        variantLabel: "PM2.5 standard node",
+        variantLabel: "Founding node reservation",
         quantity: "2",
+        fccAuthorizationRequired: "true",
+        noDeliveryBeforeAuthorization: "true",
+        refundCheckpointDate: "2026-12-31",
       },
     }));
     expect(dbStore.get("nodePurchaseSessions/cs_node_qty_123")).toMatchObject({
       userId: "user-123",
       customerEmail: "buyer@example.com",
+      tierId: "founding_node_reservation",
+      tierLabel: "Founding node reservation",
       variantId: "standard",
-      variantLabel: "PM2.5 standard node",
+      variantLabel: "Founding node reservation",
       unitAmount: 37_500,
       quantity: 2,
       amountSubtotal: 75_000,
@@ -296,8 +313,102 @@ describe("POST /v1/node-purchase/checkout-session", () => {
     await app.close();
   });
 
+  it("creates a support-only certification contribution without shipping collection", async () => {
+    mocks.productsCreate.mockResolvedValueOnce({
+      id: "prod_support_123",
+      default_price: "price_support_123",
+    });
+    mocks.checkoutSessionsCreate.mockResolvedValueOnce({
+      id: "cs_support_123",
+      url: "https://checkout.stripe.com/c/pay/cs_support_123",
+      mode: "payment",
+      currency: "usd",
+      amount_subtotal: 7_500,
+      amount_total: 7_500,
+    });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/node-purchase/checkout-session",
+      payload: {
+        tierId: "certification_support",
+        quantity: 3,
+      },
+      headers: {
+        authorization: "Bearer ok",
+        "content-type": "application/json",
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.productsCreate).toHaveBeenCalledWith({
+      name: "CrowdPM Certification Support",
+      description: "Support-only contribution toward FCC testing and launch costs. No hardware reward.",
+      tax_code: "txcd_99999999",
+      default_price_data: {
+        currency: "usd",
+        unit_amount: 2500,
+        tax_behavior: "exclusive",
+      },
+    });
+    expect(mocks.checkoutSessionsCreate).toHaveBeenCalledWith({
+      line_items: [
+        {
+          price: "price_support_123",
+          quantity: 3,
+        },
+      ],
+      mode: "payment",
+      automatic_tax: {
+        enabled: true,
+      },
+      billing_address_collection: "required",
+      custom_text: {
+        submit: {
+          message: "Support-only contribution toward FCC testing and launch costs. No hardware, service entitlement, equity, or charitable tax deduction is provided. Applicable tax, if any, is calculated at checkout.",
+        },
+      },
+      customer_email: "buyer@example.com",
+      client_reference_id: "user-123",
+      metadata: {
+        purchaseType: "certification_support",
+        userId: "user-123",
+        tierId: "certification_support",
+        tierLabel: "Certification support",
+        quantity: "3",
+        hardwareReward: "false",
+        charitableDonation: "false",
+      },
+      success_url: "https://crowdpmplatform.web.app/node?checkout=success",
+      cancel_url: "https://crowdpmplatform.web.app/node?checkout=cancelled",
+    });
+    expect(dbStore.get("paymentCatalog/certificationSupport")).toMatchObject({
+      productId: "prod_support_123",
+      defaultPriceId: "price_support_123",
+      currency: "usd",
+      unitAmount: 2500,
+      taxCode: "txcd_99999999",
+      taxBehavior: "exclusive",
+    });
+    expect(dbStore.get("nodePurchaseSessions/cs_support_123")).toMatchObject({
+      sessionId: "cs_support_123",
+      status: "created",
+      purchaseType: "certification_support",
+      userId: "user-123",
+      customerEmail: "buyer@example.com",
+      tierId: "certification_support",
+      tierLabel: "Certification support",
+      unitAmount: 2_500,
+      quantity: 3,
+      hardwareReward: false,
+      charitableDonation: false,
+    });
+    await app.close();
+  });
+
   it("reuses the stored catalog without creating a second product", async () => {
-    dbStore.set("paymentCatalog/nodeHardware", {
+    dbStore.set("paymentCatalog/nodeReservation", {
       productId: "prod_existing",
       defaultPriceId: "price_existing",
       currency: "usd",
@@ -326,7 +437,7 @@ describe("POST /v1/node-purchase/checkout-session", () => {
   });
 
   it("recreates the Stripe catalog when the stored price no longer matches the expected node price", async () => {
-    dbStore.set("paymentCatalog/nodeHardware", {
+    dbStore.set("paymentCatalog/nodeReservation", {
       productId: "prod_old",
       defaultPriceId: "price_old",
       currency: "usd",
@@ -351,7 +462,7 @@ describe("POST /v1/node-purchase/checkout-session", () => {
         },
       ],
     }));
-    expect(dbStore.get("paymentCatalog/nodeHardware")).toMatchObject({
+    expect(dbStore.get("paymentCatalog/nodeReservation")).toMatchObject({
       productId: "prod_node_123",
       defaultPriceId: "price_node_123",
       currency: "usd",
@@ -363,7 +474,7 @@ describe("POST /v1/node-purchase/checkout-session", () => {
   });
 
   it("recreates the Stripe catalog when the stored tax configuration is missing", async () => {
-    dbStore.set("paymentCatalog/nodeHardware", {
+    dbStore.set("paymentCatalog/nodeReservation", {
       productId: "prod_old",
       defaultPriceId: "price_old",
       currency: "usd",
@@ -378,7 +489,7 @@ describe("POST /v1/node-purchase/checkout-session", () => {
 
     expect(res.statusCode).toBe(200);
     expect(mocks.productsCreate).toHaveBeenCalledTimes(1);
-    expect(dbStore.get("paymentCatalog/nodeHardware")).toMatchObject({
+    expect(dbStore.get("paymentCatalog/nodeReservation")).toMatchObject({
       productId: "prod_node_123",
       defaultPriceId: "price_node_123",
       currency: "usd",
@@ -443,8 +554,10 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       purchaseType: "node_hardware",
       userId: "user-123",
       paymentStatus: "paid",
+      tierId: "founding_node_reservation",
+      tierLabel: "Founding node reservation",
       variantId: "standard",
-      variantLabel: "PM2.5 standard node",
+      variantLabel: "Founding node reservation",
       quantity: 1,
       currency: "usd",
       unitAmount: 37_500,
@@ -473,8 +586,10 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       purchaseType: "node_hardware",
       userId: "user-123",
       paymentStatus: "paid",
+      tierId: "founding_node_reservation",
+      tierLabel: "Founding node reservation",
       variantId: "standard",
-      variantLabel: "PM2.5 standard node",
+      variantLabel: "Founding node reservation",
       quantity: 3,
       currency: "usd",
       unitAmount: 37_500,
@@ -484,6 +599,25 @@ describe("POST /v1/node-purchase/checkout-session", () => {
       amountDiscount: 0,
       amountTotal: 122_625,
       completedAt: "2026-02-01T00:00:00.000Z",
+      customerEmail: "buyer@example.com",
+    });
+    dbStore.set("nodePurchaseSessions/cs_support", {
+      sessionId: "cs_support",
+      status: "completed",
+      purchaseType: "certification_support",
+      userId: "user-123",
+      paymentStatus: "paid",
+      tierId: "certification_support",
+      tierLabel: "Certification support",
+      quantity: 2,
+      currency: "usd",
+      unitAmount: 2_500,
+      amountSubtotal: 5_000,
+      amountTax: 0,
+      amountShipping: 0,
+      amountDiscount: 0,
+      amountTotal: 5_000,
+      completedAt: "2026-03-01T00:00:00.000Z",
       customerEmail: "buyer@example.com",
     });
     dbStore.set("nodePurchaseSessions/cs_pending", {
@@ -511,8 +645,16 @@ describe("POST /v1/node-purchase/checkout-session", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual([
       expect.objectContaining({
+        sessionId: "cs_support",
+        purchaseType: "certification_support",
+        tierId: "certification_support",
+        quantity: 2,
+        amountTotal: 5_000,
+      }),
+      expect.objectContaining({
         sessionId: "cs_new",
         status: "completed",
+        tierId: "founding_node_reservation",
         variantId: "standard",
         quantity: 3,
         amountTotal: 122_625,
@@ -806,8 +948,10 @@ describe("POST /v1/payments/stripe/webhook", () => {
           id: "cs_test_123",
           metadata: {
             purchaseType: "node_hardware",
+            tierId: "founding_node_reservation",
+            tierLabel: "Founding node reservation",
             variantId: "standard",
-            variantLabel: "PM2.5 standard node",
+            variantLabel: "Founding node reservation",
           },
           mode: "payment",
           payment_status: "paid",
@@ -878,9 +1022,14 @@ describe("POST /v1/payments/stripe/webhook", () => {
       amountSubtotal: 37500,
       amountTotal: 40875,
       purchaseType: "node_hardware",
+      tierId: "founding_node_reservation",
+      tierLabel: "Founding node reservation",
       variantId: "standard",
-      variantLabel: "PM2.5 standard node",
+      variantLabel: "Founding node reservation",
       quantity: 1,
+      fccAuthorizationRequired: true,
+      noDeliveryBeforeAuthorization: true,
+      refundCheckpointDate: "2026-12-31",
       amountDiscount: 0,
       amountShipping: 0,
       amountTax: 3375,

--- a/functions/test/services/nodePurchasePlanning.test.ts
+++ b/functions/test/services/nodePurchasePlanning.test.ts
@@ -99,7 +99,8 @@ describe("buildCheckoutSessionPlan", () => {
 describe("listStripeCatalogSeedConfigs", () => {
   it("returns all live Stripe-backed catalog definitions", () => {
     expect(listStripeCatalogSeedConfigs().map((config) => config.catalogDocId)).toEqual([
-      "nodeHardware",
+      "nodeReservation",
+      "certificationSupport",
       "themeSaveUnlock",
       "subscriptionProMonthly",
       "subscriptionProYearly",

--- a/shared-types/src/index.ts
+++ b/shared-types/src/index.ts
@@ -38,12 +38,16 @@ export type DeviceSummary = {
 } & Record<string, unknown>;
 
 export type NodePurchaseVariantId = "standard";
+export type NodeCampaignTierId = "founding_node_reservation" | "certification_support";
+export type NodeCampaignPurchaseType = "node_hardware" | "certification_support";
 
 export type NodePurchaseReceipt = {
   sessionId: string;
-  purchaseType: "node_hardware";
+  purchaseType: NodeCampaignPurchaseType;
   status: "completed";
   paymentStatus: string | null;
+  tierId: NodeCampaignTierId | null;
+  tierLabel: string | null;
   variantId: NodePurchaseVariantId | null;
   variantLabel: string | null;
   quantity: number;


### PR DESCRIPTION
## Summary
- convert the node page into a self-hosted FCC-pending campaign with founding reservations and certification support tiers
- add backend Stripe checkout support for conditional reservations and support-only contributions
- update receipts, shared types, legal copy, OpenAPI docs, and route tests for the new campaign model

## Verification
- pnpm --filter crowdpm-functions test -- nodePurchase
- pnpm --filter @crowdpm/types test
- pnpm --filter crowdpm-frontend typecheck
- pnpm --filter crowdpm-functions build
- pnpm --filter crowdpm-frontend build
- pnpm lint
- Playwright desktop/mobile screenshot checks for /node
