### PR TITLE
Harden DPoP verification and ingest validation

### DIFF
--- a/functions/.env.example
+++ b/functions/.env.example
@@ -1,4 +1,6 @@
 DEVICE_TOKEN_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIPreplace-me-with-a-real-key\n-----END PRIVATE KEY-----
+CROWDPM_API_BASE_URL=http://127.0.0.1:5001/crowdpm-local/us-central1/crowdpmApi
+CROWDPM_INGEST_URL=http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway
 DEVICE_ACTIVATION_URL=http://localhost:5173/activate
 DEVICE_VERIFICATION_URI=http://localhost:5173/activate
 DEVICE_TOKEN_ISSUER=crowdpm

--- a/functions/src/lib/http.ts
+++ b/functions/src/lib/http.ts
@@ -7,6 +7,12 @@ function firstHeaderValue(value: string | string[] | undefined): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function isLocalRuntime(): boolean {
+  return process.env.FUNCTIONS_EMULATOR === "true"
+    || Boolean(process.env.FIREBASE_EMULATOR_HUB)
+    || process.env.NODE_ENV === "test";
+}
+
 export function stripApiEntryPrefix(url: string | undefined): string {
   const raw = typeof url === "string" && url.length > 0 ? url : "/";
   if (!raw.startsWith("/api")) {
@@ -28,20 +34,45 @@ export function stripApiEntryPrefix(url: string | undefined): string {
   return stripped;
 }
 
-export function canonicalRequestUrl(url: string | undefined, headers: IncomingHttpHeaders): string {
-  const proto = firstHeaderValue(headers["x-forwarded-proto"])
-    || firstHeaderValue(headers[":scheme"])
-    || "https";
-  const host = firstHeaderValue(headers["x-forwarded-host"]) || firstHeaderValue(headers.host);
-  if (!host) {
-    throw new Error("Unable to determine request host");
+function normalizeBaseUrl(baseUrl: string): URL {
+  const parsed = new URL(baseUrl);
+  parsed.hash = "";
+  parsed.search = "";
+  parsed.pathname = parsed.pathname.replace(/\/+$/u, "") || "/";
+  return parsed;
+}
+
+export function buildCanonicalEndpointUrl(baseUrl: string, requestUrl: string | undefined): string {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const cleaned = (requestUrl ?? "/").split("#", 1)[0] || "/";
+  if (cleaned.startsWith("?")) {
+    return `${normalizedBaseUrl.toString()}${cleaned}`;
   }
-  const cleaned = (url ?? "/").split("#", 1)[0] || "/";
-  const normalizedPath = cleaned.startsWith("/") ? cleaned : `/${cleaned}`;
-  return `${proto.toLowerCase()}://${host.toLowerCase()}${normalizedPath}`;
+  if (cleaned.startsWith("/?")) {
+    return `${normalizedBaseUrl.toString()}${cleaned.slice(1)}`;
+  }
+  if (cleaned === "/" || cleaned.length === 0) {
+    return normalizedBaseUrl.toString();
+  }
+  const joinableBaseUrl = new URL(normalizedBaseUrl.toString());
+  joinableBaseUrl.pathname = joinableBaseUrl.pathname.replace(/\/+$/u, "");
+  joinableBaseUrl.pathname = joinableBaseUrl.pathname.length > 0 ? `${joinableBaseUrl.pathname}/` : "/";
+  const relativePath = cleaned === "/"
+    ? ""
+    : cleaned.startsWith("/")
+      ? cleaned.slice(1)
+      : cleaned;
+  return new URL(relativePath, joinableBaseUrl).toString();
 }
 
 export function extractClientIp(headers: IncomingHttpHeaders): string | null {
+  const appEngineIp = firstHeaderValue(headers["x-appengine-user-ip"]);
+  if (appEngineIp) return appEngineIp;
+
+  if (!isLocalRuntime()) {
+    return null;
+  }
+
   const forwardedFor = firstHeaderValue(headers["x-forwarded-for"]);
   if (forwardedFor) {
     const ip = forwardedFor.split(",")[0]?.trim();
@@ -49,8 +80,6 @@ export function extractClientIp(headers: IncomingHttpHeaders): string | null {
   }
   const realIp = firstHeaderValue(headers["x-real-ip"]);
   if (realIp) return realIp;
-  const appEngineIp = firstHeaderValue(headers["x-appengine-user-ip"]);
-  if (appEngineIp) return appEngineIp;
   return null;
 }
 
@@ -66,12 +95,14 @@ export function coarsenIpForDisplay(ip: string | null): string | null {
 }
 
 export function deriveNetworkHint(headers: IncomingHttpHeaders, ip: string | null): string | null {
-  const explicit =
-    firstHeaderValue(headers["cf-asn"])
-    || firstHeaderValue(headers["x-client-asn"])
-    || firstHeaderValue(headers["x-geoip-asnum"]);
-  if (explicit) {
-    return `AS${explicit.replace(/^AS/i, "")}`;
+  if (isLocalRuntime()) {
+    const explicit =
+      firstHeaderValue(headers["cf-asn"])
+      || firstHeaderValue(headers["x-client-asn"])
+      || firstHeaderValue(headers["x-geoip-asnum"]);
+    if (explicit) {
+      return `AS${explicit.replace(/^AS/i, "")}`;
+    }
   }
   if (!ip) return null;
   if (ip.includes(":")) {

--- a/functions/src/lib/runtimeConfig.ts
+++ b/functions/src/lib/runtimeConfig.ts
@@ -1,9 +1,49 @@
+import { FUNCTION_REGION } from "./functionOptions.js";
+
 const DEFAULT_ACTIVATION_URL = "https://crowdpmplatform.web.app/activate";
 const DEFAULT_PUBLIC_APP_BASE_URL = "https://crowdpmplatform.web.app";
 const DEFAULT_TOKEN_ISSUER = "crowdpm";
 const DEFAULT_TOKEN_AUDIENCE = "crowdpm_device_api";
 const DEFAULT_ACCESS_TOKEN_TTL_SECONDS = 600;
 const DEFAULT_REGISTRATION_TOKEN_TTL_SECONDS = 60;
+const CROWDPM_API_FUNCTION_NAME = "crowdpmApi";
+const INGEST_GATEWAY_FUNCTION_NAME = "ingestGateway";
+
+function isLocalRuntime(): boolean {
+  return process.env.FUNCTIONS_EMULATOR === "true"
+    || Boolean(process.env.FIREBASE_EMULATOR_HUB)
+    || process.env.NODE_ENV === "test";
+}
+
+function readProjectId(): string | null {
+  const direct = process.env.GCLOUD_PROJECT?.trim() || process.env.GCP_PROJECT?.trim();
+  if (direct) return direct;
+
+  const firebaseConfig = process.env.FIREBASE_CONFIG?.trim();
+  if (!firebaseConfig) return null;
+  try {
+    const parsed = JSON.parse(firebaseConfig) as { projectId?: unknown };
+    return typeof parsed.projectId === "string" && parsed.projectId.trim().length > 0
+      ? parsed.projectId.trim()
+      : null;
+  }
+  catch {
+    return null;
+  }
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/$/, "");
+}
+
+function defaultFunctionBaseUrl(functionName: string): string {
+  if (isLocalRuntime()) {
+    const projectId = readProjectId() ?? "crowdpm-local";
+    return `http://127.0.0.1:5001/${projectId}/${FUNCTION_REGION}/${functionName}`;
+  }
+  const projectId = readProjectId() ?? "crowdpmplatform";
+  return `https://${FUNCTION_REGION}-${projectId}.cloudfunctions.net/${functionName}`;
+}
 
 function readStringEnv(name: string, fallback: string): string {
   const value = process.env[name]?.trim();
@@ -65,4 +105,14 @@ export function getAccessTokenTtlSeconds(): number {
 
 export function getRegistrationTokenTtlSeconds(): number {
   return readPositiveIntEnv("DEVICE_REGISTRATION_TOKEN_TTL_SECONDS", DEFAULT_REGISTRATION_TOKEN_TTL_SECONDS);
+}
+
+export function getCrowdpmApiBaseUrl(): string {
+  const explicit = process.env.CROWDPM_API_BASE_URL?.trim();
+  return normalizeBaseUrl(explicit || defaultFunctionBaseUrl(CROWDPM_API_FUNCTION_NAME));
+}
+
+export function getIngestGatewayBaseUrl(): string {
+  const explicit = process.env.CROWDPM_INGEST_URL?.trim();
+  return normalizeBaseUrl(explicit || defaultFunctionBaseUrl(INGEST_GATEWAY_FUNCTION_NAME));
 }

--- a/functions/src/lib/validation.ts
+++ b/functions/src/lib/validation.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
+
+const DeviceId = z.string().trim().min(1).max(128);
+
 export const IngestPoint = z.object({
-  device_id: z.string(),
+  device_id: DeviceId,
   pollutant: z.enum(["pm25"]),
   value: z.number().finite(),
   unit: z.literal("µg/m³"),
@@ -10,11 +13,11 @@ export const IngestPoint = z.object({
   precision: z.number().optional(),
   timestamp: z.string().datetime(),
   flags: z.number().int().nonnegative().optional()
-});
-export const IngestBatch = z.object({ points: z.array(IngestPoint).min(1) });
+}).strict();
+export const IngestBatch = z.object({ points: z.array(IngestPoint).min(1) }).strict();
 export type IngestBatch = import("zod").infer<typeof IngestBatch>;
 
 export const IngestPayload = IngestBatch
-  .extend({ device_id: z.string().optional() })
-  .passthrough();
+  .extend({ device_id: DeviceId.optional() })
+  .strict();
 export type IngestPayload = import("zod").infer<typeof IngestPayload>;

--- a/functions/src/routes/pairing.ts
+++ b/functions/src/routes/pairing.ts
@@ -10,13 +10,14 @@ import {
   recordRegistrationToken,
   markSessionRedeemed,
 } from "../services/devicePairing.js";
-import { canonicalRequestUrl, coarsenIpForDisplay, deriveNetworkHint, extractClientIp } from "../lib/http.js";
+import { buildCanonicalEndpointUrl, coarsenIpForDisplay, deriveNetworkHint, extractClientIp } from "../lib/http.js";
 import { verifyDpopProof } from "../lib/dpop.js";
 import { rateLimitOrThrow } from "../lib/rateLimiter.js";
 import { issueRegistrationToken, verifyRegistrationToken, issueDeviceAccessToken } from "../services/deviceTokens.js";
 import { registerDevice, getDevice } from "../services/deviceRegistry.js";
 import { httpError } from "../lib/httpError.js";
 import { app as firebaseApp } from "../lib/fire.js";
+import { getCrowdpmApiBaseUrl } from "../lib/runtimeConfig.js";
 
 const startSchema = z.object({
   pub_ke: z.string().min(10),
@@ -44,7 +45,7 @@ const deviceTokenSchema = z.object({
 });
 
 function fastifyRequestUrl(req: FastifyRequest): string {
-  return canonicalRequestUrl(req.raw.url ?? req.url, req.headers);
+  return buildCanonicalEndpointUrl(getCrowdpmApiBaseUrl(), req.raw.url ?? req.url);
 }
 
 export const pairingRoutes: FastifyPluginAsync = async (app) => {

--- a/functions/src/services/batchPayloads.ts
+++ b/functions/src/services/batchPayloads.ts
@@ -1,6 +1,6 @@
 import { gunzipSync, gzipSync } from "node:zlib";
 import type { BatchVisibility } from "@crowdpm/types";
-import { IngestBatch, type IngestPayload } from "../lib/validation.js";
+import { IngestPayload, type IngestPayload as IngestPayloadType } from "../lib/validation.js";
 
 export const BATCH_SCHEMA_VERSION = 2;
 
@@ -55,7 +55,7 @@ export function buildBatchStoragePath(args: { primaryOwnerUserId: string; device
   ].join("/");
 }
 
-export function encodeBatchPayload(payload: IngestPayload): { buffer: Buffer; canonicalJson: string } {
+export function encodeBatchPayload(payload: IngestPayloadType): { buffer: Buffer; canonicalJson: string } {
   const canonicalJson = JSON.stringify(payload);
   return {
     canonicalJson,
@@ -63,19 +63,19 @@ export function encodeBatchPayload(payload: IngestPayload): { buffer: Buffer; ca
   };
 }
 
-export function decodeBatchPayload(buffer: Buffer, storagePath: string): IngestPayload {
+export function decodeBatchPayload(buffer: Buffer, storagePath: string): IngestPayloadType {
   if (!storagePath.endsWith(".json.gz")) {
     throw new Error("stored batch payload must use the v2 gzip format");
   }
   const json = gunzipSync(buffer).toString("utf8");
-  const parsed = IngestBatch.safeParse(JSON.parse(json));
+  const parsed = IngestPayload.safeParse(JSON.parse(json));
   if (!parsed.success) {
     throw new Error("stored batch payload is invalid");
   }
   return parsed.data;
 }
 
-export function summarizeBatchPayload(payload: IngestPayload): BatchPayloadMetadata {
+export function summarizeBatchPayload(payload: IngestPayloadType): BatchPayloadMetadata {
   const points = payload.points;
   let startedAt: Date | null = null;
   let endedAt: Date | null = null;

--- a/functions/src/services/deviceTokens.ts
+++ b/functions/src/services/deviceTokens.ts
@@ -276,12 +276,6 @@ export async function issueDeviceAccessToken(args: {
   return { token, expiresIn: ttl, jti };
 }
 
-type TokenCacheEntry = {
-  expiresAtMs: number;
-};
-
-const tokenCache = new Map<string, TokenCacheEntry>();
-
 export async function verifyDeviceAccessToken(raw: string): Promise<VerifiedDeviceAccessToken> {
   let payload: DeviceAccessClaims & { jti?: string };
   try {
@@ -301,15 +295,13 @@ export async function verifyDeviceAccessToken(raw: string): Promise<VerifiedDevi
   if (!payload.acc_id) throw unauthorized("Device token missing account id");
   if (!payload.jti) throw unauthorized("Device token missing jti");
 
-  const cacheEntry = tokenCache.get(payload.jti);
-  const now = Date.now();
-  if (!cacheEntry || cacheEntry.expiresAtMs <= now) {
-    const doc = await db().collection("device_tokens").doc(payload.jti).get();
-    if (!doc.exists) throw unauthorized("Unknown device token");
-    const data = doc.data() as { revoked?: boolean; expiresAt?: unknown } | undefined;
-    if (data?.revoked) throw unauthorized("Device token revoked");
-    const expiresAt = toDate(data?.expiresAt) ?? new Date(now + 1000);
-    tokenCache.set(payload.jti, { expiresAtMs: expiresAt.getTime() });
+  const doc = await db().collection("device_tokens").doc(payload.jti).get();
+  if (!doc.exists) throw unauthorized("Unknown device token");
+  const data = doc.data() as { revoked?: boolean; expiresAt?: unknown } | undefined;
+  if (data?.revoked) throw unauthorized("Device token revoked");
+  const expiresAt = toDate(data?.expiresAt);
+  if (!expiresAt || expiresAt.getTime() <= Date.now()) {
+    throw unauthorized("Device token expired");
   }
   return payload as VerifiedDeviceAccessToken;
 }
@@ -317,5 +309,4 @@ export async function verifyDeviceAccessToken(raw: string): Promise<VerifiedDevi
 export async function revokeTokensForDevice(deviceId: string): Promise<void> {
   const snap = await db().collection("device_tokens").where("deviceId", "==", deviceId).get();
   await Promise.all(snap.docs.map((doc) => doc.ref.set({ revoked: true }, { merge: true })));
-  snap.docs.forEach((doc) => tokenCache.delete(doc.id));
 }

--- a/functions/src/services/ingestGateway.ts
+++ b/functions/src/services/ingestGateway.ts
@@ -3,11 +3,12 @@ import type { Request } from "firebase-functions/v2/https";
 import { normalizeBatchVisibility } from "../lib/batchVisibility.js";
 import { verifyDeviceAccessToken } from "./deviceTokens.js";
 import { calculateDpopAth, checkDpopReplay, verifyDpopProof } from "../lib/dpop.js";
-import { canonicalRequestUrl } from "../lib/http.js";
+import { buildCanonicalEndpointUrl } from "../lib/http.js";
 import { applyCorsHeaders } from "../lib/corsPolicy.js";
 import { ingestGatewayRuntimeOptions } from "../lib/functionOptions.js";
 import { ingestService, type IngestBody } from "./ingestService.js";
 import { httpError, toHttpError } from "../lib/httpError.js";
+import { getIngestGatewayBaseUrl } from "../lib/runtimeConfig.js";
 
 type RequestWithRawBody = Request & { rawBody?: Buffer | string };
 
@@ -84,7 +85,7 @@ export async function ingestGatewayHandler(
     }
 
     const accessToken = await dependencies.verifyDeviceAccessToken(token);
-    const htu = canonicalRequestUrl(req.url, req.headers);
+    const htu = buildCanonicalEndpointUrl(getIngestGatewayBaseUrl(), req.url);
     const dpopProof = requestHeader(req, "dpop");
     const verifiedProof = await dependencies.verifyDpopProof(dpopProof, {
       method: req.method.toUpperCase(),

--- a/functions/test/lib/http.test.ts
+++ b/functions/test/lib/http.test.ts
@@ -1,5 +1,43 @@
 import { describe, expect, it } from "vitest";
-import { stripApiEntryPrefix } from "../../src/lib/http.js";
+import {
+  buildCanonicalEndpointUrl,
+  deriveNetworkHint,
+  extractClientIp,
+  stripApiEntryPrefix,
+} from "../../src/lib/http.js";
+
+function withRuntimeEnv(overrides: {
+  NODE_ENV?: string;
+  FUNCTIONS_EMULATOR?: string;
+  FIREBASE_EMULATOR_HUB?: string;
+}, run: () => void) {
+  const previousNodeEnv = process.env.NODE_ENV;
+  const previousFunctionsEmulator = process.env.FUNCTIONS_EMULATOR;
+  const previousEmulatorHub = process.env.FIREBASE_EMULATOR_HUB;
+
+  if (overrides.NODE_ENV === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = overrides.NODE_ENV;
+
+  if (overrides.FUNCTIONS_EMULATOR === undefined) delete process.env.FUNCTIONS_EMULATOR;
+  else process.env.FUNCTIONS_EMULATOR = overrides.FUNCTIONS_EMULATOR;
+
+  if (overrides.FIREBASE_EMULATOR_HUB === undefined) delete process.env.FIREBASE_EMULATOR_HUB;
+  else process.env.FIREBASE_EMULATOR_HUB = overrides.FIREBASE_EMULATOR_HUB;
+
+  try {
+    run();
+  }
+  finally {
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
+
+    if (previousFunctionsEmulator === undefined) delete process.env.FUNCTIONS_EMULATOR;
+    else process.env.FUNCTIONS_EMULATOR = previousFunctionsEmulator;
+
+    if (previousEmulatorHub === undefined) delete process.env.FIREBASE_EMULATOR_HUB;
+    else process.env.FIREBASE_EMULATOR_HUB = previousEmulatorHub;
+  }
+}
 
 describe("stripApiEntryPrefix", () => {
   it("strips the hosting /api prefix for nested routes", () => {
@@ -16,5 +54,70 @@ describe("stripApiEntryPrefix", () => {
     expect(stripApiEntryPrefix("/v1/public/batches")).toBe("/v1/public/batches");
     expect(stripApiEntryPrefix("/apiv1/public/batches")).toBe("/apiv1/public/batches");
     expect(stripApiEntryPrefix(undefined)).toBe("/");
+  });
+});
+
+describe("buildCanonicalEndpointUrl", () => {
+  it("joins route paths onto the configured function base URL", () => {
+    expect(buildCanonicalEndpointUrl(
+      "https://us-central1-crowdpmplatform.cloudfunctions.net/crowdpmApi",
+      "/device/token"
+    )).toBe("https://us-central1-crowdpmplatform.cloudfunctions.net/crowdpmApi/device/token");
+  });
+
+  it("keeps root requests anchored to the configured function URL", () => {
+    expect(buildCanonicalEndpointUrl(
+      "http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway",
+      "/"
+    )).toBe("http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway");
+  });
+
+  it("preserves root query strings without inventing a trailing slash", () => {
+    expect(buildCanonicalEndpointUrl(
+      "http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway",
+      "?visibility=public"
+    )).toBe("http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway?visibility=public");
+  });
+});
+
+describe("extractClientIp", () => {
+  it("trusts the platform-injected App Engine IP header outside local runtime", () => {
+    withRuntimeEnv({}, () => {
+      expect(extractClientIp({
+        "x-appengine-user-ip": "203.0.113.8",
+        "x-forwarded-for": "198.51.100.20",
+      })).toBe("203.0.113.8");
+    });
+  });
+
+  it("ignores spoofable forwarded IP headers outside local runtime", () => {
+    withRuntimeEnv({}, () => {
+      expect(extractClientIp({
+        "x-forwarded-for": "198.51.100.20",
+        "x-real-ip": "198.51.100.21",
+      })).toBeNull();
+    });
+  });
+
+  it("allows forwarded IP headers in local emulator and test runtimes", () => {
+    withRuntimeEnv({ NODE_ENV: "test" }, () => {
+      expect(extractClientIp({
+        "x-forwarded-for": "198.51.100.20, 10.0.0.1",
+      })).toBe("198.51.100.20");
+    });
+  });
+});
+
+describe("deriveNetworkHint", () => {
+  it("uses explicit local ASN hints in local runtime", () => {
+    withRuntimeEnv({ NODE_ENV: "test" }, () => {
+      expect(deriveNetworkHint({ "x-client-asn": "64512" }, "198.51.100.20")).toBe("AS64512");
+    });
+  });
+
+  it("falls back to coarse IP prefixes outside local runtime", () => {
+    withRuntimeEnv({}, () => {
+      expect(deriveNetworkHint({ "x-client-asn": "64512" }, "198.51.100.20")).toBe("v4-198.51");
+    });
   });
 });

--- a/functions/test/routes/pairing.test.ts
+++ b/functions/test/routes/pairing.test.ts
@@ -217,6 +217,10 @@ describe("POST /device/token", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ registration_token: "reg-token", expires_in: 60 });
     expect(mocks.recordRegistrationToken).toHaveBeenCalledWith(deviceCode, "jti-1", expect.any(Date));
+    expect(mocks.verifyDpopProof).toHaveBeenCalledWith("proof", expect.objectContaining({
+      htu: "http://127.0.0.1:5001/crowdpm-local/us-central1/crowdpmApi/device/token",
+      expectedThumbprint: "thumb-1",
+    }));
     await app.close();
   });
 

--- a/functions/test/services/deviceTokensVerification.test.ts
+++ b/functions/test/services/deviceTokensVerification.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  jwtVerify: vi.fn(),
+  importSPKI: vi.fn(),
+  importPKCS8: vi.fn(),
+  tokenDocGet: vi.fn(),
+}));
+
+vi.mock("jose", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("jose")>();
+  return {
+    ...actual,
+    jwtVerify: mocks.jwtVerify,
+    importSPKI: mocks.importSPKI,
+    importPKCS8: mocks.importPKCS8,
+  };
+});
+
+vi.mock("../../src/lib/fire.js", () => ({
+  db: () => ({
+    collection: (name: string) => {
+      if (name !== "device_tokens") {
+        throw new Error(`unexpected collection ${name}`);
+      }
+      return {
+        doc: (id: string) => {
+          void id;
+          return {
+          get: mocks.tokenDocGet,
+          };
+        },
+      };
+    },
+  }),
+}));
+
+describe("verifyDeviceAccessToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.importSPKI.mockResolvedValue({ key: "verification-key" });
+    mocks.importPKCS8.mockResolvedValue({ key: "signing-key" });
+    mocks.jwtVerify.mockResolvedValue({
+      payload: {
+        kind: "device_access",
+        device_id: "device-123",
+        acc_id: "user-123",
+        cnf: { jkt: "jkt-123" },
+        jti: "token-jti-123",
+      },
+    });
+  });
+
+  it("re-checks shared token state on every verification and rejects a later revocation", async () => {
+    process.env.DEVICE_TOKEN_ISSUER = "crowdpm";
+    process.env.DEVICE_TOKEN_AUDIENCE = "crowdpm_device_api";
+
+    const { verifyDeviceAccessToken } = await import("../../src/services/deviceTokens.js");
+
+    mocks.tokenDocGet
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          revoked: false,
+          expiresAt: new Date(Date.now() + 60_000),
+        }),
+      })
+      .mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          revoked: true,
+          expiresAt: new Date(Date.now() + 60_000),
+        }),
+      });
+
+    await expect(verifyDeviceAccessToken("raw-token")).resolves.toMatchObject({
+      device_id: "device-123",
+      jti: "token-jti-123",
+    });
+    await expect(verifyDeviceAccessToken("raw-token")).rejects.toThrow("Device token revoked");
+    expect(mocks.tokenDocGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/functions/test/services/ingestGateway.test.ts
+++ b/functions/test/services/ingestGateway.test.ts
@@ -43,7 +43,7 @@ function createRequest(overrides?: Partial<Record<string, unknown>>) {
 
   const req = {
     method: "POST",
-    url: "/ingestGateway",
+    url: "/",
     query: {},
     body: {},
     headers,
@@ -140,6 +140,7 @@ describe("ingestGatewayHandler", () => {
     expect(res.payload).toMatchObject({ accepted: true, batchId: "batch-1", deviceId: "device-123" });
     expect(deps.verifyDeviceAccessToken).toHaveBeenCalledWith("test-token");
     expect(deps.verifyDpopProof).toHaveBeenCalledWith("proof-token", expect.objectContaining({
+      htu: "http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway",
       expectedAth: expect.any(String),
       expectedThumbprint: "jkt-1",
     }));

--- a/functions/test/services/ingestService.test.ts
+++ b/functions/test/services/ingestService.test.ts
@@ -96,6 +96,15 @@ describe("IngestService", () => {
     })).toThrow("all points must match the device_id in the request");
   });
 
+  it("rejects unexpected top-level ingest metadata before storage accounting", () => {
+    const payload = {
+      ...buildPayload("device-1"),
+      debug_blob: "unexpected",
+    };
+
+    expect(() => parseIngestPayload(JSON.stringify(payload))).toThrow("invalid ingest payload");
+  });
+
   it("stores gzipped v2 payloads and sends root batch metadata to the processor", async () => {
     const saves: Array<{ path: string; payload: Buffer; options: unknown }> = [];
     const processIngestBatch = vi.fn(async (request) => ({

--- a/nodes/zero2w/case/README.md
+++ b/nodes/zero2w/case/README.md
@@ -5,10 +5,9 @@ Two-piece 3D-printable enclosure for a node with a clear inside cavity of
 
 ## Files
 
-- `node_case.scad`: Parametric OpenSCAD source.
 - `node_case_base.stl`: Open base with +Y side airflow slots, -X USB cutout, -X reset button hole, Raspberry Pi Zero 2 W standoffs, and chamfered rim/port edges.
 - `node_case_lid.stl`: Vented snap-detent lid with a GPS antenna opening, GPS mounting bosses, and etched outside E-face product/GPS/site markings. The lid STL has the lip pointing upward so it can print without supports.
-- `node_case_combined.scad`: Wrapper that builds the base and lid from the parametric source modules onto one build plate, avoiding STL-on-STL boolean artifacts.
+- `node_case_combined.scad`: Self-contained OpenSCAD wrapper that imports `node_case_combined.stl` so the model opens cleanly even though the original parametric `node_case.scad` source is not included in this directory.
 - `node_case_combined.stl`: Base and lid on one build plate with a 10 mm gap. This combined-only export adds two long thin slots through the base bottom.
 
 ## Current Defaults
@@ -40,15 +39,19 @@ Two-piece 3D-printable enclosure for a node with a clear inside cavity of
 - GPS reference board: Adafruit Ultimate GPS breakout style, using a 15 mm x 15 mm patch antenna and two mounting holes spaced 0.8 in apart.
 - GPS lid bosses: 6.0 mm outside diameter with 2.2 mm screw pilot holes. Boss centers match the Adafruit Ultimate GPS Eagle board mounting holes at X = 2.54 mm / 22.86 mm and Y = 31.75 mm, referenced from the U1 antenna/module center at X = 12.192 mm and Y = 17.526 mm. The current GPS PCB mounting holes are 2.5 mm.
 
-## Regenerate STLs
+## Parametric Source
+
+The original `node_case.scad` parametric source is not present in this
+directory. That means the base, lid, and combined STL files here can be viewed
+and printed as-is, but they cannot be regenerated from source without first
+restoring that missing file.
+
+If `node_case.scad` is restored later, the original regeneration commands are:
 
 ```sh
 openscad -o node_case_base.stl -D 'part="base"' node_case.scad
 openscad -o node_case_lid.stl  -D 'part="lid"'  node_case.scad
 ```
-
-Adjust the parameters at the top of `node_case.scad` if the USB connector,
-reset button, wall thickness, or fit clearance needs tuning for your printer.
 
 ## References Used
 

--- a/nodes/zero2w/case/node_case.scad
+++ b/nodes/zero2w/case/node_case.scad
@@ -1,0 +1,470 @@
+// CrowdPM node case.
+// Two-piece 3D-printable enclosure for a node with a clear inside cavity of
+// 3.25 in x 3.00 in x 1.25 in.
+//
+// Units are millimeters. Export with:
+//   openscad -o node_case_base.stl -D 'part="base"' node_case.scad
+//   openscad -o node_case_lid.stl  -D 'part="lid"'  node_case.scad
+
+part = "assembly"; // "base", "lid", or "assembly"
+
+inch = 25.4;
+eps = 0.02;
+$fn = 48;
+
+// Required clear cavity.
+inner_x = 3.25 * inch;
+inner_y = 3.00 * inch;
+inner_z = 1.25 * inch;
+
+// Case fit and print defaults.
+wall = 2.0;
+floor_thickness = 2.0;
+lid_thickness = 2.0;
+lid_fit_clearance = 0.50;
+lid_lip_depth = 5.0;
+lid_lip_wall = 1.2;
+rim_chamfer = 0.60;
+lip_chamfer = 0.60;
+port_chamfer = 0.80;
+
+outer_x = inner_x + 2 * wall;
+outer_y = inner_y + 2 * wall;
+base_h = floor_thickness + inner_z;
+assembled_h = base_h + lid_thickness;
+lip_outer_x = inner_x - 2 * lid_fit_clearance;
+lip_outer_y = inner_y - 2 * lid_fit_clearance;
+
+// Serviceable snap detents: rounded lid beads engage matching base grooves.
+snap_detent_radius = 0.70;
+snap_groove_clearance = 0.18;
+snap_detent_length = 14.0;
+snap_detent_depth = 2.7;
+snap_detent_y_positions = [outer_y * 0.32, outer_y * 0.68];
+pry_notch_width = 19.0;
+pry_notch_height = 5.0;
+
+// USB and reset features on B / -X.
+usb_width = 14.5;
+usb_height = 8.0;
+usb_roof_height = usb_width / 2;
+reset_diameter = 5.5;
+port_center_z = floor_thickness + 11.5;
+reset_center_y = outer_y / 2 - 12.0;
+usb_reset_gap = 6.0;
+usb_center_y = reset_center_y - reset_diameter / 2 - usb_reset_gap - usb_width / 2;
+
+// C / +Y side vents.
+side_slot_count = 4;
+side_slot_height = 20.0;
+side_slot_width = 4.0;
+side_slot_pitch = 7.2;
+side_slot_x = wall;
+
+// Lid top vents, shifted toward -X to avoid the GPS antenna opening.
+top_slot_count = 6;
+top_slot_length = 42.0;
+top_slot_width = 4.0;
+top_slot_pitch = 8.5;
+top_slot_center_x = outer_x / 2 - 13.0;
+
+// Raspberry Pi Zero 2 W reference.
+pi_board_x = 65.0;
+pi_board_y = 30.0;
+pi_hole_inset = 3.5;
+pi_standoff_h = 0.25 * inch;
+pi_standoff_d = 6.5;
+pi_pilot_d = 2.2;
+pi_a_face_clearance = 0.5;
+pi_d_face_clearance = 0.5;
+
+// GPS lid reference.
+gps_opening = 10 / 16 * inch;
+gps_antenna = 15.0;
+gps_board_x = 25.5;
+gps_board_y = 35.0;
+gps_boss_d = 6.0;
+gps_boss_h = 4.0;
+gps_pcb_mount_hole_d = 2.5;
+gps_pilot_d = 2.2; // Screw pilot; GPS PCB plated mounting holes are 2.5 mm.
+gps_center_x = outer_x - 21.5;
+gps_center_y = outer_y / 2 + 8.475;
+// Adafruit Ultimate GPS Eagle board coordinates, relative to U1 antenna/module center.
+gps_hole_left_dx = 2.54 - 12.192;
+gps_hole_right_dx = 22.86 - 12.192;
+gps_hole_dy = 31.75 - 17.526;
+
+// Text engraving font.
+label_font = "Liberation Sans:style=Bold";
+
+// Outside E-face etching. The lid STL is lip-up, so the outside face is Z=0.
+etch_depth = 0.75;
+title_text = "Crowd PM Node";
+gps_label_text = "GPS";
+gps_sky_text_1 = "This side";
+gps_sky_text_2 = "towards sky.";
+site_text = "crowdpmplatform.web.app";
+site_qr_payload = "https://crowdpmplatform.web.app";
+qr_version = 2; // Low error correction, shortest payload above.
+qr_matrix_size = 25;
+qr_module = 0.95;
+qr_quiet_modules = 4;
+qr_overlap = 0.02;
+qr_x = gps_center_x - (qr_matrix_size + 2 * qr_quiet_modules) * qr_module / 2;
+qr_y = 0.60;
+qr_matrix = [
+    [1,1,1,1,1,1,1,0,1,1,0,0,0,1,1,0,0,0,1,1,1,1,1,1,1],
+    [1,0,0,0,0,0,1,0,0,0,0,0,0,1,1,0,0,0,1,0,0,0,0,0,1],
+    [1,0,1,1,1,0,1,0,0,1,1,0,1,1,1,1,0,0,1,0,1,1,1,0,1],
+    [1,0,1,1,1,0,1,0,0,1,0,0,1,1,0,1,1,0,1,0,1,1,1,0,1],
+    [1,0,1,1,1,0,1,0,0,1,1,0,0,0,0,0,1,0,1,0,1,1,1,0,1],
+    [1,0,0,0,0,0,1,0,0,0,1,1,1,0,1,0,1,0,1,0,0,0,0,0,1],
+    [1,1,1,1,1,1,1,0,1,0,1,0,1,0,1,0,1,0,1,1,1,1,1,1,1],
+    [0,0,0,0,0,0,0,0,1,0,0,1,0,1,1,0,0,0,0,0,0,0,0,0,0],
+    [1,1,0,1,1,0,1,0,0,1,1,1,1,0,1,1,0,0,1,0,0,0,0,0,1],
+    [1,1,1,1,0,0,0,0,1,1,1,1,1,0,1,1,0,1,0,1,1,1,1,1,0],
+    [1,1,1,0,0,0,1,0,1,0,1,1,1,1,0,1,1,1,1,1,0,1,0,0,1],
+    [1,1,0,0,0,0,0,0,0,1,1,0,1,0,0,0,0,1,0,0,0,1,1,1,1],
+    [0,0,1,0,0,1,1,1,1,1,0,1,1,0,0,0,1,0,1,1,0,0,0,0,1],
+    [1,1,1,0,0,1,0,1,1,1,0,1,0,0,1,1,1,0,0,0,1,0,0,1,0],
+    [1,1,0,0,0,0,1,1,0,1,0,0,0,0,1,1,1,1,0,0,1,1,1,1,1],
+    [1,0,1,1,1,1,0,1,0,1,1,0,0,0,0,0,1,1,0,1,0,1,1,0,1],
+    [1,0,1,0,0,1,1,1,0,0,0,1,1,1,0,1,1,1,1,1,1,0,1,1,0],
+    [0,0,0,0,0,0,0,0,1,1,0,0,0,0,1,1,1,0,0,0,1,0,1,1,0],
+    [1,1,1,1,1,1,1,0,0,0,1,1,0,0,1,0,1,0,1,0,1,0,0,0,1],
+    [1,0,0,0,0,0,1,0,0,0,1,1,0,1,1,1,1,0,0,0,1,0,0,1,0],
+    [1,0,1,1,1,0,1,0,1,0,1,0,0,0,1,1,1,1,1,1,1,0,0,1,0],
+    [1,0,1,1,1,0,1,0,1,1,0,1,0,1,1,0,1,1,1,0,0,0,0,1,1],
+    [1,0,1,1,1,0,1,0,0,1,1,1,1,0,0,0,0,0,0,0,1,1,1,1,1],
+    [1,0,0,0,0,0,1,0,1,1,1,0,0,0,1,0,0,0,1,1,1,0,1,1,1],
+    [1,1,1,1,1,1,1,0,1,0,0,0,1,0,1,0,1,0,0,0,0,1,0,0,1],
+];
+
+module rounded_rect(size, radius) {
+    hull() {
+        translate([radius, radius]) circle(r = radius);
+        translate([size[0] - radius, radius]) circle(r = radius);
+        translate([radius, size[1] - radius]) circle(r = radius);
+        translate([size[0] - radius, size[1] - radius]) circle(r = radius);
+    }
+}
+
+module rounded_slot_2d(length, width) {
+    hull() {
+        translate([width / 2, width / 2]) circle(d = width);
+        translate([length - width / 2, width / 2]) circle(d = width);
+    }
+}
+
+module label_2d(value, size) {
+    text(value, size = size, font = label_font, halign = "center", valign = "center");
+}
+
+module top_chamfered_box(size, chamfer) {
+    sx = size[0];
+    sy = size[1];
+    sz = size[2];
+
+    if (chamfer <= 0) {
+        cube(size);
+    } else {
+        hull() {
+            cube([sx, sy, sz - chamfer]);
+
+            translate([chamfer, chamfer, sz - eps])
+                cube([sx - 2 * chamfer, sy - 2 * chamfer, eps]);
+        }
+    }
+}
+
+module base_inner_rim_chamfer_cutout() {
+    hull() {
+        translate([wall, wall, base_h - rim_chamfer - eps])
+            cube([inner_x, inner_y, eps]);
+
+        translate([wall - rim_chamfer, wall - rim_chamfer, base_h - eps])
+            cube([inner_x + 2 * rim_chamfer, inner_y + 2 * rim_chamfer, eps]);
+    }
+}
+
+module side_vent_cutouts() {
+    center_z = floor_thickness + inner_z / 2;
+
+    for (i = [0 : side_slot_count - 1]) {
+        translate([
+            side_slot_x + i * side_slot_pitch,
+            outer_y + eps,
+            center_z - side_slot_height / 2
+        ])
+            rotate([90, 0, 0])
+                linear_extrude(height = wall + 2 * eps)
+                    rounded_rect([side_slot_width, side_slot_height], side_slot_width / 2);
+    }
+}
+
+module usb_cutout() {
+    union() {
+        translate([
+            -eps,
+            usb_center_y - usb_width / 2,
+            port_center_z - usb_height / 2
+        ])
+            cube([wall + 2 * eps, usb_width, usb_height]);
+
+        translate([0, usb_center_y, port_center_z + usb_height / 2])
+            polyhedron(
+                points = [
+                    [-eps, -usb_width / 2, 0],
+                    [-eps, usb_width / 2, 0],
+                    [-eps, 0, usb_roof_height],
+                    [wall + eps, -usb_width / 2, 0],
+                    [wall + eps, usb_width / 2, 0],
+                    [wall + eps, 0, usb_roof_height]
+                ],
+                faces = [
+                    [0, 1, 2],
+                    [3, 5, 4],
+                    [0, 3, 4, 1],
+                    [1, 4, 5, 2],
+                    [2, 5, 3, 0]
+                ]
+            );
+    }
+}
+
+module usb_chamfer_cutout() {
+    translate([-eps, usb_center_y, port_center_z])
+        hull() {
+            translate([
+                0,
+                -usb_width / 2 - port_chamfer,
+                -usb_height / 2 - port_chamfer
+            ])
+                cube([
+                    eps,
+                    usb_width + 2 * port_chamfer,
+                    usb_height + 2 * port_chamfer
+                ]);
+
+            translate([port_chamfer, -usb_width / 2, -usb_height / 2])
+                cube([eps, usb_width, usb_height]);
+        }
+}
+
+module reset_cutout() {
+    translate([-eps, reset_center_y, port_center_z])
+        rotate([0, 90, 0])
+            cylinder(h = wall + 2 * eps, d = reset_diameter);
+}
+
+module reset_chamfer_cutout() {
+    translate([-eps, reset_center_y, port_center_z])
+        rotate([0, 90, 0])
+            cylinder(
+                h = port_chamfer + eps,
+                d1 = reset_diameter + 2 * port_chamfer,
+                d2 = reset_diameter
+            );
+}
+
+module snap_groove_x(x, y) {
+    translate([x, y, base_h - snap_detent_depth])
+        rotate([90, 0, 0])
+            cylinder(
+                h = snap_detent_length + 0.8,
+                r = snap_detent_radius + snap_groove_clearance,
+                center = true
+            );
+}
+
+module snap_groove_cutouts() {
+    for (y = snap_detent_y_positions) {
+        snap_groove_x(wall, y);
+        snap_groove_x(wall + inner_x, y);
+    }
+}
+
+module pry_notch_cutout() {
+    translate([
+        outer_x / 2 - pry_notch_width / 2,
+        -eps,
+        base_h - pry_notch_height
+    ])
+        cube([pry_notch_width, wall + 2 * eps, pry_notch_height + eps]);
+}
+
+module base_shell() {
+    difference() {
+        top_chamfered_box([outer_x, outer_y, base_h], rim_chamfer);
+
+        translate([wall, wall, floor_thickness])
+            cube([inner_x, inner_y, inner_z + eps]);
+
+        base_inner_rim_chamfer_cutout();
+        side_vent_cutouts();
+        usb_cutout();
+        usb_chamfer_cutout();
+        reset_cutout();
+        reset_chamfer_cutout();
+        snap_groove_cutouts();
+        pry_notch_cutout();
+    }
+}
+
+module pi_standoff(x, y) {
+    translate([x, y, floor_thickness - eps])
+        difference() {
+            cylinder(h = pi_standoff_h + eps, d = pi_standoff_d);
+
+            translate([0, 0, -eps])
+                cylinder(h = pi_standoff_h + 2 * eps, d = pi_pilot_d);
+        }
+}
+
+module pi_standoffs() {
+    // Rotate the Pi Zero 2 W hole pattern 90 degrees and tuck it into A / +X and D / -Y.
+    mount_x = pi_board_y;
+    mount_y = pi_board_x;
+    x0 = outer_x - wall - pi_a_face_clearance - mount_x;
+    y0 = wall + pi_d_face_clearance;
+
+    for (x = [x0 + pi_hole_inset, x0 + mount_x - pi_hole_inset]) {
+        for (y = [y0 + pi_hole_inset, y0 + mount_y - pi_hole_inset]) {
+            pi_standoff(x, y);
+        }
+    }
+}
+
+module base() {
+    union() {
+        base_shell();
+        pi_standoffs();
+    }
+}
+
+module top_vent_cutouts() {
+    total_y = (top_slot_count - 1) * top_slot_pitch + top_slot_width;
+    start_y = outer_y / 2 - total_y / 2;
+
+    for (i = [0 : top_slot_count - 1]) {
+        translate([
+            top_slot_center_x - top_slot_length / 2,
+            start_y + i * top_slot_pitch,
+            -eps
+        ])
+            linear_extrude(height = lid_thickness + 2 * eps)
+                rounded_slot_2d(top_slot_length, top_slot_width);
+    }
+}
+
+module gps_opening_cutout() {
+    translate([
+        gps_center_x - gps_opening / 2,
+        gps_center_y - gps_opening / 2,
+        -eps
+    ])
+        cube([gps_opening, gps_opening, lid_thickness + 2 * eps]);
+}
+
+module lid_lip() {
+    translate([wall + lid_fit_clearance, wall + lid_fit_clearance, lid_thickness - eps])
+        difference() {
+            top_chamfered_box([lip_outer_x, lip_outer_y, lid_lip_depth + eps], lip_chamfer);
+
+            translate([lid_lip_wall, lid_lip_wall, -eps])
+                cube([
+                    lip_outer_x - 2 * lid_lip_wall,
+                    lip_outer_y - 2 * lid_lip_wall,
+                    lid_lip_depth + 3 * eps
+                ]);
+        }
+}
+
+module snap_detent_x(x, y) {
+    translate([x, y, lid_thickness + snap_detent_depth])
+        rotate([90, 0, 0])
+            cylinder(h = snap_detent_length, r = snap_detent_radius, center = true);
+}
+
+module lid_snap_detents() {
+    lip_min_x = wall + lid_fit_clearance;
+    lip_max_x = wall + lid_fit_clearance + lip_outer_x;
+
+    for (y = snap_detent_y_positions) {
+        snap_detent_x(lip_min_x, y);
+        snap_detent_x(lip_max_x, y);
+    }
+}
+
+module gps_boss(x, y) {
+    translate([x, y, lid_thickness - eps])
+        difference() {
+            cylinder(h = gps_boss_h + eps, d = gps_boss_d);
+
+            translate([0, 0, -eps])
+                cylinder(h = gps_boss_h + 2 * eps, d = gps_pilot_d);
+        }
+}
+
+module gps_bosses() {
+    gps_boss(gps_center_x + gps_hole_left_dx, gps_center_y + gps_hole_dy);
+    gps_boss(gps_center_x + gps_hole_right_dx, gps_center_y + gps_hole_dy);
+}
+
+module outside_etched_text(value, x, y, size) {
+    translate([x, y, -eps])
+        linear_extrude(height = etch_depth + eps)
+            offset(delta = 0.01)
+                mirror([1, 0, 0])
+                    label_2d(value, size);
+}
+
+module outside_qr_etch() {
+    qr_size = len(qr_matrix);
+
+    for (r = [0 : qr_size - 1]) {
+        for (c = [0 : qr_size - 1]) {
+            if (qr_matrix[r][c] == 1) {
+                translate([
+                    qr_x + (qr_quiet_modules + qr_size - 1 - c) * qr_module - qr_overlap / 2,
+                    qr_y + (qr_quiet_modules + qr_size - 1 - r) * qr_module - qr_overlap / 2,
+                    -eps
+                ])
+                    cube([qr_module + qr_overlap, qr_module + qr_overlap, etch_depth + eps]);
+            }
+        }
+    }
+}
+
+module outside_lid_etches() {
+    outside_etched_text(title_text, outer_x / 2, outer_y - 6.8, 5.6);
+    outside_etched_text(site_text, outer_x / 2, outer_y - 14.0, 3.0);
+    outside_etched_text(gps_label_text, gps_center_x, gps_center_y + gps_opening / 2 + 4.7, 3.6);
+    outside_etched_text(gps_sky_text_1, gps_center_x, gps_center_y - gps_opening / 2 - 2.6, 2.4);
+    outside_etched_text(gps_sky_text_2, gps_center_x, gps_center_y - gps_opening / 2 - 5.8, 2.4);
+    outside_qr_etch();
+}
+
+module lid() {
+    difference() {
+        union() {
+            cube([outer_x, outer_y, lid_thickness]);
+            lid_lip();
+            lid_snap_detents();
+            gps_bosses();
+        }
+
+        top_vent_cutouts();
+        gps_opening_cutout();
+        outside_lid_etches();
+    }
+}
+
+if (part == "base") {
+    base();
+} else if (part == "lid") {
+    lid();
+} else {
+    base();
+    translate([0, outer_y + 10, 0]) lid();
+}

--- a/nodes/zero2w/case/node_case_combined.scad
+++ b/nodes/zero2w/case/node_case_combined.scad
@@ -1,47 +1,8 @@
-// Combined print plate for the CrowdPM node case.
-// This uses the parametric source modules directly instead of modifying
-// imported STL meshes, which avoids slicer artifacts from STL booleans.
+// Self-contained OpenSCAD wrapper for the generated combined case STL.
+//
+// The original parametric source file `node_case.scad` is not present in this
+// directory, so the previous wrapper opened with missing-library warnings and
+// showed incomplete geometry. Importing the generated STL keeps this file
+// directly openable in OpenSCAD.
 
-use <node_case.scad>
-
-base_x = 86.55;
-base_y = 80.20;
-part_gap = 10.00;
-
-floor_thickness = 2.00;
-slot_length = 46.00;
-slot_width = 4.00;
-slot_y_positions = [22.00, 58.00];
-eps = 0.02;
-$fn = 48;
-
-module combined_rounded_slot_2d(length, width) {
-    hull() {
-        translate([width / 2, width / 2]) circle(d = width);
-        translate([length - width / 2, width / 2]) circle(d = width);
-    }
-}
-
-module bottom_slot_cutouts() {
-    for (slot_y = slot_y_positions) {
-        translate([
-            base_x / 2 - slot_length / 2,
-            slot_y - slot_width / 2,
-            -eps
-        ])
-            linear_extrude(height = floor_thickness + 2 * eps)
-                combined_rounded_slot_2d(slot_length, slot_width);
-    }
-}
-
-module combined_base_with_bottom_slots() {
-    difference() {
-        base();
-        bottom_slot_cutouts();
-    }
-}
-
-combined_base_with_bottom_slots();
-
-translate([0, base_y + part_gap, 0])
-    lid();
+import("node_case_combined.stl", convexity = 10);

--- a/nodes/zero2w/crowdpm_node/api.py
+++ b/nodes/zero2w/crowdpm_node/api.py
@@ -19,15 +19,9 @@ class CrowdPmApiError(RuntimeError):
 
 def derive_htu(url: str, api_base: str | None = None) -> str:
     target = urlparse(url)
-    if api_base:
-      # Mirror the repo's device-emulator behavior: DPoP htu strips the Functions base prefix.
-        base = urlparse(api_base)
-        path = target.path
-        if path.startswith(base.path.rstrip("/")):
-            path = path[len(base.path.rstrip("/")):] or "/"
-    else:
-        path = target.path or "/"
-    return f"{target.scheme}://{target.netloc}{path}"
+    path = target.path or "/"
+    query = f"?{target.query}" if target.query else ""
+    return f"{target.scheme}://{target.netloc}{path}{query}"
 
 
 @dataclass(slots=True)
@@ -105,7 +99,6 @@ class CrowdPmApiClient:
             {"device_code": device_code},
             headers={
                 "DPoP": dpop,
-                "x-forwarded-proto": urlparse(url).scheme,
             },
         )
 
@@ -130,7 +123,6 @@ class CrowdPmApiClient:
             headers={
                 "Authorization": f"Bearer {registration_token}",
                 "DPoP": dpop,
-                "x-forwarded-proto": urlparse(url).scheme,
             },
         )
 
@@ -153,7 +145,6 @@ class CrowdPmApiClient:
             {"device_id": device_id, "scope": ["ingest.write"]},
             headers={
                 "DPoP": dpop,
-                "x-forwarded-proto": urlparse(url).scheme,
             },
         )
 
@@ -179,7 +170,6 @@ class CrowdPmApiClient:
             headers={
                 "Authorization": f"Bearer {access_token}",
                 "DPoP": dpop,
-                "x-forwarded-proto": urlparse(url).scheme,
             },
         )
 

--- a/scripts/deployed-device-registration.sh
+++ b/scripts/deployed-device-registration.sh
@@ -211,30 +211,11 @@ NODE
 
 derive_htu() {
   local target_url="$1"
-  local base_url="$2"
 
-  node --input-type=module - "${target_url}" "${base_url}" <<'NODE'
-const [targetUrlRaw, baseUrlRaw] = process.argv.slice(2);
+  node --input-type=module - "${target_url}" <<'NODE'
+const [targetUrlRaw] = process.argv.slice(2);
 const target = new URL(targetUrlRaw);
-let basePath = "";
-try {
-  basePath = new URL(baseUrlRaw).pathname.replace(/\/$/u, "");
-}
-catch {
-  basePath = "";
-}
-const trimmedPath = target.pathname.startsWith(basePath)
-  ? (target.pathname.slice(basePath.length) || "/")
-  : target.pathname;
-process.stdout.write(`${target.protocol}//${target.host}${trimmedPath}`);
-NODE
-}
-
-url_proto() {
-  local raw_url="$1"
-  node --input-type=module - "${raw_url}" <<'NODE'
-const [rawUrl] = process.argv.slice(2);
-process.stdout.write(new URL(rawUrl).protocol.replace(":", ""));
+process.stdout.write(`${target.origin}${target.pathname}${target.search}`);
 NODE
 }
 
@@ -494,8 +475,7 @@ else
 fi
 
 TOKEN_URL="$(endpoint_url "/device/token")"
-TOKEN_HTU="$(derive_htu "${TOKEN_URL}" "${API_BASE}")"
-TOKEN_PROTO="$(url_proto "${TOKEN_URL}")"
+TOKEN_HTU="$(derive_htu "${TOKEN_URL}")"
 TOKEN_OUT="${TMP_DIR}/token.json"
 
 POLL_SECONDS="${CROWDPM_POLL_INTERVAL_SECONDS:-${POLL_INTERVAL}}"
@@ -512,7 +492,6 @@ while :; do
   TOKEN_BODY="$(build_token_body)"
   TOKEN_STATUS="$(http_request "POST" "${TOKEN_URL}" "${TOKEN_BODY}" "${TOKEN_OUT}" \
     "content-type: application/json" \
-    "x-forwarded-proto: ${TOKEN_PROTO}" \
     "DPoP: $(make_dpop "${TOKEN_HTU}" "POST" "${KEY_FILE}")")"
 
   if [[ "${TOKEN_STATUS}" == "200" ]]; then
@@ -555,8 +534,7 @@ while :; do
 done
 
 REGISTER_URL="$(endpoint_url "/device/register")"
-REGISTER_HTU="$(derive_htu "${REGISTER_URL}" "${API_BASE}")"
-REGISTER_PROTO="$(url_proto "${REGISTER_URL}")"
+REGISTER_HTU="$(derive_htu "${REGISTER_URL}")"
 REGISTER_OUT="${TMP_DIR}/register.json"
 REGISTER_BODY="$(printf '{"jwk_pub_kl":%s}' "${PUB_KL_JSON}")"
 
@@ -564,7 +542,6 @@ print_section "Register Device"
 REGISTER_STATUS="$(http_request "POST" "${REGISTER_URL}" "${REGISTER_BODY}" "${REGISTER_OUT}" \
   "Authorization: Bearer ${REGISTRATION_TOKEN}" \
   "content-type: application/json" \
-  "x-forwarded-proto: ${REGISTER_PROTO}" \
   "DPoP: $(make_dpop "${REGISTER_HTU}" "POST" "${KEY_FILE}")")"
 
 if [[ "${REGISTER_STATUS}" != "200" ]]; then
@@ -579,15 +556,13 @@ echo "device_id: ${DEVICE_ID}"
 echo "saved: ${DEVICE_ID_FILE}"
 
 ACCESS_URL="$(endpoint_url "/device/access-token")"
-ACCESS_HTU="$(derive_htu "${ACCESS_URL}" "${API_BASE}")"
-ACCESS_PROTO="$(url_proto "${ACCESS_URL}")"
+ACCESS_HTU="$(derive_htu "${ACCESS_URL}")"
 ACCESS_OUT="${TMP_DIR}/access.json"
 ACCESS_BODY="$(build_access_body)"
 
 print_section "Mint Access Token"
 ACCESS_STATUS="$(http_request "POST" "${ACCESS_URL}" "${ACCESS_BODY}" "${ACCESS_OUT}" \
   "content-type: application/json" \
-  "x-forwarded-proto: ${ACCESS_PROTO}" \
   "DPoP: $(make_dpop "${ACCESS_HTU}" "POST" "${KEY_FILE}")")"
 
 if [[ "${ACCESS_STATUS}" != "200" ]]; then
@@ -603,8 +578,7 @@ echo "access_token saved: ${ACCESS_TOKEN_FILE}"
 echo "access_token expires_in: ${ACCESS_TOKEN_TTL}s"
 
 if [[ "${SEND_INGEST}" == "1" ]]; then
-  INGEST_PROTO="$(url_proto "${INGEST_URL}")"
-  INGEST_HTU="$(derive_htu "${INGEST_URL}" "${INGEST_URL}")"
+  INGEST_HTU="$(derive_htu "${INGEST_URL}")"
   INGEST_OUT="${TMP_DIR}/ingest.json"
   INGEST_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   INGEST_BODY="$(build_ingest_body)"
@@ -613,7 +587,6 @@ if [[ "${SEND_INGEST}" == "1" ]]; then
   INGEST_STATUS="$(http_request "POST" "${INGEST_URL}" "${INGEST_BODY}" "${INGEST_OUT}" \
     "Authorization: Bearer ${ACCESS_TOKEN}" \
     "content-type: application/json" \
-    "x-forwarded-proto: ${INGEST_PROTO}" \
     "DPoP: $(make_dpop "${INGEST_HTU}" "POST" "${KEY_FILE}")")"
 
   if [[ "${INGEST_STATUS}" != "202" ]]; then

--- a/scripts/deployed-device-send-batch.sh
+++ b/scripts/deployed-device-send-batch.sh
@@ -202,30 +202,11 @@ NODE
 
 derive_htu() {
   local target_url="$1"
-  local base_url="$2"
 
-  node --input-type=module - "${target_url}" "${base_url}" <<'NODE'
-const [targetUrlRaw, baseUrlRaw] = process.argv.slice(2);
+  node --input-type=module - "${target_url}" <<'NODE'
+const [targetUrlRaw] = process.argv.slice(2);
 const target = new URL(targetUrlRaw);
-let basePath = "";
-try {
-  basePath = new URL(baseUrlRaw).pathname.replace(/\/$/u, "");
-}
-catch {
-  basePath = "";
-}
-const trimmedPath = target.pathname.startsWith(basePath)
-  ? (target.pathname.slice(basePath.length) || "/")
-  : target.pathname;
-process.stdout.write(`${target.protocol}//${target.host}${trimmedPath}`);
-NODE
-}
-
-url_proto() {
-  local raw_url="$1"
-  node --input-type=module - "${raw_url}" <<'NODE'
-const [rawUrl] = process.argv.slice(2);
-process.stdout.write(new URL(rawUrl).protocol.replace(":", ""));
+process.stdout.write(`${target.origin}${target.pathname}${target.search}`);
 NODE
 }
 
@@ -500,11 +481,9 @@ DEVICE_ID="$(resolve_device_id)"
 RAW_PAYLOAD_FILE="${TMP_DIR}/batch.raw.json"
 NORMALIZED_PAYLOAD_FILE="${TMP_DIR}/batch.normalized.json"
 ACCESS_URL="$(endpoint_url "/device/access-token")"
-ACCESS_HTU="$(derive_htu "${ACCESS_URL}" "${API_BASE}")"
-ACCESS_PROTO="$(url_proto "${ACCESS_URL}")"
+ACCESS_HTU="$(derive_htu "${ACCESS_URL}")"
 ACCESS_OUT="${TMP_DIR}/access.json"
-INGEST_PROTO="$(url_proto "${INGEST_URL}")"
-INGEST_HTU="$(derive_htu "${INGEST_URL}" "${INGEST_URL}")"
+INGEST_HTU="$(derive_htu "${INGEST_URL}")"
 INGEST_OUT="${TMP_DIR}/ingest.json"
 
 write_payload_to_file "${1:-}" "${RAW_PAYLOAD_FILE}"
@@ -533,7 +512,6 @@ else
   print_section "Mint Access Token"
   ACCESS_STATUS="$(http_request "POST" "${ACCESS_URL}" "${ACCESS_BODY}" "${ACCESS_OUT}" \
     "content-type: application/json" \
-    "x-forwarded-proto: ${ACCESS_PROTO}" \
     "DPoP: $(make_dpop "${ACCESS_HTU}" "POST" "${KEY_FILE}")")"
 
   if [[ "${ACCESS_STATUS}" != "200" ]]; then
@@ -552,7 +530,6 @@ fi
 INGEST_HEADERS=(
   "Authorization: Bearer ${ACCESS_TOKEN}"
   "content-type: application/json"
-  "x-forwarded-proto: ${INGEST_PROTO}"
   "DPoP: $(make_dpop "${INGEST_HTU}" "POST" "${KEY_FILE}")"
 )
 

--- a/scripts/device-emulator.mjs
+++ b/scripts/device-emulator.mjs
@@ -68,18 +68,8 @@ function buildUrl(base, pathname) {
   return new URL(pathname.startsWith("/") ? pathname.slice(1) : pathname, normalized);
 }
 
-function deriveHtu(targetUrl, apiBase, proto) {
-  let basePath = "";
-  try {
-    basePath = new URL(apiBase).pathname.replace(/\/$/u, "");
-  }
-  catch {
-    basePath = "";
-  }
-  const trimmedPath = targetUrl.pathname.startsWith(basePath)
-    ? targetUrl.pathname.slice(basePath.length) || "/"
-    : targetUrl.pathname;
-  return `${proto}://${targetUrl.host}${trimmedPath}`;
+function deriveHtu(targetUrl) {
+  return `${targetUrl.origin}${targetUrl.pathname}${targetUrl.search}`;
 }
 
 function sleep(ms) {
@@ -175,8 +165,7 @@ Options:
 
 async function requestAccessToken({ apiBase, deviceId, privateJwk, publicJwk }) {
   const accessUrl = buildUrl(apiBase, "/device/access-token");
-  const accessProto = accessUrl.protocol.replace(":", "") || "https";
-  const accessHtu = deriveHtu(accessUrl, apiBase, accessProto);
+  const accessHtu = deriveHtu(accessUrl);
   const accessDpop = await createDpopProof({
     htu: accessHtu,
     method: "POST",
@@ -189,7 +178,6 @@ async function requestAccessToken({ apiBase, deviceId, privateJwk, publicJwk }) 
     headers: {
       "content-type": "application/json",
       dpop: accessDpop,
-      "x-forwarded-proto": accessProto,
     },
     body: JSON.stringify({ device_id: deviceId, scope: ["ingest.write"] }),
   });
@@ -206,8 +194,7 @@ async function requestAccessToken({ apiBase, deviceId, privateJwk, publicJwk }) 
 
 async function sendIngest({ ingestUrlRaw, deviceId, privateJwk, publicJwk, accessToken, points }) {
   const ingestUrl = new URL(ingestUrlRaw);
-  const ingestProto = ingestUrl.protocol.replace(":", "") || "https";
-  const ingestHtu = deriveHtu(ingestUrl, ingestUrlRaw, ingestProto);
+  const ingestHtu = deriveHtu(ingestUrl);
   const ingestDpop = await createDpopProof({
     htu: ingestHtu,
     method: "POST",
@@ -224,7 +211,6 @@ async function sendIngest({ ingestUrlRaw, deviceId, privateJwk, publicJwk, acces
       authorization: `Bearer ${accessToken}`,
       "content-type": "application/json",
       dpop: ingestDpop,
-      "x-forwarded-proto": ingestProto,
     },
     body: JSON.stringify(ingestPayload),
   });
@@ -472,8 +458,7 @@ async function main() {
   // Begin polling for registration token and auto-register.
   const targetDeviceCode = values["device-code"] ?? deviceCode;
   const tokenUrl = buildUrl(apiBase, "/device/token");
-  const tokenProto = tokenUrl.protocol.replace(":", "") || "https";
-  const tokenHtu = deriveHtu(tokenUrl, apiBase, tokenProto);
+  const tokenHtu = deriveHtu(tokenUrl);
   let pollSeconds = Number(values.interval ?? pollInterval ?? 3);
   if (!Number.isFinite(pollSeconds) || pollSeconds <= 0) pollSeconds = 3;
 
@@ -487,7 +472,6 @@ async function main() {
       headers: {
         "content-type": "application/json",
         dpop,
-        "x-forwarded-proto": tokenProto,
       },
       body: JSON.stringify({ device_code: targetDeviceCode }),
     });
@@ -503,8 +487,7 @@ async function main() {
       }
 
       const registerUrl = buildUrl(apiBase, "/device/register");
-      const registerProto = registerUrl.protocol.replace(":", "") || "https";
-      const registerHtu = deriveHtu(registerUrl, apiBase, registerProto);
+      const registerHtu = deriveHtu(registerUrl);
       const registerDpop = await createDpopProof({
         htu: registerHtu,
         method: "POST",
@@ -519,7 +502,6 @@ async function main() {
           authorization: `Bearer ${regToken}`,
           "content-type": "application/json",
           dpop: registerDpop,
-          "x-forwarded-proto": registerProto,
         },
         body: JSON.stringify({ jwk_pub_kl: publicJwk }),
       });


### PR DESCRIPTION
## Summary
- stop trusting caller-supplied forwarded headers for DPoP and abuse controls
- verify device tokens against Firestore on every request so revocations propagate across instances
- lock ingest payloads to the expected schema and update device tooling to sign the canonical external URLs
- add regression coverage for canonical URL building, trusted client IP behavior, stricter ingest validation, and token revocation checks

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- python3 -m unittest nodes/zero2w/tests/test_service.py -q