### PR TITLE
Fix legacy node DPoP compatibility

### DIFF
--- a/functions/src/lib/dpop.ts
+++ b/functions/src/lib/dpop.ts
@@ -6,6 +6,8 @@ import { httpError } from "./httpError.js";
 type VerifyOptions = {
   method: string;
   htu: string;
+  acceptableHtu?: string[];
+  allowMissingAthOnHtu?: string[];
   maxAgeSeconds?: number;
   clockSkewSeconds?: number;
   expectedThumbprint?: string;
@@ -70,7 +72,7 @@ export async function verifyDpopProof(proof: string | undefined, options: Verify
     throw unauthorized("DPoP htm mismatch");
   }
 
-  if (htu !== options.htu) {
+  if (htu !== options.htu && !(options.acceptableHtu ?? []).includes(htu)) {
     throw unauthorized("DPoP htu mismatch");
   }
 
@@ -81,8 +83,12 @@ export async function verifyDpopProof(proof: string | undefined, options: Verify
     throw unauthorized("DPoP iat outside acceptable window");
   }
 
-  if (options.expectedAth && (!ath || typeof ath !== "string" || ath !== options.expectedAth)) {
-    throw unauthorized("DPoP ath mismatch");
+  if (options.expectedAth) {
+    const allowMissingAth = !ath
+      && (options.allowMissingAthOnHtu ?? []).includes(htu);
+    if (!allowMissingAth && (typeof ath !== "string" || ath !== options.expectedAth)) {
+      throw unauthorized("DPoP ath mismatch");
+    }
   }
 
   if (!protectedJwk) {

--- a/functions/src/lib/http.ts
+++ b/functions/src/lib/http.ts
@@ -65,6 +65,21 @@ export function buildCanonicalEndpointUrl(baseUrl: string, requestUrl: string | 
   return new URL(relativePath, joinableBaseUrl).toString();
 }
 
+export function buildFunctionRelativeEndpointUrl(baseUrl: string, requestUrl: string | undefined): string {
+  const origin = normalizeBaseUrl(baseUrl).origin;
+  const cleaned = (requestUrl ?? "/").split("#", 1)[0] || "/";
+  if (cleaned === "/" || cleaned.length === 0) {
+    return `${origin}/`;
+  }
+  if (cleaned.startsWith("?")) {
+    return `${origin}/${cleaned}`;
+  }
+  if (cleaned.startsWith("/?")) {
+    return `${origin}${cleaned}`;
+  }
+  return `${origin}${cleaned.startsWith("/") ? cleaned : `/${cleaned}`}`;
+}
+
 export function extractClientIp(headers: IncomingHttpHeaders): string | null {
   const appEngineIp = firstHeaderValue(headers["x-appengine-user-ip"]);
   if (appEngineIp) return appEngineIp;

--- a/functions/src/routes/pairing.ts
+++ b/functions/src/routes/pairing.ts
@@ -10,7 +10,13 @@ import {
   recordRegistrationToken,
   markSessionRedeemed,
 } from "../services/devicePairing.js";
-import { buildCanonicalEndpointUrl, coarsenIpForDisplay, deriveNetworkHint, extractClientIp } from "../lib/http.js";
+import {
+  buildCanonicalEndpointUrl,
+  buildFunctionRelativeEndpointUrl,
+  coarsenIpForDisplay,
+  deriveNetworkHint,
+  extractClientIp,
+} from "../lib/http.js";
 import { verifyDpopProof } from "../lib/dpop.js";
 import { rateLimitOrThrow } from "../lib/rateLimiter.js";
 import { issueRegistrationToken, verifyRegistrationToken, issueDeviceAccessToken } from "../services/deviceTokens.js";
@@ -46,6 +52,10 @@ const deviceTokenSchema = z.object({
 
 function fastifyRequestUrl(req: FastifyRequest): string {
   return buildCanonicalEndpointUrl(getCrowdpmApiBaseUrl(), req.raw.url ?? req.url);
+}
+
+function legacyFastifyRequestUrl(req: FastifyRequest): string {
+  return buildFunctionRelativeEndpointUrl(getCrowdpmApiBaseUrl(), req.raw.url ?? req.url);
 }
 
 export const pairingRoutes: FastifyPluginAsync = async (app) => {
@@ -104,6 +114,7 @@ export const pairingRoutes: FastifyPluginAsync = async (app) => {
       await verifyDpopProof(typeof proof === "string" ? proof : Array.isArray(proof) ? proof[0] : undefined, {
         method: req.method.toUpperCase(),
         htu,
+        acceptableHtu: [legacyFastifyRequestUrl(req)],
         expectedThumbprint: session.pubKeThumbprint,
       });
     }
@@ -175,6 +186,7 @@ export const pairingRoutes: FastifyPluginAsync = async (app) => {
     await verifyDpopProof(proofValue, {
       method: req.method.toUpperCase(),
       htu,
+      acceptableHtu: [legacyFastifyRequestUrl(req)],
       expectedThumbprint: verifiedToken.cnf.jkt,
     });
 
@@ -247,6 +259,7 @@ export const pairingRoutes: FastifyPluginAsync = async (app) => {
     const verifiedProof = await verifyDpopProof(typeof proof === "string" ? proof : Array.isArray(proof) ? proof[0] : undefined, {
       method: req.method.toUpperCase(),
       htu,
+      acceptableHtu: [legacyFastifyRequestUrl(req)],
       expectedThumbprint: device.pubKlThumbprint,
     });
 

--- a/functions/src/services/ingestGateway.ts
+++ b/functions/src/services/ingestGateway.ts
@@ -3,7 +3,7 @@ import type { Request } from "firebase-functions/v2/https";
 import { normalizeBatchVisibility } from "../lib/batchVisibility.js";
 import { verifyDeviceAccessToken } from "./deviceTokens.js";
 import { calculateDpopAth, checkDpopReplay, verifyDpopProof } from "../lib/dpop.js";
-import { buildCanonicalEndpointUrl } from "../lib/http.js";
+import { buildCanonicalEndpointUrl, buildFunctionRelativeEndpointUrl } from "../lib/http.js";
 import { applyCorsHeaders } from "../lib/corsPolicy.js";
 import { ingestGatewayRuntimeOptions } from "../lib/functionOptions.js";
 import { ingestService, type IngestBody } from "./ingestService.js";
@@ -86,10 +86,13 @@ export async function ingestGatewayHandler(
 
     const accessToken = await dependencies.verifyDeviceAccessToken(token);
     const htu = buildCanonicalEndpointUrl(getIngestGatewayBaseUrl(), req.url);
+    const legacyHtu = buildFunctionRelativeEndpointUrl(getIngestGatewayBaseUrl(), req.url);
     const dpopProof = requestHeader(req, "dpop");
     const verifiedProof = await dependencies.verifyDpopProof(dpopProof, {
       method: req.method.toUpperCase(),
       htu,
+      acceptableHtu: [legacyHtu],
+      allowMissingAthOnHtu: [legacyHtu],
       expectedThumbprint: accessToken.cnf.jkt,
       expectedAth: calculateDpopAth(token),
     });

--- a/functions/test/lib/dpop.test.ts
+++ b/functions/test/lib/dpop.test.ts
@@ -1,0 +1,100 @@
+import crypto from "node:crypto";
+import { exportJWK, SignJWT } from "jose";
+import { describe, expect, it } from "vitest";
+import { verifyDpopProof } from "../../src/lib/dpop.js";
+
+async function buildProof(args: { htu: string; method?: string; ath?: string }) {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  const publicJwk = await exportJWK(publicKey);
+  const payload: Record<string, string> = {
+    htm: args.method ?? "POST",
+    htu: args.htu,
+  };
+  if (args.ath) {
+    payload.ath = args.ath;
+  }
+
+  return new SignJWT(payload)
+    .setProtectedHeader({
+      alg: "EdDSA",
+      typ: "dpop+jwt",
+      jwk: publicJwk,
+    })
+    .setIssuedAt()
+    .setJti("proof-jti-1")
+    .sign(privateKey);
+}
+
+describe("verifyDpopProof", () => {
+  it("accepts the canonical endpoint URL", async () => {
+    const htu = "https://us-central1-crowdpmplatform.cloudfunctions.net/crowdpmApi/device/access-token";
+    const proof = await buildProof({ htu });
+
+    await expect(verifyDpopProof(proof, {
+      method: "POST",
+      htu,
+    })).resolves.toMatchObject({
+      jti: "proof-jti-1",
+    });
+  });
+
+  it("accepts an explicitly allowed legacy function-relative URL", async () => {
+    const canonicalHtu = "https://us-central1-crowdpmplatform.cloudfunctions.net/crowdpmApi/device/access-token";
+    const legacyHtu = "https://us-central1-crowdpmplatform.cloudfunctions.net/device/access-token";
+    const proof = await buildProof({ htu: legacyHtu });
+
+    await expect(verifyDpopProof(proof, {
+      method: "POST",
+      htu: canonicalHtu,
+      acceptableHtu: [legacyHtu],
+    })).resolves.toMatchObject({
+      jti: "proof-jti-1",
+    });
+  });
+
+  it("rejects mismatched URLs outside the compatibility list", async () => {
+    const proof = await buildProof({
+      htu: "https://us-central1-crowdpmplatform.cloudfunctions.net/not-the-right-path",
+    });
+
+    await expect(verifyDpopProof(proof, {
+      method: "POST",
+      htu: "https://us-central1-crowdpmplatform.cloudfunctions.net/crowdpmApi/device/access-token",
+      acceptableHtu: ["https://us-central1-crowdpmplatform.cloudfunctions.net/device/access-token"],
+    })).rejects.toMatchObject({
+      statusCode: 401,
+      message: "DPoP htu mismatch",
+    });
+  });
+
+  it("allows missing ath only on explicitly grandfathered legacy URLs", async () => {
+    const canonicalHtu = "https://us-central1-crowdpmplatform.cloudfunctions.net/ingestGateway";
+    const legacyHtu = "https://us-central1-crowdpmplatform.cloudfunctions.net/";
+    const proof = await buildProof({ htu: legacyHtu });
+
+    await expect(verifyDpopProof(proof, {
+      method: "POST",
+      htu: canonicalHtu,
+      acceptableHtu: [legacyHtu],
+      allowMissingAthOnHtu: [legacyHtu],
+      expectedAth: "expected-ath",
+    })).resolves.toMatchObject({
+      jti: "proof-jti-1",
+    });
+  });
+
+  it("still requires ath on the canonical URL", async () => {
+    const canonicalHtu = "https://us-central1-crowdpmplatform.cloudfunctions.net/ingestGateway";
+    const proof = await buildProof({ htu: canonicalHtu });
+
+    await expect(verifyDpopProof(proof, {
+      method: "POST",
+      htu: canonicalHtu,
+      allowMissingAthOnHtu: ["https://us-central1-crowdpmplatform.cloudfunctions.net/"],
+      expectedAth: "expected-ath",
+    })).rejects.toMatchObject({
+      statusCode: 401,
+      message: "DPoP ath mismatch",
+    });
+  });
+});

--- a/functions/test/lib/http.test.ts
+++ b/functions/test/lib/http.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCanonicalEndpointUrl,
+  buildFunctionRelativeEndpointUrl,
   deriveNetworkHint,
   extractClientIp,
   stripApiEntryPrefix,
@@ -77,6 +78,29 @@ describe("buildCanonicalEndpointUrl", () => {
       "http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway",
       "?visibility=public"
     )).toBe("http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway?visibility=public");
+  });
+});
+
+describe("buildFunctionRelativeEndpointUrl", () => {
+  it("builds the legacy function-relative URL for crowdpmApi routes", () => {
+    expect(buildFunctionRelativeEndpointUrl(
+      "https://us-central1-crowdpmplatform.cloudfunctions.net/crowdpmApi",
+      "/device/access-token"
+    )).toBe("https://us-central1-crowdpmplatform.cloudfunctions.net/device/access-token");
+  });
+
+  it("builds the legacy function-relative URL for ingest root requests", () => {
+    expect(buildFunctionRelativeEndpointUrl(
+      "https://us-central1-crowdpmplatform.cloudfunctions.net/ingestGateway",
+      "/"
+    )).toBe("https://us-central1-crowdpmplatform.cloudfunctions.net/");
+  });
+
+  it("preserves root query strings for legacy ingest URLs", () => {
+    expect(buildFunctionRelativeEndpointUrl(
+      "https://us-central1-crowdpmplatform.cloudfunctions.net/ingestGateway",
+      "?visibility=public"
+    )).toBe("https://us-central1-crowdpmplatform.cloudfunctions.net/?visibility=public");
   });
 });
 

--- a/functions/test/services/ingestGateway.test.ts
+++ b/functions/test/services/ingestGateway.test.ts
@@ -141,6 +141,8 @@ describe("ingestGatewayHandler", () => {
     expect(deps.verifyDeviceAccessToken).toHaveBeenCalledWith("test-token");
     expect(deps.verifyDpopProof).toHaveBeenCalledWith("proof-token", expect.objectContaining({
       htu: "http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway",
+      acceptableHtu: ["http://127.0.0.1:5001/"],
+      allowMissingAthOnHtu: ["http://127.0.0.1:5001/"],
       expectedAth: expect.any(String),
       expectedThumbprint: "jkt-1",
     }));


### PR DESCRIPTION
## Summary
- add explicit legacy DPoP HTU compatibility for old nodes on pairing and ingest
- allow missing DPoP ath only for the grandfathered legacy ingest URL shape
- add tests covering canonical vs legacy URL handling and ingest gateway wiring

## Validation
- source ~/.nvm/nvm.sh && nvm exec 24.15.0 pnpm --filter crowdpm-functions test -- test/lib/dpop.test.ts test/services/ingestGateway.test.ts test/lib/http.test.ts

## Deployment note
- this PR backfills the repo workflow for the production hotfix already applied to restore uploads from the deployed legacy node