### PR TITLE
Fix deploy workflow functions tests

### DIFF
--- a/functions/test/routes/pairing.test.ts
+++ b/functions/test/routes/pairing.test.ts
@@ -218,8 +218,9 @@ describe("POST /device/token", () => {
     expect(res.json()).toEqual({ registration_token: "reg-token", expires_in: 60 });
     expect(mocks.recordRegistrationToken).toHaveBeenCalledWith(deviceCode, "jti-1", expect.any(Date));
     expect(mocks.verifyDpopProof).toHaveBeenCalledWith("proof", expect.objectContaining({
-      htu: "http://127.0.0.1:5001/crowdpm-local/us-central1/crowdpmApi/device/token",
+      htu: expect.stringMatching(/^http:\/\/127\.0\.0\.1:5001\/[^/]+\/us-central1\/crowdpmApi\/device\/token$/),
       expectedThumbprint: "thumb-1",
+      method: "POST",
     }));
     await app.close();
   });

--- a/functions/test/services/deviceTokensVerification.test.ts
+++ b/functions/test/services/deviceTokensVerification.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   jwtVerify: vi.fn(),
@@ -35,9 +38,32 @@ vi.mock("../../src/lib/fire.js", () => ({
   }),
 }));
 
+const testPrivateKeyFile = join(tmpdir(), `crowdpm-device-token-verification-${process.pid}.pem`);
+const originalEnv = {
+  DEVICE_TOKEN_AUDIENCE: process.env.DEVICE_TOKEN_AUDIENCE,
+  DEVICE_TOKEN_ISSUER: process.env.DEVICE_TOKEN_ISSUER,
+  DEVICE_TOKEN_PRIVATE_KEY: process.env.DEVICE_TOKEN_PRIVATE_KEY,
+  DEVICE_TOKEN_PRIVATE_KEY_FILE: process.env.DEVICE_TOKEN_PRIVATE_KEY_FILE,
+};
+
+function restoreEnv(name: keyof typeof originalEnv): void {
+  const originalValue = originalEnv[name];
+  if (originalValue === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = originalValue;
+}
+
 describe("verifyDeviceAccessToken", () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
+    delete process.env.DEVICE_TOKEN_PRIVATE_KEY;
+    process.env.DEVICE_TOKEN_PRIVATE_KEY_FILE = testPrivateKeyFile;
+    process.env.DEVICE_TOKEN_ISSUER = "crowdpm";
+    process.env.DEVICE_TOKEN_AUDIENCE = "crowdpm_device_api";
+    rmSync(testPrivateKeyFile, { force: true });
     mocks.importSPKI.mockResolvedValue({ key: "verification-key" });
     mocks.importPKCS8.mockResolvedValue({ key: "signing-key" });
     mocks.jwtVerify.mockResolvedValue({
@@ -51,10 +77,15 @@ describe("verifyDeviceAccessToken", () => {
     });
   });
 
-  it("re-checks shared token state on every verification and rejects a later revocation", async () => {
-    process.env.DEVICE_TOKEN_ISSUER = "crowdpm";
-    process.env.DEVICE_TOKEN_AUDIENCE = "crowdpm_device_api";
+  afterEach(() => {
+    rmSync(testPrivateKeyFile, { force: true });
+    restoreEnv("DEVICE_TOKEN_AUDIENCE");
+    restoreEnv("DEVICE_TOKEN_ISSUER");
+    restoreEnv("DEVICE_TOKEN_PRIVATE_KEY");
+    restoreEnv("DEVICE_TOKEN_PRIVATE_KEY_FILE");
+  });
 
+  it("re-checks shared token state on every verification and rejects a later revocation", async () => {
     const { verifyDeviceAccessToken } = await import("../../src/services/deviceTokens.js");
 
     mocks.tokenDocGet

--- a/functions/test/services/ingestGateway.test.ts
+++ b/functions/test/services/ingestGateway.test.ts
@@ -140,11 +140,12 @@ describe("ingestGatewayHandler", () => {
     expect(res.payload).toMatchObject({ accepted: true, batchId: "batch-1", deviceId: "device-123" });
     expect(deps.verifyDeviceAccessToken).toHaveBeenCalledWith("test-token");
     expect(deps.verifyDpopProof).toHaveBeenCalledWith("proof-token", expect.objectContaining({
-      htu: "http://127.0.0.1:5001/crowdpm-local/us-central1/ingestGateway",
+      htu: expect.stringMatching(/^http:\/\/127\.0\.0\.1:5001\/[^/]+\/us-central1\/ingestGateway$/),
       acceptableHtu: ["http://127.0.0.1:5001/"],
       allowMissingAthOnHtu: ["http://127.0.0.1:5001/"],
       expectedAth: expect.any(String),
       expectedThumbprint: "jkt-1",
+      method: "POST",
     }));
     expect(deps.checkDpopReplay).toHaveBeenCalledWith(expect.objectContaining({
       accessTokenJti: "token-jti-1",


### PR DESCRIPTION
## Summary
- make DPoP URL test assertions tolerate the deploy workflow project id
- isolate device token verification tests from deploy-time DEVICE_TOKEN_PRIVATE_KEY secrets

## Verification
- FIREBASE_PROJECT_ID=crowdpmplatform GCLOUD_PROJECT=crowdpmplatform GCP_PROJECT=crowdpmplatform DEVICE_TOKEN_PRIVATE_KEY=not-a-valid-key nvm exec 24.15.0 pnpm --filter crowdpm-functions test -- test/routes/pairing.test.ts test/services/ingestGateway.test.ts test/services/deviceTokensVerification.test.ts
- nvm exec 24.15.0 pnpm --filter crowdpm-functions test
- nvm exec 24.15.0 pnpm --filter crowdpm-functions build